### PR TITLE
FOGL-81 - pip requirements are now separated with their versions and tests call via make

### DIFF
--- a/src/python/.pylintrc
+++ b/src/python/.pylintrc
@@ -70,7 +70,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
-#msg-template=
+msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
 
 # Set the output format. Available formats are text, parseable, colorized, json
 # and msvs (visual studio).You can also give a reporter class, eg

--- a/src/python/Makefile
+++ b/src/python/Makefile
@@ -15,6 +15,9 @@ help:
 	@echo "install-doc-requirements - installing doc dependencies using requirements_doc.txt"
 	@echo "install-test-requirements - installing test dependencies using requirements_test.txt"
 	@echo "copy-config - copy example configuration file"
+	@echo "test - run all (src/python/tests and docs/check_sphinx) tests"
+	@echo "py-test - run src/python/tests"
+	@echo "doc-test - run docs/check_sphinx tests"
 	@echo "lint - run python and js lint checks"
 	@echo "lint-python - run python files lint check only"
 	@echo "lint-js - run ui/*.js files lint check only"
@@ -61,6 +64,18 @@ copy-config:
 	[ -f foglamp/foglamp-env.yaml ] && echo "foglamp-env already exists." || cp foglamp/foglamp-env.example.yaml foglamp/foglamp-env.yaml
 	#[ -f foglamp-config.yaml ] && echo "foglamp-config already exists." || cp foglamp-config.example.yaml foglamp-config.yaml
 
+test: py-test doc-test
+
+py-test:
+	@echo "-- Executing py tests"
+	pip install tox
+	tox -e py35
+
+doc-test:
+	@echo "-- Executing doc tests"
+	pip install tox
+	tox -e docs
+
 lint: lint-python lint-js
 
 lint-python: install-test-requirements
@@ -93,4 +108,7 @@ live-doc: install-doc-requirements
 	lint-python \
 	lint-js \
 	doc \
-	live-doc
+	live-doc \
+	test \
+	py-test \
+	doc-test \

--- a/src/python/Makefile
+++ b/src/python/Makefile
@@ -10,9 +10,9 @@ help:
 	@echo "clean-build - remove build artifacts"
 	@echo "clean-pyc - remove Python file artifacts"
 	@echo "clean-test - remove test artifacts"
-	@echo "install-py-requirements - installing Py dependencies using requirements.txt"
-	@echo "install-dev-requirements - installing dev dependencies using requirements_dev.txt"
-	@echo "install-doc-requirements - installing doc dependencies using requirements_doc.txt"
+	@echo "install-py-requirements - installing python dependencies using requirements.txt"
+	@echo "install-dev-requirements - installing python dev dependencies using requirements_dev.txt"
+	@echo "install-doc-requirements - installing sphinx doc dependencies using requirements_doc.txt"
 	@echo "install-test-requirements - installing test dependencies using requirements_test.txt"
 	@echo "copy-config - copy example configuration file"
 	@echo "test - run all (src/python/tests and docs/check_sphinx) tests"
@@ -44,15 +44,15 @@ clean-test:
 	rm -fr .tox
 
 install-py-requirements: check-root
-	@echo "-- Installing Py dependencies."
+	@echo "-- Installing Python dependencies."
 	pip install -r requirements.txt
 
 install-dev-requirements: check-root
-	@echo "-- Installing dev dependencies."
+	@echo "-- Installing Python dev dependencies."
 	pip install -r requirements_dev.txt
 
 install-doc-requirements: check-root
-	@echo "-- Installing doc dependencies."
+	@echo "-- Installing Sphinx doc dependencies."
 	pip install -r requirements_doc.txt
 
 install-test-requirements: check-root
@@ -67,12 +67,12 @@ copy-config:
 test: py-test doc-test
 
 py-test:
-	@echo "-- Executing py tests"
+	@echo "-- Executing python tests"
 	pip install tox
 	tox -e py35
 
 doc-test:
-	@echo "-- Executing doc tests"
+	@echo "-- Executing sphinx doc tests"
 	pip install tox
 	tox -e docs
 

