### PR TITLE
FOGL-615

### DIFF
--- a/src/python/foglamp/storage/storage.py
+++ b/src/python/foglamp/storage/storage.py
@@ -160,6 +160,8 @@ class Storage(AbstractStorage):
         # Allow shutdown()?
         pass
 
+    # FIXME: As per JIRA-615 strict=false at python side (interim solution)
+    # fix is required at storage layer (error message with escape sequence using a single quote)
     def insert_into_tbl(self, tbl_name, data):
         """ insert json payload into given table
 
@@ -199,7 +201,7 @@ class Storage(AbstractStorage):
 
         res = r.read().decode()
         conn.close()
-        return json.loads(res)
+        return json.loads(res, strict=False)
 
     def update_tbl(self, tbl_name, data):
         """ update json payload for specified condition into given table
@@ -244,7 +246,7 @@ class Storage(AbstractStorage):
 
         res = r.read().decode()
         conn.close()
-        return json.loads(res)
+        return json.loads(res, strict=False)
 
     def delete_from_tbl(self, tbl_name, condition=None):
         """ Delete for specified condition from given table
@@ -281,7 +283,7 @@ class Storage(AbstractStorage):
 
         res = r.read().decode()
         conn.close()
-        return json.loads(res)
+        return json.loads(res, strict=False)
 
     def query_tbl(self, tbl_name, query=None):
         """ Simple SELECT query for the specified table with optional query params
@@ -314,7 +316,7 @@ class Storage(AbstractStorage):
 
         res = r.read().decode()
         conn.close()
-        return json.loads(res)
+        return json.loads(res, strict=False)
 
     def query_tbl_with_payload(self, tbl_name, query_payload):
         """ Complex SELECT query for the specified table with a payload
@@ -348,7 +350,7 @@ class Storage(AbstractStorage):
 
         res = r.read().decode()
         conn.close()
-        return json.loads(res)
+        return json.loads(res, strict=False)
 
 
 class Readings(Storage):
@@ -410,7 +412,7 @@ class Readings(Storage):
 
         res = r.read().decode()
         conn.close()
-        return json.loads(res)
+        return json.loads(res, strict=False)
 
     @classmethod
     def fetch(cls, reading_id, count):
@@ -441,7 +443,7 @@ class Readings(Storage):
 
         res = r.read().decode()
         conn.close()
-        return json.loads(res)
+        return json.loads(res, strict=False)
 
     @classmethod
     def query(cls, query_payload):
@@ -476,7 +478,7 @@ class Readings(Storage):
 
         res = r.read().decode()
         conn.close()
-        return json.loads(res)
+        return json.loads(res, strict=False)
 
     @classmethod
     def purge(cls, age, sent_id, flag=None):
@@ -528,4 +530,4 @@ class Readings(Storage):
         #       then the error “409 Conflict” will be returned.
         res = r.read().decode()
         conn.close()
-        return json.loads(res)
+        return json.loads(res, strict=False)

--- a/src/python/tests/storage/test_storage_api.py
+++ b/src/python/tests/storage/test_storage_api.py
@@ -74,7 +74,6 @@ class TestStorageRead:
         assert result["rows"][0]["value"] == 10
         assert result["rows"][0]["previous_value"] == 2
 
-    @pytest.mark.skip(reason="FOGL-615")
     def test_where_invalid_key(self):
         payload = PayloadBuilder().WHERE(["bla", "=", "invalid"]).payload()
         result = Storage().query_tbl_with_payload("statistics", payload)
@@ -228,7 +227,6 @@ class TestStorageInsert:
         result = Storage().insert_into_tbl("statistics", payload)
         assert result == {'response': 'inserted'}
 
-    @pytest.mark.skip(reason="FOGL-615")
     def test_invalid_insert(self):
         payload = PayloadBuilder().INSERT(key='TEST_3', value='11', previous_value=2).payload()
         result = Storage().insert_into_tbl("statistics", payload)
@@ -278,7 +276,6 @@ class TestStorageUpdate:
         for r in result["rows"]:
             assert "Updated test value 2" != r["description"]
 
-    @pytest.mark.skip(reason="FOGL-615")
     def test_invalid_type_update(self):
         payload = PayloadBuilder().SET(value="invalid", description="Updated test value 3").\
             WHERE(["key", "=", "TEST_2"]).payload()


### PR DESCRIPTION
[FOGL-615](https://scaledb.atlassian.net/browse/FOGL-615) - Storage service should return a well formatted JSON response in case of db errors

**Fixed items:**
* strict=False key/value pair added when  results return via json.loads after decoding of response
* 615 references removed from test_storage_api.py

Tests O/P:
```
collected 30 items 

tests/storage/test_storage_api.py ....ss.....s.ss.ssss..sss.....

======= 18 passed, 12 skipped in 0.87 seconds=======
```