### PR TITLE
FOGL-161

### DIFF
--- a/src/python/.pylintrc
+++ b/src/python/.pylintrc
@@ -224,7 +224,7 @@ logging-modules=logging
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX,TODO
+notes=FIXME,XXX,TODO,HACK
 
 
 [SIMILARITIES]

--- a/src/python/Makefile
+++ b/src/python/Makefile
@@ -61,7 +61,7 @@ install-test-requirements: check-root
 
 create-env:
 	@echo "-- Creating environment file."
-	[ -f foglamp/foglamp-env.yaml ] && echo "foglamp-env already exists." || cp foglamp/foglamp-env.example.yaml foglamp/foglamp-env.yaml
+	[ -f foglamp/foglamp-env.yaml ] && echo "foglamp-env already exists" || cp foglamp/foglamp-env.example.yaml foglamp/foglamp-env.yaml
 
 test: py-test doc-build-test
 

--- a/src/python/Makefile
+++ b/src/python/Makefile
@@ -60,7 +60,7 @@ install-test-requirements: check-root
 	pip install -r requirements_test.txt
 
 create-env:
-	@echo "-- Creating environment file."
+	@echo "-- Creating environment file"
 	[ -f foglamp/foglamp-env.yaml ] && echo "foglamp-env already exists" || cp foglamp/foglamp-env.example.yaml foglamp/foglamp-env.yaml
 
 test: py-test doc-build-test

--- a/src/python/build.sh
+++ b/src/python/build.sh
@@ -20,7 +20,7 @@ fi
 pushd `dirname "$SCRIPT"` > /dev/null
 SCRIPTNAME=$(basename "$SCRIPT")
 
-usage="=== $SCRIPTNAME ===
+USAGE="=== $SCRIPTNAME ===
 
 Activates a Python virtual environment for python3.5 or 
 python3 if python3.5 can not be found. Installs 
@@ -36,44 +36,46 @@ Sourcing this script:
   Sourcing this script causes the shell to inherit the virtual
   environment so, for example, the 'python' command actually 
   runs python3. Deactivate the virtual environment by running
-  \"deactivate\". 
+  \"deactivate\". The environment variable VENV_PATH is
+  created.
 
 Options:
-  -a, --activate  Create and activate the virtual environment
-                  and exit. Do not install dependencies.
-                  (must invoke via 'source')
-  -c, --clean     Delete the virtual environment and remove
-                  'build' directories
-  -d, --doc       Generate html in doc/_build directory
+  -a, --activate   Create and activate the virtual environment
+                   and exit. Do not install dependencies.
+                   (must invoke via 'source')
+  -c, --clean      Delete the virtual environment and remove
+                   'build' directories
+  -d, --doc        Generate HTML in doc/_build directory
   --doc-build-test Run docs/check_sphinx.py