--- a/src/python/Makefile
+++ b/src/python/Makefile
@@ -11,6 +11,9 @@ help:
 	@echo "clean-pyc - remove Python file artifacts"
 	@echo "clean-test - remove test artifacts"
 	@echo "install-python-requirements - installing Python development dependencies using requirements.txt"
+	@echo "install-dev-requirements - installing dev environment dependencies using requirements_dev.txt"
+	@echo "install-doc-requirements - installing doc dependencies using requirements_doc.txt"
+	@echo "install-test-requirements - installing test dependencies using requirements_test.txt"
 	@echo "copy-config - copy example configuration file"
 	@echo "lint - run python and js lint checks"
 	@echo "lint-python - run python files lint check only"
@@ -41,6 +44,18 @@ install-python-requirements: check-root
 	@echo "-- Installing Python development dependencies."
 	pip install -r requirements.txt
 
+install-dev-requirements: check-root
+	@echo "-- Installing dev environment dependencies."
+	pip install -r requirements_dev.txt
+
+install-doc-requirements: check-root
+	@echo "-- Installing doc dependencies."
+	pip install -r requirements_doc.txt
+
+install-test-requirements: check-root
+	@echo "-- Installing test dependencies."
+	pip install -r requirements_test.txt
+
 copy-config:
 	@echo "-- Copying configuration file."
 	[ -f foglamp/foglamp-env.yaml ] && echo "foglamp-env already exists." || cp foglamp/foglamp-env.example.yaml foglamp/foglamp-env.yaml
@@ -70,6 +85,9 @@ live-doc:
 	clean-pyc \
 	clean-test \
 	install-python-requirements \
+	install-dev-requirements \
+	install-doc-requirements \
+	install-test-requirements \
 	copy-config \
 	lint \
 	lint-python \

--- a/src/python/Makefile
+++ b/src/python/Makefile
@@ -10,8 +10,8 @@ help:
 	@echo "clean-build - remove build artifacts"
 	@echo "clean-pyc - remove Python file artifacts"
 	@echo "clean-test - remove test artifacts"
-	@echo "install-python-requirements - installing Python development dependencies using requirements.txt"
-	@echo "install-dev-requirements - installing dev environment dependencies using requirements_dev.txt"
+	@echo "install-py-requirements - installing Py dependencies using requirements.txt"
+	@echo "install-dev-requirements - installing dev dependencies using requirements_dev.txt"
 	@echo "install-doc-requirements - installing doc dependencies using requirements_doc.txt"
 	@echo "install-test-requirements - installing test dependencies using requirements_test.txt"
 	@echo "copy-config - copy example configuration file"
@@ -40,12 +40,12 @@ clean-test:
 	rm -fr .cache
 	rm -fr .tox
 
-install-python-requirements: check-root
-	@echo "-- Installing Python development dependencies."
+install-py-requirements: check-root
+	@echo "-- Installing Py dependencies."
 	pip install -r requirements.txt
 
 install-dev-requirements: check-root
-	@echo "-- Installing dev environment dependencies."
+	@echo "-- Installing dev dependencies."
 	pip install -r requirements_dev.txt
 
 install-doc-requirements: check-root
@@ -63,19 +63,19 @@ copy-config:
 
 lint: lint-python lint-js
 
-lint-python:
+lint-python: install-test-requirements
 	@echo "-- Linting Python files."
 	rm -f pylint*.log
-	pylint $(shell find . -iname "*.py" ! -path './venv*' ! -path './.tox*') --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" > pylint_$(shell date +%FT%T%Z).log || exit 0
+	pylint $(shell find . -iname "*.py" ! -path './venv*' ! -path './.tox*') > pylint_$(shell date +%FT%T%Z).log || exit 0
 
 lint-js:
     @echo "-- TODO: add js lint | added here for example, to add later"
 
-doc:
+doc: install-doc-requirements
 	@echo "-- Generate docs html."
 	cd ../../docs && make html
 
-live-doc:
+live-doc: install-doc-requirements
 	cd ../../docs && make livehtml
 
 .PHONY: \
@@ -84,7 +84,7 @@ live-doc:
 	clean-build \
 	clean-pyc \
 	clean-test \
-	install-python-requirements \
+	install-py-requirements \
 	install-dev-requirements \
 	install-doc-requirements \
 	install-test-requirements \

