### PR TITLE
Fogl 263 Scheduler w/ interval tasks

### DIFF
--- a/src/python/foglamp/core/__main__.py
+++ b/src/python/foglamp/core/__main__.py
@@ -5,7 +5,7 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-from foglamp.core import server
+from foglamp.core.server import Server
 
 __author__    = "Terris Linenbach"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -13,5 +13,5 @@ __license__   = "Apache 2.0"
 __version__   = "${VERSION}"
 
 
-server.start()
+Server.start()
 

--- a/src/python/foglamp/core/__main__.py
+++ b/src/python/foglamp/core/__main__.py
@@ -5,13 +5,14 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
+"""Core server starter"""
+
 from foglamp.core.server import Server
 
-__author__    = "Terris Linenbach"
+__author__ = "Terris Linenbach"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
-__license__   = "Apache 2.0"
-__version__   = "${VERSION}"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
 
 
 Server.start()
-

--- a/src/python/foglamp/core/scheduler.py
+++ b/src/python/foglamp/core/scheduler.py
@@ -118,9 +118,9 @@ class Scheduler(object):
     def stop(self):
         """Stops the scheduler
 
-        Terminates long-running processes like the device server.
+        Asks all tasks to terminate
 
-        :return True if all processes have stopped
+        :return True if all tasks have stopped
         """
         logging.getLogger(__name__).info("Processing stop request")
         all_stopped = True
@@ -138,6 +138,7 @@ class Scheduler(object):
 
         for key in keys_to_delete:
             logging.getLogger(__name__).info("Stopped task %s", key)
+            # TODO use safe-delete
             del self.__processes[key]
 
         return all_stopped

--- a/src/python/foglamp/core/scheduler.py
+++ b/src/python/foglamp/core/scheduler.py
@@ -85,8 +85,9 @@ class Scheduler(object):
 
         # Instance variables (begin)
         self.start_time = time.time()
-        self.last_check_time = self.start_time
         self.check_schedules_interval_seconds = 60
+        self.__last_schedule_time = self.start_time
+        """The last time `schedule()` ran"""
         self.__scheduled_processes = dict()
         """ scheduled_processes.id to script """
         self.__schedules = dict()
@@ -171,7 +172,7 @@ class Scheduler(object):
                         t = row.interval
                         interval_seconds = 3600*t.hour+60*t.minute+t.second
 
-                    self.__schedules[row.id] = _Schedule(
+                    self.__schedules[row.id] = self._Schedule(
                                                 id=row.id,
                                                 type=row.schedule_type,
                                                 time=row.schedule_time,
@@ -222,10 +223,12 @@ class Scheduler(object):
                            state=self._TaskState.complete))
 
     async def schedule(self):
-        seconds_run = self.__start_time - self.__last_check_time
+        seconds_run = self.start_time - self.__last_schedule_time
+        self.__last_schedule_time = time.time()
+
         for key, schedule in self.__schedules:
             if schedule.exclusive:
-                if is running:
+                if True: # is running:
                     next
 
             start_task = False
@@ -243,14 +246,11 @@ class Scheduler(object):
             if start_task:
                 asyncio.ensure_future(self._start_task(schedule))
 
-
     async def _schedule(self):
         await asyncio.ensure_future(self._read_storage())
         while True:
             await self.schedule()
             await asyncio.sleep(self.check_schedules_interval_seconds)
-
-asyncio.ensure_future(self.schedule)
 
     async def _read_storage(self):
         """Read processes and schedules"""

--- a/src/python/foglamp/core/scheduler.py
+++ b/src/python/foglamp/core/scheduler.py
@@ -83,14 +83,26 @@ class Scheduler(object):
         self.start_time = time.time()
         self.last_check_time = self.start_time
         self.schedule_seconds = 60
-        self.__processes = []
         self.__scheduled_processes = dict()
         self.__schedules = dict()
-
+        self.__schedule_factors = dict()
+        """For interval schedules only
+        
+        Maps schedule id to a "time factor" when process was last executed
+        
+        A "time factor" is the amount of time the scheduler has been running divided by 
+        the schedule's interval time. The division is converted to an integer
+        using floor(). For example, if the interval time is
+        15 minutes and the process has been running for 35 minutes, the
+        time factor is 2.
+        """
+        self.__running_exclusive_schedules = set()
+        """A set of session ids that are running, if they are 'exclusive'"""
+        self.__processes = dict()
         # pylint: disable=line-too-long
-        """Long running processes
+        """Running processes
 
