### PR TITLE
FOGL-430: Change connection pool size and close connection after execution in purge process

### DIFF
--- a/src/python/foglamp/data_purge/purge.py
+++ b/src/python/foglamp/data_purge/purge.py
@@ -32,7 +32,7 @@ Description: Based on FOGL-200 (https://docs.google.com/document/d/1GdMTerNq_-XQ
      total_failed_to_remove > 0 then it is safe to assume that that there was an error with INSERTS, and if 
      total_failed_to_remove > total_rows_removed then PURGE completely failed. 
 """
-
+import aiopg.sa
 import asyncio
 import datetime
 import sqlalchemy
@@ -108,13 +108,10 @@ def execute_command(stmt):
     Returns:
         Returns result set 
     """
-    # Set connection to database
-    engine = sqlalchemy.create_engine(__CONNECTION_STRING, pool_size=20, max_overflow=0)
-    conn = engine.connect()
-    # Execute query
-    query_result = conn.execute(stmt)
-    return query_result
 
+    engine = sqlalchemy.create_engine(__CONNECTION_STRING, pool_size=20, max_overflow=0)
+    with engine.connect() as conn: 
+        return conn.execute(stmt)
 
 def insert_into_log(level=0, log=None):
     """"INSERT into log table values"""

--- a/src/python/foglamp/data_purge/purge.py
+++ b/src/python/foglamp/data_purge/purge.py
@@ -48,7 +48,7 @@ __version__ = "${VERSION}"
 
 # Create Connection
 __CONNECTION_STRING = "postgres:///foglamp"
-
+__ENGINE = sqlalchemy.create_engine(__CONNECTION_STRING, pool_size=5, max_overflow=0)
 _DEFAULT_PURGE_CONFIG = {
     "age": {
         "description": "Age of data to be retained, all data that is older than this value will be removed," +
@@ -107,9 +107,7 @@ def execute_command(stmt):
     Returns:
         Returns result set 
     """
-
-    engine = sqlalchemy.create_engine(__CONNECTION_STRING, pool_size=5, max_overflow=0)
-    with engine.connect() as conn: 
+    with __ENGINE.connect() as conn: 
         return conn.execute(stmt)
 
 def insert_into_log(level=0, log=None):

--- a/src/python/foglamp/data_purge/purge.py
+++ b/src/python/foglamp/data_purge/purge.py
@@ -32,7 +32,6 @@ Description: Based on FOGL-200 (https://docs.google.com/document/d/1GdMTerNq_-XQ
      total_failed_to_remove > 0 then it is safe to assume that that there was an error with INSERTS, and if 
      total_failed_to_remove > total_rows_removed then PURGE completely failed. 
 """
-import aiopg.sa
 import asyncio
 import datetime
 import sqlalchemy

--- a/src/python/foglamp/data_purge/purge.py
+++ b/src/python/foglamp/data_purge/purge.py
@@ -109,7 +109,7 @@ def execute_command(stmt):
         Returns result set 
     """
 
-    engine = sqlalchemy.create_engine(__CONNECTION_STRING, pool_size=20, max_overflow=0)
+    engine = sqlalchemy.create_engine(__CONNECTION_STRING, pool_size=5, max_overflow=0)
     with engine.connect() as conn: 
         return conn.execute(stmt)
 


### PR DESCRIPTION
Since the code is single threaded non-async, it could work with a pool size of 1. However, to make things a little more safe, I have set the pool_size to 5. 