### PR TITLE
Fogl 650 startup and configuration of device server fix

### DIFF
--- a/src/python/foglamp/device/coap_device.py
+++ b/src/python/foglamp/device/coap_device.py
@@ -27,7 +27,7 @@ _DEFAULT_CONFIG = {
     'plugin': {
          'description': 'Python module name of the plugin to load',
          'type': 'string',
-         'default': 'foglamp.device.coap_device'
+         'default': 'coap'
     },
     'port': {
         'description': 'Port to listen on',

--- a/src/python/foglamp/device/server.py
+++ b/src/python/foglamp/device/server.py
@@ -79,10 +79,11 @@ class Server:
             try:
                 plugin_module = config['plugin']['value']
             except KeyError:
-                sys.exit(1)
+                _LOGGER.warning("Unable to obtain configuration of module for plugin {}".format(plugin))
+                raise
 
             try:
-                cls._plugin = __import__(plugin_module, fromlist=[''])
+                cls._plugin = __import__("foglamp.device.{}_device".format(plugin_module), fromlist=[''])
             except Exception:
                 error = 'Unable to load module {} for device plugin {}'.format(plugin_module,
                                                                                plugin)

--- a/src/python/foglamp/device/server.py
+++ b/src/python/foglamp/device/server.py
@@ -69,20 +69,17 @@ class Server:
         cls._core_management_port = core_mgt_port
 
         try:
-            # TODO: Category name column is allows only 10 characters.
-            # This needs to be increased
             category = plugin
-
             config = {}
-
             await configuration_manager.create_category(category, config,
                                                         '{} Device'.format(plugin), True)
 
+            config = await configuration_manager.get_category_all_items(category)
+
             try:
-                plugin_module = config['plugin']
+                plugin_module = config['plugin']['value']
             except KeyError:
-                # TODO: Delete me
-                plugin_module = 'foglamp.device.coap_device'
+                sys.exit(1)
 
             try:
                 cls._plugin = __import__(plugin_module, fromlist=[''])

--- a/src/sql/foglamp_init_data.sql
+++ b/src/sql/foglamp_init_data.sql
@@ -73,9 +73,8 @@ INSERT INTO foglamp.configuration ( key, description, value )
 INSERT INTO foglamp.configuration ( key, description, value )
      VALUES ( 'SYPURGE', 'System Purge', to_jsonb( '{ "retention" : 259200, "last purge" : "' || now() || '" }' ) );
 
--- SYPRG: System Purge
---        retention : data retention in seconds. Default is 3 days (259200 seconds)
---        last purge: ts of the last purge call
+-- COAP:  CoAP device server
+--        plugin: python module to load dynamically
 INSERT INTO foglamp.configuration ( key, description, value )
      VALUES ( 'COAP', 'CoAP Plugin Configuration', ' { "plugin" : { "type" : "string", "value" : "foglamp.device.coap_device", "default" : "foglamp.device.coap_device", "description" : "Python module name of the plugin to load" } } ');
 

--- a/src/sql/foglamp_init_data.sql
+++ b/src/sql/foglamp_init_data.sql
@@ -78,7 +78,6 @@ INSERT INTO foglamp.configuration ( key, description, value )
 --        last purge: ts of the last purge call
 INSERT INTO foglamp.configuration ( key, description, value )
      VALUES ( 'COAP', 'CoAP Plugin Configuration', ' { "plugin" : { "type" : "string", "value" : "foglamp.device.coap_device", "default" : "foglamp.device.coap_device", "description" : "Python module name of the plugin to load" } } ');
---     VALUES ( 'COAP', 'CoAP Plugin Configuration', to_jsonb( '{ "plugin" : { "type" : "string", "value" : "foglamp.device.coap_device", "default" : "foglamp.device.coap_device", "description" : "Python module name of the plugin to load" } }'::TEXT ) );
 
 -- DELETE data for roles, resources and permissions
 DELETE FROM foglamp.role_resource_permission;

--- a/src/sql/foglamp_init_data.sql
+++ b/src/sql/foglamp_init_data.sql
@@ -73,7 +73,12 @@ INSERT INTO foglamp.configuration ( key, description, value )
 INSERT INTO foglamp.configuration ( key, description, value )
      VALUES ( 'SYPURGE', 'System Purge', to_jsonb( '{ "retention" : 259200, "last purge" : "' || now() || '" }' ) );
 
-
+-- SYPRG: System Purge
+--        retention : data retention in seconds. Default is 3 days (259200 seconds)
+--        last purge: ts of the last purge call
+INSERT INTO foglamp.configuration ( key, description, value )
+     VALUES ( 'COAP', 'CoAP Plugin Configuration', ' { "plugin" : { "type" : "string", "value" : "foglamp.device.coap_device", "default" : "foglamp.device.coap_device", "description" : "Python module name of the plugin to load" } } ');
+--     VALUES ( 'COAP', 'CoAP Plugin Configuration', to_jsonb( '{ "plugin" : { "type" : "string", "value" : "foglamp.device.coap_device", "default" : "foglamp.device.coap_device", "description" : "Python module name of the plugin to load" } }'::TEXT ) );
 
 -- DELETE data for roles, resources and permissions
 DELETE FROM foglamp.role_resource_permission;
@@ -115,7 +120,7 @@ INSERT INTO foglamp.statistics ( key, description, value, previous_value )
 -- Use this to create guids: https://www.uuidgenerator.net/version1 */
 -- Weekly repeat for timed schedules: set schedule_interval to 168:00:00
 
-insert into foglamp.scheduled_processes (name, script) values ('device', '["python3", "-m", "foglamp.device"]');
+insert into foglamp.scheduled_processes (name, script) values ('COAP', '["python3", "-m", "foglamp.device"]');
 insert into foglamp.scheduled_processes (name, script) values ('purge', '["python3", "-m", "foglamp.data_purge"]');
 insert into foglamp.scheduled_processes (name, script) values ('stats collector', '["python3", "-m", "foglamp.update_statistics_history"]');
 insert into foglamp.scheduled_processes (name, script) values ('sending process', '["python3", "-m", "foglamp.sending_process", "-s", "1", "-d", "1"]');
@@ -125,7 +130,7 @@ insert into foglamp.scheduled_processes (name, script) values ('statistics to pi
 -- Start the device server at start-up
 insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
 schedule_interval, exclusive)
-values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'device', 1,
+values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'COAP', 1,
 '0:0', true);
 
 -- Run the purge process every 5 minutes

--- a/src/sql/foglamp_init_data.sql
+++ b/src/sql/foglamp_init_data.sql
@@ -76,7 +76,7 @@ INSERT INTO foglamp.configuration ( key, description, value )
 -- COAP:  CoAP device server
 --        plugin: python module to load dynamically
 INSERT INTO foglamp.configuration ( key, description, value )
-     VALUES ( 'COAP', 'CoAP Plugin Configuration', ' { "plugin" : { "type" : "string", "value" : "foglamp.device.coap_device", "default" : "foglamp.device.coap_device", "description" : "Python module name of the plugin to load" } } ');
+     VALUES ( 'COAP', 'CoAP Plugin Configuration', ' { "plugin" : { "type" : "string", "value" : "coap", "default" : "coap", "description" : "Python module name of the plugin to load" } } ');
 
 -- DELETE data for roles, resources and permissions
 DELETE FROM foglamp.role_resource_permission;


### PR DESCRIPTION
1. change foglamp_init_data.sql - COAP configuration, task name for device is COAP also
2. change device server code to retrieve plugin to load (from configuration) based on command line argument passed in

