### PR TITLE
FOGL-256 - "make cov-report" is not working on Ubuntu

### DIFF
--- a/docs/build-tools.rst
+++ b/docs/build-tools.rst
@@ -42,6 +42,8 @@ Prerequisite
 
  Install allure on your local machine. Use instructions listed `here <http://wiki.qatools.ru/display/AL/Allure+Commandline>`_
 
+ `Note:` Unable to locate package allure-commandline for Ubuntu users. See `link <https://stackoverflow.com/questions/34772906/unable-to-install-allure-cli-on-ubuntu-15-10>`_
+
 How to generate Allure Report (through make)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/python/Makefile
+++ b/src/python/Makefile
@@ -10,6 +10,7 @@
 # FogLAMP build tasks (makefile)
 
 USER := $(shell whoami)
+OS := $(shell uname)
 
 check-root:
 ifeq ($(USER), root)
@@ -73,7 +74,12 @@ clean-test:
 	rm -f coverage.xml
 
 cov-report:
+ifeq ($(OS), Darwin)
 	open htmlcov/index.html
+endif
+ifeq ($(OS), Linux)
+	xdg-open htmlcov/index.html
+endif
 
 # TODO deleteme
 create-env:


### PR DESCRIPTION
[FOGL-256](https://scaledb.atlassian.net/browse/FOGL-256) - "make cov-report" is not working on Ubuntu

Fixed items:
1) `cov-report` now has OS check
2) Note added for allure command line installation in `build-tools.rst` updated