--- a/src/python/build.sh
+++ b/src/python/build.sh
@@ -113,6 +113,7 @@ setup_and_run() {
 
     if [ "$option" == "LINT" ]
     then
+        make install-test-requirements
         make lint
 
     elif [ "$option" == "TEST" ]
@@ -137,6 +138,7 @@ setup_and_run() {
 
     elif [ "$option" == "BUILD_DOC" ]
     then
+        make install-doc-requirements
         make doc
 
     elif [ "$option" == "TEST_DOC" ]

--- a/src/python/build.sh
+++ b/src/python/build.sh
@@ -120,7 +120,7 @@ setup_and_run() {
     then
         echo "tox is on the job; see tox.ini"
         make test
-        # to run only /src/python/tests, use tox -e py35
+        # to run only /src/python/tests, use make py-test
 
     elif [ "$option" == "INSTALL" ]
     then

--- a/src/python/build.sh
+++ b/src/python/build.sh
@@ -107,13 +107,12 @@ setup_and_run() {
         return
     fi
 
-    make install-python-requirements
+    make install-py-requirements
 
     make copy-config
 
     if [ "$option" == "LINT" ]
     then
-        make install-test-requirements
         make lint
 
     elif [ "$option" == "TEST" ]
@@ -138,7 +137,6 @@ setup_and_run() {
 
     elif [ "$option" == "BUILD_DOC" ]
     then
-        make install-doc-requirements
         make doc
 
     elif [ "$option" == "TEST_DOC" ]
@@ -213,4 +211,3 @@ if [ $# -gt 0 ]
 fi
 
 popd > /dev/null
-

--- a/src/python/build.sh
+++ b/src/python/build.sh
@@ -113,12 +113,13 @@ setup_and_run() {
 
     if [ "$option" == "LINT" ]
     then
+        echo "Running lint checker"
         make lint
 
     elif [ "$option" == "TEST" ]
     then
         echo "tox is on the job; see tox.ini"
-        tox
+        make test
         # to run only /src/python/tests, use tox -e py35
 
     elif [ "$option" == "INSTALL" ]
@@ -137,12 +138,13 @@ setup_and_run() {
 
     elif [ "$option" == "BUILD_DOC" ]
     then
+        echo "Building doc"
         make doc
 
     elif [ "$option" == "TEST_DOC" ]
     then
         echo "Running Sphnix docs test"
-        tox -e docs
+        make doc-test
 
     elif [ "$option" == "UNINSTALL" ]
     then

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,21 +1,21 @@
-# env
-PyYAML==3.12
+# coap
+aiocoap==0.3
+cbor2==4.0.0
+LinkHeader==0.4.3
 
 # deployment
 packaging==16.8
 
-# run
-python-daemon==2.1.2
+# env
+PyYAML==3.12
+
+# healthCheck
+deepdiff==3.2.1
 
 # postgreSQL
 aiopg==0.13.0
 SQLAlchemy==1.1.10
 psycopg2==2.7.1
-
-# coap
-aiocoap==0.3
-cbor2==4.0.0
-LinkHeader==0.4.3
 
 # rest
 aiohttp==2.1.0
@@ -24,5 +24,5 @@ gunicorn==19.7.1
 httpie==0.9.9
 PyJWT==1.5.0
 
-# healthCheck
-deepdiff==3.2.1
+# run
+python-daemon==2.1.2

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,9 +1,3 @@
-# ?
-appdirs
-lockfile
-pyparsing
-six
-
 # env
 PyYAML
 
@@ -32,20 +26,3 @@ PyJWT
 
 # healthCheck
 deepdiff
-
-# docs
-docutils
-Sphinx
-sphinx-autobuild
-
-# test
-pytest
-
-# tox
-tox
-
-# lint
-pylint
-
-# test report packages
-pytest-allure-adaptor

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,28 +1,28 @@
 # env
-PyYAML
+PyYAML==3.12
 
 # deployment
-packaging
+packaging==16.8
 
 # run
-python-daemon
+python-daemon==2.1.2
 
 # postgreSQL
-aiopg
-SQLAlchemy
-psycopg2
+aiopg==0.13.0
+SQLAlchemy==1.1.10
+psycopg2==2.7.1
 
 # coap
-aiocoap
-cbor2
-LinkHeader
+aiocoap==0.3
+cbor2==4.0.0
+LinkHeader==0.4.3
 
 # rest
-aiohttp
-cchardet
-gunicorn
-httpie
-PyJWT
+aiohttp==2.1.0
+cchardet==2.1.0
+gunicorn==19.7.1
+httpie==0.9.9
+PyJWT==1.5.0
 
 # healthCheck
-deepdiff
+deepdiff==3.2.1

--- a/src/python/requirements_dev.txt
+++ b/src/python/requirements_dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+-r requirements_test.txt

--- a/src/python/requirements_dev.txt
+++ b/src/python/requirements_dev.txt
@@ -1,3 +1,2 @@
 -r requirements.txt
-tox==2.7.0
 -r requirements_test.txt

--- a/src/python/requirements_dev.txt
+++ b/src/python/requirements_dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
+tox==2.7.0
 -r requirements_test.txt

--- a/src/python/requirements_doc.txt
+++ b/src/python/requirements_doc.txt
@@ -1,4 +1,4 @@
 # docs
-docutils
-Sphinx
-sphinx-autobuild
+docutils==0.13.1
+Sphinx==1.6.2
+sphinx-autobuild==0.6.0

--- a/src/python/requirements_doc.txt
+++ b/src/python/requirements_doc.txt
@@ -1,4 +1,3 @@
-# docs
 docutils==0.13.1
 Sphinx==1.6.2
 sphinx-autobuild==0.6.0

--- a/src/python/requirements_doc.txt
+++ b/src/python/requirements_doc.txt
@@ -1,0 +1,4 @@
+# docs
+docutils
+Sphinx
+sphinx-autobuild

--- a/src/python/requirements_test.txt
+++ b/src/python/requirements_test.txt
@@ -1,0 +1,9 @@
+# test
+pytest
+pytest-allure-adaptor
+
+# tox
+tox
+
+# lint
+pylint

--- a/src/python/requirements_test.txt
+++ b/src/python/requirements_test.txt
@@ -1,9 +1,6 @@
 # test
-pytest
-pytest-allure-adaptor
-
-# tox
-tox
+pytest==3.1.1
+pytest-allure-adaptor==1.7.7
 
 # lint
-pylint
+pylint==1.7.1

--- a/src/python/requirements_test.txt
+++ b/src/python/requirements_test.txt
@@ -1,6 +1,3 @@
-# test
+pylint==1.7.1
 pytest==3.1.1
 pytest-allure-adaptor==1.7.7
-
-# lint
-pylint==1.7.1

--- a/src/python/tox.ini
+++ b/src/python/tox.ini
@@ -5,14 +5,13 @@ skipsdist = TRUE
 envlist = py35,docs
 
 [testenv]
-deps=-rrequirements.txt
+deps=-rrequirements_test.txt
 commands=pip install -e .
          pytest tests --alluredir=../../allure/unit_test_report
          /bin/bash -c "pip uninstall FogLAMP <<< y"
 
 [testenv:docs]
 changedir=../../docs
-deps=sphinx
-     pytest
-     pytest-allure-adaptor
+deps=-rrequirements_doc.txt
+     -rrequirements_test.txt
 commands=pytest -v check_sphinx.py --alluredir=../allure/doc_report

--- a/src/python/tox.ini
+++ b/src/python/tox.ini
@@ -5,7 +5,7 @@ skipsdist = TRUE
 envlist = py35,docs
 
 [testenv]
-deps=-rrequirements_test.txt
+deps=-rrequirements_dev.txt
 commands=pip install -e .
          pytest tests --alluredir=../../allure/unit_test_report
          /bin/bash -c "pip uninstall FogLAMP <<< y"


### PR DESCRIPTION
[FOGL-81](https://scaledb.atlassian.net/browse/FOGL-81)

Fixed items:
1) requirements - basic python dependencies
2) requirements_doc - only docs dependencies
3) requirements_test - only test dependencies
4) requirements_dev - python dependencies + test dependencies + docs dependencies
5) Now we should run our _doc and python_ tests by calling **make**
6) pip packages with their versions as standard process.