-        A list of
+        A dictionary of
         `Process <https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.asyncio.subprocess.Process>`_
         objects
         """
@@ -106,7 +118,7 @@ class Scheduler(object):
 
         :return True if all processes have stopped
         """
-        # TODO After telling processes to stop, wait for them to stop
+        # TODO: After telling processes to stop, wait for them to stop
         logging.getLogger(__name__).info("Stopping")
         for process in self.__processes:
             try:
@@ -121,7 +133,7 @@ class Scheduler(object):
 
         # TODO what if this fails?
         process = await asyncio.create_subprocess_exec('python3', '-m', 'foglamp.device')
-        self.__processes.append(process)
+        self.__processes[uuid.uuid4()] = process
 
     async def _get_scheduled_processes(self):
         query = sa.select([self.__scheduled_processes_tbl.c.name,
@@ -136,46 +148,71 @@ class Scheduler(object):
     async def _get_schedules(self):
         query = sa.select([self.__schedules_tbl.c.id,
                            self.__schedules_tbl.c.schedule_type,
-                           self.__schedules_tbl.c.schedule_interval,
                            self.__schedules_tbl.c.schedule_time,
+                           self.__schedules_tbl.c.schedule_interval,
                            self.__schedules_tbl.c.exclusive,
                            self.__schedules_tbl.c.process_name])
 
         query.select_from(self.__schedules_tbl)
 
-        Schedule = collections.namedtuple('Schedule', 'type time interval exclusive process_name')
+        ScheduleInfo = collections.namedtuple(
+            'ScheduleInfo',
+            'id type time interval exclusive process_name')
 
         async with aiopg.sa.create_engine(_CONNECTION_STRING) as engine:
             async with engine.acquire() as conn:
                 async for row in conn.execute(query):
-                    self.__schedules[row.id] = Schedule(
+                    interval_seconds = None
+                    if row.interval is not None:
+                        t = row.interval
+                        interval_seconds = 3600*t.hour+60*t.minute+t.second
+
+                    self.__schedules[row.id] = ScheduleInfo(
+                                                id=row.id,
                                                 type=row.schedule_type,
                                                 time=row.schedule_time,
-                                                interval=row.schedule_interval,
+                                                interval=interval_seconds,
                                                 exclusive=row.exclusive,
                                                 process_name=row.process_name)
 
-    async def _add_task(self, process_info):
-        row_id = uuid.uuid4()
+    async def _start_process(self, schedule_info):
+        # TODO: What if this fails
+        process = await asyncio.create_subprocess_exec(
+            self.__scheduled_processes[schedule_info.process_name].script)
+
+        task_id = uuid.uuid4()
+        self.__processes[task_id] = process
+
+        if schedule_info.exclusive:
+            self.__running_exclusive_schedules.add(schedule_info.id)
 
         async with aiopg.sa.create_engine(_CONNECTION_STRING) as engine:
             async with engine.acquire() as conn:
                 await conn.execute(self.__tasks_tbl.insert().values(
-                                        id=row_id,
-                                        process_name=process_info.name,
+                                        id=task_id,
+                                        process_name=schedule_info.process_name,
                                         state=self._TaskState.running,
                                         start_time=time.time()))
 
-        return row_id
+        asyncio.ensure_future(self._wait_for_task_completion(task_id, schedule_info))
 
-    async def _wait_for_process(self, row_id, process):
-        process.wait()
+    async def _wait_for_task_completion(self, task_id, schedule_info):
+        # TODO: Catch the right exception
+        try:
+            self.__processes[task_id].wait()
+        except Exception:
+            pass
+
+        if schedule_info.exclusive:
+            self.__running_exclusive_schedules.remove(schedule_info.id)
+
+        del self.__processes[task_id]
 
         async with aiopg.sa.create_engine(_CONNECTION_STRING) as engine:
             async with engine.acquire() as conn:
                 await conn.execute(
                     self.__tasks_tbl.update().
-                    where(self.__tasks_tbl.c.id == row_id).
+                    where(self.__tasks_tbl.c.id == task_id).
                     values(reason='?',
                            end_time=time.time(),
                            state=self._TaskState.complete))

--- a/src/python/foglamp/core/scheduler.py
+++ b/src/python/foglamp/core/scheduler.py
@@ -86,9 +86,8 @@ class Scheduler(object):
 
         # Instance variables (begin)
         self.start_time = time.time()
-        self.check_schedules_seconds = 5
-        self.__last_schedule_time = self.start_time
-        """The last time `schedule()` ran"""
+        self.check_schedules_seconds = 30
+        """Check for tasks to run every this many seconds"""
         self.__scheduled_processes = dict()
         """ scheduled_processes.id to script """
         self.__schedules = dict()
@@ -96,7 +95,7 @@ class Scheduler(object):
         self.__schedule_factors = dict()
         """For interval schedules only
         
-        Maps schedules.id to a "time factor" when process was last executed
+        Maps schedules.id to a "time factor" when a schedule was last started.
         
         A "time factor" is the amount of time the scheduler has been running divided by 
         the schedule's interval time. The division is converted to an integer
@@ -139,6 +138,7 @@ class Scheduler(object):
                 pass
 
         for key in keys_to_delete:
+            logging.getLogger(__name__).info("Stopped %s", key)
             del self.__processes[key]
 
         return all_stopped
@@ -231,8 +231,7 @@ class Scheduler(object):
                            end_time=datetime.datetime.utcnow()))
 
     async def schedule(self):
-        seconds_run = self.start_time - self.__last_schedule_time
-        self.__last_schedule_time = time.time()
+        seconds_run = time.time() - self.start_time
         keys_to_delete = []
 
         for key, schedule in self.__schedules.items():

--- a/src/python/foglamp/core/scheduler.py
+++ b/src/python/foglamp/core/scheduler.py
@@ -6,6 +6,7 @@
 
 """FogLAMP Scheduler"""
 
+import time
 import asyncio
 from asyncio.subprocess import Process
 
@@ -14,10 +15,27 @@ __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
-# For Process methods, see https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.asyncio.subprocess.Process
-# or upgrade to a version of Python that uses type annotations
-_processes = []  # type: List[Process]
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
 
+"""CoAP handler for coap://other/sensor_readings URI 
+"""
+
+_sensor_values_tbl = sa.Table(
+    'readings',
+    sa.MetaData(),
+    sa.Column('asset_code', sa.types.VARCHAR(50)),
+    sa.Column('read_key', sa.types.VARCHAR(50)),
+    sa.Column('user_ts', sa.types.TIMESTAMP),
+    sa.Column('reading', JSONB))
+
+_processes = []  # type: List[Process]
+"""Long running processes
+
+https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.asyncio.subprocess.Process
+"""
+
+_last_check_time = time.now()
 
 def shutdown():
     """Stops the scheduler
@@ -29,6 +47,8 @@ def shutdown():
     for process in _processes:
         process.terminate()
 
+def
+    """Processes interval schedules and starts processes"""
 
 async def _start_device_server():
     """Starts the device server (foglamp.device) as a subprocess"""

--- a/src/python/foglamp/core/scheduler.py
+++ b/src/python/foglamp/core/scheduler.py
@@ -10,10 +10,10 @@ import time
 from enum import Enum
 import asyncio
 import logging
-import aiopg.sa
 import collections
 import uuid
 
+import aiopg.sa
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg_types
 

--- a/src/python/foglamp/core/server.py
+++ b/src/python/foglamp/core/server.py
@@ -33,11 +33,12 @@ class Server:
         if not loop:
             loop = asyncio.get_event_loop()
 
+        cls.__scheduler = scheduler.Scheduler()
+
         # Register signal handlers
         for signal_name in (signal.SIGINT, signal.SIGTERM, signal.SIGQUIT):
             loop.add_signal_handler(signal_name, cls.stop, loop)
 
-        cls.__scheduler = scheduler.Scheduler()
         cls.__scheduler.start()
 
         # https://aiohttp.readthedocs.io/en/stable/_modules/aiohttp/web.html#run_app

--- a/src/python/foglamp/core/server_daemon.py
+++ b/src/python/foglamp/core/server_daemon.py
@@ -36,30 +36,25 @@ _MAX_STOP_RETRY = 5
 """How many times to send TERM signal to core server process when stopping"""
 
 
-def _safe_make_dirs(path):
-    """Creates any missing parent directories
-
-    :param path: The path of the directory to create
-    """
-
-    try:
-        os.makedirs(path, 0o750)
-    except OSError as exception:
-        if not os.path.exists(path):
-            raise exception
-
-
-class TimeoutError(Exception):
-    """Operation timed out"""
-    pass
-
-
 class Daemon(object):
     # TODO FOGL-282: Return true/false instead of printing
     """FogLAMP Daemon"""
 
     logging_configured = False
     """Set to true when it's safe to use logging"""
+
+    @staticmethod
+    def _safe_make_dirs(path):
+        """Creates any missing parent directories
+
+        :param path: The path of the directory to create
+        """
+
+        try:
+            os.makedirs(path, 0o750)
+        except OSError as exception:
+            if not os.path.exists(path):
+                raise exception
 
     @classmethod
     def _configure_logging(cls):
@@ -86,15 +81,15 @@ class Daemon(object):
         """Starts the core server"""
 
         cls._configure_logging()
-        Server().start()
+        Server.start()
 
     @classmethod
     def start(cls):
         """Starts FogLAMP"""
 
-        _safe_make_dirs(_WORKING_DIR)
-        _safe_make_dirs(os.path.dirname(_PID_PATH))
-        _safe_make_dirs(os.path.dirname(_LOG_PATH))
+        cls._safe_make_dirs(_WORKING_DIR)
+        cls._safe_make_dirs(os.path.dirname(_PID_PATH))
+        cls._safe_make_dirs(os.path.dirname(_LOG_PATH))
 
         pid = cls.get_pid()
 
@@ -229,7 +224,7 @@ def main():
     """
 
     try:
-        Daemon().main()
+        Daemon.main()
         # pylint: disable=W0703
     except Exception as exception:
         # pylint: enable=W0703

--- a/src/python/foglamp/core/server_daemon.py
+++ b/src/python/foglamp/core/server_daemon.py
@@ -100,7 +100,7 @@ def stop(pid = None):
         print("FogLAMP is not running")
         return
 
-    stoppped = False
+    stopped = False
     
     try:
         for retry_index in range(_MAX_STOP_RETRY):

--- a/src/python/foglamp/core/server_daemon.py
+++ b/src/python/foglamp/core/server_daemon.py
@@ -63,7 +63,7 @@ class Daemon(object):
             return
 
         file_handler = logging.FileHandler(_LOG_PATH)
-        file_handler.setLevel(logging.WARNING)
+        file_handler.setLevel(logging.INFO)
 
         format_str = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
         formatter = logging.Formatter(format_str)
@@ -72,7 +72,7 @@ class Daemon(object):
 
         logger = logging.getLogger('')
         logger.addHandler(file_handler)
-        logger.setLevel(logging.WARNING)
+        logger.setLevel(logging.INFO)
 
         cls.logging_configured = True
 

--- a/src/sql/README.rst
+++ b/src/sql/README.rst
@@ -1,0 +1,7 @@
+Installing
+==========
+
+.. code-block:: python
+    PGPASSWORD=postgres psql -U postgres -h localhost -f foglamp_ddl.sql postgres
+    PGPASSWORD=foglamp psql -U foglamp -h localhost -f foglamp_init_data.sql foglamp 
+

--- a/src/sql/README.rst
+++ b/src/sql/README.rst
@@ -1,7 +1,7 @@
 Installing
 ==========
 
-.. code-block:: 
+Run the following commands from the shell:: 
     PGPASSWORD=postgres psql -U postgres -h localhost -f foglamp_ddl.sql postgres
     PGPASSWORD=foglamp psql -U foglamp -h localhost -f foglamp_init_data.sql foglamp 
 

--- a/src/sql/README.rst
+++ b/src/sql/README.rst
@@ -1,7 +1,7 @@
 Installing
 ==========
 
-.. code-block:: python
+.. code-block:: 
     PGPASSWORD=postgres psql -U postgres -h localhost -f foglamp_ddl.sql postgres
     PGPASSWORD=foglamp psql -U foglamp -h localhost -f foglamp_init_data.sql foglamp 
 

--- a/src/sql/README.rst
+++ b/src/sql/README.rst
@@ -4,6 +4,5 @@ Installing
 Execute the following commands::
 
     PGPASSWORD=postgres psql -U postgres -h localhost -f foglamp_ddl.sql postgres
-    
     PGPASSWORD=foglamp psql -U foglamp -h localhost -f foglamp_init_data.sql foglamp 
 

--- a/src/sql/README.rst
+++ b/src/sql/README.rst
@@ -1,7 +1,9 @@
 Installing
 ==========
 
-Run the following commands from the shell:: 
+Execute the following commands::
+
     PGPASSWORD=postgres psql -U postgres -h localhost -f foglamp_ddl.sql postgres
+    
     PGPASSWORD=foglamp psql -U foglamp -h localhost -f foglamp_init_data.sql foglamp 
 

--- a/src/sql/demo_data/scheduler.sql
+++ b/src/sql/demo_data/scheduler.sql
@@ -1,10 +1,12 @@
-insert into foglamp.scheduled_processes (name, script) values ('device_server', '["python3", "-m", "foglamp.device"]');
-insert into foglamp.scheduled_processes (name, script) values ('monkey', '["echo", "monkey", ">>", "/home/foglamp/monkey.txt"]');
+insert into foglamp.scheduled_processes (name, script) values ('device', '["python3", "-m", "foglamp.device"]');
+insert into foglamp.scheduled_processes (name, script) values ('monkey', '["echo", "monkey"]');
 
 /* https://www.uuidgenerator.net/version1 */
 
 insert into foglamp.schedules(id, process_name, schedule_name, schedule_type, schedule_interval, exclusive)
-values ('7c62b8f6-6843-11e7-907b-a6006ad3dba0', 'monkey', 'monkey', 0, '0:0', false)
+values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'device', 0, '0:0', false);
+insert into foglamp.schedules(id, process_name, schedule_name, schedule_type, schedule_interval, exclusive)
+values ('7c62b8f6-6843-11e7-907b-a6006ad3dba0', 'monkey', 'monkey', 0, '0:0', false);
 
 
 

--- a/src/sql/demo_data/scheduler.sql
+++ b/src/sql/demo_data/scheduler.sql
@@ -1,4 +1,10 @@
 insert into foglamp.scheduled_processes (name, script) values ('device_server', '["python3", "-m", "foglamp.device"]');
 insert into foglamp.scheduled_processes (name, script) values ('monkey', '["echo", "monkey", ">>", "/home/foglamp/monkey.txt"]');
 
+/* https://www.uuidgenerator.net/version1 */
+
+insert into foglamp.schedules(id, process_name, schedule_name, schedule_type, schedule_interval, exclusive)
+values ('7c62b8f6-6843-11e7-907b-a6006ad3dba0', 'monkey', 'monkey', 0, '0:0', false)
+
+
 

--- a/src/sql/demo_data/scheduler.sql
+++ b/src/sql/demo_data/scheduler.sql
@@ -3,7 +3,7 @@ insert into foglamp.scheduled_processes (name, script) values ('device', '["pyth
 /* https://www.uuidgenerator.net/version1 */
 
 insert into foglamp.schedules(id, process_name, schedule_name, schedule_type, schedule_interval, exclusive)
-values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'device', 0, '0:0', false);
+values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'device', 2, '0:0', false);
 
 
 

--- a/src/sql/demo_data/scheduler.sql
+++ b/src/sql/demo_data/scheduler.sql
@@ -1,0 +1,4 @@
+insert into foglamp.scheduled_processes (name, script) values ('device_server', '["python3", "-m", "foglamp.device"]');
+insert into foglamp.scheduled_processes (name, script) values ('monkey', '["echo", "monkey", ">>", "/home/foglamp/monkey.txt"]');
+
+

--- a/src/sql/demo_data/scheduler.sql
+++ b/src/sql/demo_data/scheduler.sql
@@ -1,12 +1,11 @@
 insert into foglamp.scheduled_processes (name, script) values ('device', '["python3", "-m", "foglamp.device"]');
-insert into foglamp.scheduled_processes (name, script) values ('monkey', '["echo", "monkey"]');
 
 /* https://www.uuidgenerator.net/version1 */
 
 insert into foglamp.schedules(id, process_name, schedule_name, schedule_type, schedule_interval, exclusive)
 values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'device', 0, '0:0', false);
-insert into foglamp.schedules(id, process_name, schedule_name, schedule_type, schedule_interval, exclusive)
-values ('7c62b8f6-6843-11e7-907b-a6006ad3dba0', 'monkey', 'monkey', 0, '0:0', false);
+
+
 
 
 

--- a/src/sql/foglamp_ddl.sql
+++ b/src/sql/foglamp_ddl.sql
@@ -845,7 +845,7 @@ CREATE INDEX fki_user_asset_permissions_fk2
 -- List of scheduled Processes
 CREATE TABLE foglamp.scheduled_processes (
   name   character varying(20)  NOT NULL, -- Name of the process
-  script character varying(255) NOT NULL, -- Full path of the process
+  script jsonb, -- Full path of the process
   CONSTRAINT scheduled_processes_pkey PRIMARY KEY (name)
        USING INDEX TABLESPACE foglamp )
   WITH ( OIDS = FALSE ) TABLESPACE foglamp;


### PR DESCRIPTION
- [ ] daemon and core converted to classes because they have mutable globals
- [ ] new scheduler.py with interval schedules
- [ ] An interval schedule starts the device server at start-up time (no more hard-coded tasks). Start-up tasks do not repeat and they are not entered into the tasks table.

I'm requesting an earlybird review. I am working on timed schedules. Methods will be docstring'ed and modules will be sent through lint. As you will see, there are many TODOs to handle errors. This won't be ready for merge until Monday.