### PR TITLE
value is in payload not in URL parameter for set configuration item

### DIFF
--- a/src/python/foglamp/core/api.py
+++ b/src/python/foglamp/core/api.py
@@ -21,9 +21,7 @@ _help = """
 
     | GET             | /categories                                       |
     | GET             | /category/{category_name}                         |
-    | GET DELETE      | /category/{category_name}/{config_item}           |
-    | PUT             | /category/{category_name}/{config_item}/{value}   |
-
+    | GET PUT DELETE  | /category/{category_name}/{config_item}           |
     -----------------------------------------------------------------------
 """
 
@@ -76,7 +74,7 @@ async def get_category_item(request):
     """
 
     :param request: category_name & config_item are required
-    :return:  the configuration item in the given category.
+    :return: the configuration item in the given category.
     """
     category_name = request.match_info.get('category_name', None)
     config_item = request.match_info.get('config_item', None)
@@ -91,13 +89,15 @@ async def get_category_item(request):
 async def set_configuration_item(request):
     """
 
-    :param request: category_name, config_item are required and value is required only when PUT
+    :param request: category_name, config_item are required and For PUT request {"value" : someValue) is required
     :return: set the configuration item value in the given category.
     """
     category_name = request.match_info.get('category_name', None)
     config_item = request.match_info.get('config_item', None)
+
     if request.method == 'PUT':
-        value = request.match_info.get('value', None)
+        data = await request.json()
+        value = data['value']
     elif request.method == 'DELETE':
         value = ''
 

--- a/src/python/foglamp/core/api.py
+++ b/src/python/foglamp/core/api.py
@@ -91,6 +91,14 @@ async def set_configuration_item(request):
 
     :param request: category_name, config_item are required and For PUT request {"value" : someValue) is required
     :return: set the configuration item value in the given category.
+
+    :Example:
+
+        For {category_name} PURGE  update/delete value for config_item {age}
+
+        curl -H "Content-Type: application/json" -X PUT -d '{"value":some_value}' http://localhost:8082/foglamp/category/{category_name}/{config_item}
+
+        curl -X DELETE http://localhost:8082/foglamp/category/{category_name}/{config_item}
     """
     category_name = request.match_info.get('category_name', None)
     config_item = request.match_info.get('config_item', None)

--- a/src/python/foglamp/core/routes.py
+++ b/src/python/foglamp/core/routes.py
@@ -6,6 +6,7 @@
 
 from foglamp.core import api
 from foglamp.core import browser
+from aiohttp import web
 
 __author__ = "Ashish Jabble, Praveen Garg"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -16,10 +17,13 @@ __version__ = "${VERSION}"
 def setup(app):
     # app.router.add_route('POST', '/foglamp/a-post-req', api.a_post_req, expect_handler = aiohttp.web.Request.json)
     app.router.add_route('GET', '/foglamp/ping', api.ping)
+
+    # Configuration
     app.router.add_route('GET', '/foglamp/categories', api.get_categories)
     app.router.add_route('GET', '/foglamp/category/{category_name}', api.get_category)
     app.router.add_route('GET', '/foglamp/category/{category_name}/{config_item}', api.get_category_item)
-    app.router.add_route('PUT', '/foglamp/category/{category_name}/{config_item}/{value}', api.set_configuration_item)
+    app.router.add_route('PUT', '/foglamp/category/{category_name}/{config_item}', api.set_configuration_item,
+                         expect_handler=web.Request.json)
     app.router.add_route('DELETE', '/foglamp/category/{category_name}/{config_item}', api.set_configuration_item)
 
     browser.setup(app)


### PR DESCRIPTION
[FOGL-219](https://scaledb.atlassian.net/browse/FOGL-219) - Complimentary PR

Problem:
For setting configuration item in Rest API; We did a mistake on PUT! the value is in the payload, not a parameter in the URL

**To test this PR, please proceed as follows:**
1) Run query
```
INSERT INTO foglamp.configuration ( key, description, VALUE ) 
      VALUES ( 'PURGE', 'Purge data process', '{"age": {"description": "Age of data to be retained, all data that is older than this value will be removed, unless retained. (in Hours)", "type": "integer", "default": "72"}}');
```
2) CURL request:

> curl -H "Content-Type: application/json" -X PUT -d '{"value":24}' http://localhost:8082/foglamp/category/PURGE/age
> 
> curl -X DELETE http://localhost:8082/foglamp/category/PURGE/age
> 
> curl -X GET http://localhost:8082/foglamp/category/PURGE/age
