### PR TITLE
fogl-585 : type error handling for category name and description with their unit tests

### DIFF
--- a/src/python/foglamp/configuration_manager.py
+++ b/src/python/foglamp/configuration_manager.py
@@ -387,6 +387,12 @@ async def create_category(category_name, category_value, category_description=''
     Only default values can be entered for and item's entries.
     A "value" entry specified for an item will raise an exception.
     """
+    if not isinstance(category_name, str):
+        raise TypeError('category_name must be a string')
+
+    if not isinstance(category_description, str):
+        raise TypeError('category_description must be a string')
+
     category_val_prepared = ''
     try:
         # validate new category_val, set "value" from default


### PR DESCRIPTION
[FOGL-585](https://scaledb.atlassian.net/browse/FOGL-585) - Invalid Error when setting invalid category_name in create_category

**Fixed items:**
* category name and description accepts only as string
* unit tests added for ^^ handling
* PEP8 warning fixes and other refactoring for configuration unit tests

**tests O/p**
tests/test_configuration_manager.py ................XXXXX...

==================================================== 19 passed, 5 xpassed in 1.48 seconds =====================================================