-  --deactivate    Deactivate the virtual environment
-                  (must invoke via 'source')
-  -i, --install   Install FogLAMP packages and scripts
-  -l, --lint      Run pylint. Writes output to 
-                  pylint-report.txt
-  --live-doc      Live doc serves the built html for docs/ on localhost, observe the changes in doc and update the html live
-  -p, --py-test    Run only Python tests
-  -r, --run       Start FogLAMP
-  -s, --service   Start FogLAMP daemon
-  -t, --test      Run all tests
-  -u, --uninstall Remove FogLAMP packages and scripts
-  Anything else   Show this help text
+  --deactivate     Deactivate the virtual environment
+                   (must invoke via 'source')
+  -i, --install    Install FogLAMP packages and scripts
+  -l, --lint       Run pylint. Writes output to 
+                   pylint-report.txt
+  --live-doc       Run webserver and observe changes in doc
+                   DIRECTORY to automatically generate HTML
+  -p, --py-test     Run only Python tests
+  -r, --run        Start FogLAMP
+  -s, --service    Start FogLAMP daemon
+  -t, --test       Run all tests
+  -u, --uninstall  Remove FogLAMP packages and scripts
+  Anything else    Show this help text
 
 Exit status code:
   When this script is not invoked via 'source', it exits
   with status code 1 when errors occur (e.g., tests fail)"
 
 setup_and_run() {
-    ALREADY_IN_VENV=$(python -c 'import sys; print ("1" if hasattr(sys, "real_prefix") else "0")')
+    IN_VENV=$(python -c 'import sys; print ("1" if hasattr(sys, "real_prefix") else "0")')
 
-    if [ $ALREADY_IN_VENV -gt 0 ]
+    if [ $IN_VENV -gt 0 ]
     then
         echo "-- A virtual environment is already active"
-    fi
+    fi 
 
-    if [ "$option" == "ACTIVATE" ]
+    if [ "$OPTION" == "ACTIVATE" ]
     then
-        if [ $ALREADY_IN_VENV -gt 0 ]
+        if [ $IN_VENV -gt 0 ]
         then
             return
         fi
@@ -85,9 +87,9 @@ setup_and_run() {
         fi
     fi
 
-    if [ "$option" == "DEACTIVATE" ]
+    if [ "$OPTION" == "DEACTIVATE" ]
     then
-        if [ $ALREADY_IN_VENV -gt 0 ]
+        if [ $IN_VENV -gt 0 ] 
         then
             # deactivate doesn't work unless sourcing
             if [ $SOURCING -lt 1 ]
@@ -102,11 +104,11 @@ setup_and_run() {
         return
     fi
 
-    VENV_PATH="venv/$HOSTNAME"
+    VENV_PATH="`pwd`/venv/$HOSTNAME"
 
-    if [ "$option" == "CLEAN" ]
+    if [ "$OPTION" == "CLEAN" ]
     then
-        if [ $ALREADY_IN_VENV -gt 0 ]
+        if [ $IN_VENV -gt 0 ] 
         then
             # deactivate doesn't work unless sourcing
             if [ $SOURCING -lt 1 ]
@@ -119,14 +121,14 @@ setup_and_run() {
             deactivate
         fi
 
-        echo "-- Removing `pwd`/$VENV_PATH"
+        echo "-- Removing $VENV_PATH"
         rm -rf "$VENV_PATH"
 
         make clean
         return
     fi
 
-    if [ $ALREADY_IN_VENV -lt 1 ]
+    if [ $IN_VENV -lt 1 ]
     then
         if [ ! -f "$VENV_PATH/bin/activate" ]
         then
@@ -173,7 +175,7 @@ setup_and_run() {
             virtualenv "--python=$python_path" "$VENV_PATH"
         fi
 
-        echo "-- Activating the virtualenv at `pwd`/$VENV_PATH"
+        echo "-- Activating the virtualenv at $VENV_PATH"
         source "$VENV_PATH/bin/activate"
 
         IN_VENV=$(python -c 'import sys; print ("1" if hasattr(sys, "real_prefix") else "0")')
@@ -185,15 +187,15 @@ setup_and_run() {
         fi
     fi
 
-    if [ "$option" == "ACTIVATE" ]
+    if [ "$OPTION" == "ACTIVATE" ]
     then
         return
     fi
-
+    
     make install-py-requirements
     make create-env
 
-    if [ "$option" == "LINT" ]
+    if [ "$OPTION" == "LINT" ]
     then
         echo "Running lint checker"
         make lint
@@ -202,7 +204,7 @@ setup_and_run() {
             exit 1
         fi
 
-    elif [ "$option" == "TEST" ]
+    elif [ "$OPTION" == "TEST" ]
     then
         echo "Running all tests"
         make test
@@ -211,7 +213,7 @@ setup_and_run() {
             exit 1
         fi
 
-    elif [ "$option" == "TEST_PYTHON" ]
+    elif [ "$OPTION" == "TEST_PYTHON" ]
     then
         echo "Running pytest"
         make py-test
@@ -220,19 +222,33 @@ setup_and_run() {
             exit 1
         fi
 
-    elif [ "$option" == "INSTALL" ]
+    elif [ "$OPTION" == "INSTALL" ]
     then
         pip install -e .
+        if [ $? -gt 0 ] && [ $SOURCING -lt 1 ]
+        then
+            exit 1
+        fi
 
-    elif [ "$option" == "RUN" ]
+    elif [ "$OPTION" == "RUN" ]
     then
+        pip install -e .
+        if [ $? -gt 0 ] && [ $SOURCING -lt 1 ]
+        then
+            exit 1
+        fi
         foglamp
 
-    elif [ "$option" == "RUN_DAEMON" ]
+    elif [ "$OPTION" == "RUN_DAEMON" ]
     then
-        foglamp-d
+        pip install -e .
+        if [ $? -gt 0 ] && [ $SOURCING -lt 1 ]
+        then
+            exit 1
+        fi
+        foglampd
 
-    elif [ "$option" == "BUILD_DOC" ]
+    elif [ "$OPTION" == "BUILD_DOC" ]
     then
         echo "Building doc"
         make doc
@@ -241,32 +257,32 @@ setup_and_run() {
             exit 1
         fi
 
-    elif [ "$option" == "TEST_DOC_BUILD" ]
+    elif [ "$OPTION" == "TEST_DOC_BUILD" ]
     then
-        echo "Running Sphinx doc build test"
+        echo "Running Sphinx docs test"
         make doc-build-test
         if [ $? -gt 0 ] && [ $SOURCING -lt 1 ]
         then
             exit 1
         fi
-
-    elif [ "$option" == "LIVE_DOC" ]
+        
+    elif [ "$OPTION" == "LIVE_DOC" ]
     then
-        echo "Observe the changes in doc and update the html live"
+        echo "Observe the changes in doc and update HTML live"
         make live-doc
         if [ $? -gt 0 ] && [ $SOURCING -lt 1 ]
         then
             exit 1
         fi
 
-    elif [ "$option" == "UNINSTALL" ]
+    elif [ "$OPTION" == "UNINSTALL" ]
     then
         echo "This will remove the package"
         pip uninstall FogLAMP <<< y
     fi
 }
 
-option=''
+OPTION=''
 
 if [ $# -gt 0 ]
   then
@@ -275,55 +291,55 @@ if [ $# -gt 0 ]
          case $i in
 
            -a|--activate)
-             option="ACTIVATE"
+             OPTION="ACTIVATE"
              ;;
 
            --deactivate)
-             option="DEACTIVATE"
+             OPTION="DEACTIVATE"
              ;;
 
            -l|--lint)
-             option="LINT"
+             OPTION="LINT"
              ;;
 
            -t|--test)
-             option="TEST"
+             OPTION="TEST"
              ;;
 
            -p|--py-test)
-             option="TEST_PYTHON"
+             OPTION="TEST_PYTHON"
              ;;
 
            -i|--install)
-             option="INSTALL"
+             OPTION="INSTALL"
              ;;
 
             -r|--run)
-             option="RUN"
+             OPTION="RUN"
              ;;
 
             -s|--service)
-             option="RUN_DAEMON"
+             OPTION="RUN_DAEMON"
              ;;
 
             -u|--uninstall)
-             option="UNINSTALL"
+             OPTION="UNINSTALL"
              ;;
 
             -c|--clean)
-             option="CLEAN"
+             OPTION="CLEAN"
              ;;
 
             -d|--doc)
-             option="BUILD_DOC"
+             OPTION="BUILD_DOC"
              ;;
 
             --doc-build-test)
-              option="TEST_DOC_BUILD"
+              OPTION="TEST_DOC_BUILD"
               ;;
 
             --live-doc)
-              option="LIVE_DOC"
+              OPTION="LIVE_DOC"
               ;;
 
             *)
@@ -338,3 +354,15 @@ if [ $# -gt 0 ]
 fi
 
 popd > /dev/null
+
+# Unset all temporary variables used above
+if [ $SOURCING -gt 0 ]
+then
+    unset IN_VENV
+    unset OPTION
+    unset SCRIPT
+    unset SCRIPTNAME
+    unset SOURCING
+    unset USAGE
+fi
+

--- a/src/python/build.sh
+++ b/src/python/build.sh
@@ -56,7 +56,7 @@ Options:
                    DIRECTORY to automatically generate HTML
   -p, --py-test     Run only Python tests
   -r, --run        Start FogLAMP
-  -s, --service    Start FogLAMP daemon
+  -s, --service    Start FogLAMP service
   -t, --test       Run all tests
   -u, --uninstall  Remove FogLAMP packages and scripts
   Anything else    Show this help text
@@ -343,7 +343,7 @@ if [ $# -gt 0 ]
               ;;
 
             *)
-             echo "${usage}" # anything including -h :]
+             echo "${USAGE}" # anything including -h :]
              break
              ;;
          esac

--- a/src/python/build.sh
+++ b/src/python/build.sh
@@ -152,8 +152,6 @@ setup_and_run() {
             fi
 
             # Find Python3.5 or Python3 if it doesn't exist
-            #
-
             python_path=$( which python3.5 )
 
             if [ $? -gt 0 ]

--- a/src/python/build.sh
+++ b/src/python/build.sh
@@ -41,20 +41,21 @@ Sourcing this script:
 
 Options:
   -a, --activate   Create and activate the virtual environment
-                   and exit. Do not install dependencies.
-                   (must invoke via 'source')
+                   and exit. Do not install dependencies. Must
+                   must invoke via 'source.'
   -c, --clean      Delete the virtual environment and remove
-                   'build' directories
+                   build and cache directories
   -d, --doc        Generate HTML in doc/_build directory
   --doc-build-test Run docs/check_sphinx.py
-  --deactivate     Deactivate the virtual environment
-                   (must invoke via 'source')
+  --deactivate     Deactivate the virtual environment. Must
+                   invoke via 'source.'
   -i, --install    Install FogLAMP packages and scripts
   -l, --lint       Run pylint. Writes output to 
                    pylint-report.txt
-  --live-doc       Run webserver and observe changes in doc
-                   DIRECTORY to automatically generate HTML
-  -p, --py-test     Run only Python tests
+  --live-doc       Run a local webserver that serves files in 
+                   doc/_build and monitors modifications to
+                   files in doc/ and regenerates HTML
+  -p, --py-test    Run only Python tests
   -r, --run        Start FogLAMP
   -s, --service    Start FogLAMP service
   -t, --test       Run all tests
@@ -259,7 +260,7 @@ setup_and_run() {
 
     elif [ "$OPTION" == "TEST_DOC_BUILD" ]
     then
-        echo "Running Sphinx docs test"
+        echo "Running Sphinx docs build test"
         make doc-build-test
         if [ $? -gt 0 ] && [ $SOURCING -lt 1 ]
         then

--- a/src/python/foglamp_daemon.py
+++ b/src/python/foglamp_daemon.py
@@ -13,7 +13,6 @@ from foglamp.controller import start
 def do_something(logf):
     """
     :param logf: log file
-    :return:
     """
     file_handler = logging.FileHandler(logf)
     file_handler.setLevel(logging.DEBUG)
@@ -37,7 +36,6 @@ def start_daemon(pidf, logf, wdir):
     :param pidf: pidfile
     :param logf: log file
     :param wdir: working directory
-    :return:
     """
 
     # XXX: pidfile is a context
@@ -52,7 +50,6 @@ def start_daemon(pidf, logf, wdir):
 def safe_makedirs(directory):
     """
     :param directory: working directory
-    :return:
     """
     directory = os.path.expanduser(directory)
     try:
@@ -75,7 +72,8 @@ def main():
     safe_makedirs(os.path.dirname(args.log_file))
 
     # TODO: ['start', 'stop', 'restart', 'status', 'info']
-    start_daemon(pidf=os.path.expanduser(args.pid_file), logf=os.path.expanduser(args.log_file),
+    start_daemon(pidf=os.path.expanduser(args.pid_file),
+                 logf=os.path.expanduser(args.log_file),
                  wdir=os.path.expanduser(args.working_dir))
 
 

--- a/src/python/foglamp_daemon.py
+++ b/src/python/foglamp_daemon.py
@@ -11,40 +11,55 @@ from foglamp.controller import start
 
 
 def do_something(logf):
-    fh = logging.FileHandler(logf)
-    fh.setLevel(logging.DEBUG)
+    """
+    :param logf: log file
+    :return:
+    """
+    file_handler = logging.FileHandler(logf)
+    file_handler.setLevel(logging.DEBUG)
 
     formatstr = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
     formatter = logging.Formatter(formatstr)
 
-    fh.setFormatter(formatter)
+    file_handler.setFormatter(formatter)
 
     logger = logging.getLogger('')
-    logger.addHandler(fh)
+    logger.addHandler(file_handler)
     logger.setLevel(logging.DEBUG)
 
     start()
 
 
-def start_daemon(pidf, logf, wd):
-    """Launches the daemon"""
+def start_daemon(pidf, logf, wdir):
+    """
+    Launches the daemon
 
-    # XXX pidfile is a context
+    :param pidf: pidfile
+    :param logf: log file
+    :param wdir: working directory
+    :return:
+    """
+
+    # XXX: pidfile is a context
     with daemon.DaemonContext(
-            working_directory=wd,
-            umask=0o002,
-            pidfile=pidfile.TimeoutPIDLockFile(pidf)
+        working_directory=wdir,
+        umask=0o002,
+        pidfile=pidfile.TimeoutPIDLockFile(pidf)
     ) as context:
         do_something(logf)
 
 
-def safe_makedirs(dir):
-    dir = os.path.expanduser(dir)
+def safe_makedirs(directory):
+    """
+    :param directory: working directory
+    :return:
+    """
+    directory = os.path.expanduser(directory)
     try:
-        os.makedirs(dir, 0o750)
+        os.makedirs(directory, 0o750)
     except Exception as e:
-        if not os.path.exists(dir):
-          raise e
+        if not os.path.exists(directory):
+            raise e
 
 
 def main():
@@ -60,9 +75,9 @@ def main():
     safe_makedirs(os.path.dirname(args.log_file))
 
     # TODO: ['start', 'stop', 'restart', 'status', 'info']
-    start_daemon(pidf=os.path.expanduser(args.pid_file), logf=os.path.expanduser(args.log_file), wd=os.path.expanduser(args.working_dir))
+    start_daemon(pidf=os.path.expanduser(args.pid_file), logf=os.path.expanduser(args.log_file),
+                 wdir=os.path.expanduser(args.working_dir))
 
 
 if __name__ == "__main__":
     main()
-

--- a/src/python/foglamp_daemon.py
+++ b/src/python/foglamp_daemon.py
@@ -1,9 +1,12 @@
 """Runs foglamp as a daemon"""
 
+import os
+
 import argparse
 import logging
 import daemon
 from daemon import pidfile
+
 from foglamp.controller import start
 
 
@@ -17,7 +20,6 @@ def do_something(logf):
     fh.setFormatter(formatter)
 
     logger = logging.getLogger('')
-
     logger.addHandler(fh)
     logger.setLevel(logging.DEBUG)
 
@@ -31,21 +33,35 @@ def start_daemon(pidf, logf, wd):
     with daemon.DaemonContext(
             working_directory=wd,
             umask=0o002,
-            pidfile=pidfile.TimeoutPIDLockFile(pidf),
+            pidfile=pidfile.TimeoutPIDLockFile(pidf)
     ) as context:
         do_something(logf)
+
+
+def safe_makedirs(dir):
+    dir = os.path.expanduser(dir)
+    try:
+        os.makedirs(dir, 0o750)
+    except Exception as e:
+        if not os.path.exists(dir):
+          raise e
 
 
 def main():
     parser = argparse.ArgumentParser(description="FogLAMP daemon in Python")
     parser.add_argument('-p', '--pid-file', default='~/var/run/foglamp.pid')
     parser.add_argument('-l', '--log-file', default='~/var/log/foglamp.log')
-    parser.add_argument('-w', '--working-dir', default='/var/log/foglamp')
+    parser.add_argument('-w', '--working-dir', default='~/var/log')
 
     args = parser.parse_args()
 
-    # TODO ['start', 'stop', 'restart', 'status', 'info']
-    start_daemon(pidf=args.pid_file, logf=args.log_file, wd=args.working_dir)
+    safe_makedirs(args.working_dir)
+    safe_makedirs(os.path.dirname(args.pid_file))
+    safe_makedirs(os.path.dirname(args.log_file))
+
+    # TODO: ['start', 'stop', 'restart', 'status', 'info']
+    start_daemon(pidf=os.path.expanduser(args.pid_file), logf=os.path.expanduser(args.log_file), wd=os.path.expanduser(args.working_dir))
+
 
 if __name__ == "__main__":
     main()

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -12,7 +12,7 @@ setup(
     entry_points={
         'console_scripts': [
             'foglamp = foglamp_start:main',
-            'foglamp-d = foglamp_daemon:main',
+            'foglampd = foglamp_daemon:main',
         ],
     },
     zip_safe=False


### PR DESCRIPTION
build.sh and Makefile message cleanup
Fix build.sh --run option
Daemon creates needed directories so it doesn't fail instantly
Rename foglamp-d script to foglampd
Remove temporary variables inadvertently exported from build.sh when using 'source'
