### PR TITLE
[FOGL-626] improved purge task, allow scalablity fixes

### DIFF
--- a/src/python/foglamp/data_purge/__main__.py
+++ b/src/python/foglamp/data_purge/__main__.py
@@ -8,7 +8,8 @@
 """Purge process starter"""
 
 import sys
-from foglamp.data_purge import purge
+
+from foglamp.data_purge.purge import Purge
 from foglamp import logger
 from foglamp.parser import ArgumentParserError, Parser
 
@@ -32,4 +33,5 @@ if __name__ == '__main__':
     elif core_mgt_address is None:
         _logger.warning("Required argument '--address' is missing")
     else:
-        purge.start(core_mgt_address, core_mgt_port)
+        purge = Purge(core_mgt_address, core_mgt_port)
+        purge.start()

--- a/src/python/foglamp/data_purge/purge.py
+++ b/src/python/foglamp/data_purge/purge.py
@@ -139,7 +139,7 @@ class Purge:
         self._insert_into_log(level=error_level, log={"start_time": start_time, "end_time": end_time,
                                                       "rowsRemoved": total_rows_removed,
                                                       "unsentRowsRemoved": unsent_rows_removed,
-                                                      "rows_retained": unsent_retained, "rowsRemaining": total_count})
+                                                      "rowsRetained": unsent_retained, "rowsRemaining": total_count})
 
         return total_rows_removed, unsent_rows_removed
 

--- a/src/python/foglamp/data_purge/purge.py
+++ b/src/python/foglamp/data_purge/purge.py
@@ -24,14 +24,15 @@ Statistics reported by Purge process are:
 """
 import asyncio
 import time
+
 from foglamp import configuration_manager
+# from foglamp.statistics import Statistics
 from foglamp import statistics
-from foglamp.storage.storage import Storage, Readings
 from foglamp.storage.payload_builder import PayloadBuilder
+from foglamp.storage.storage import Storage, Readings
 from foglamp import logger
 
 
-"""Script information and connection to the Database"""
 __author__ = "Ori Shadmon, Vaibhav Singhal"
 __copyright__ = "Copyright (c) 2017 OSI Soft, LLC"
 __license__ = "Apache 2.0"
@@ -39,6 +40,7 @@ __version__ = "${VERSION}"
 
 
 class Purge:
+
     _DEFAULT_PURGE_CONFIG = {
         "age": {
             "description": "Age of data to be retained, all data that is older than this value will be removed," +
@@ -60,9 +62,13 @@ class Purge:
         self._readings = Readings(core_mgt_address, core_mgt_port)
         self._logger = logger.setup("Data Purge")
 
-    @classmethod
-    def write_statistics(cls, total_purged, unsent_purged):
+    def write_statistics(self, total_purged, unsent_purged):
         loop = asyncio.get_event_loop()
+
+        # stats = Statistics(self._storage)
+        # loop.run_until_complete(stats.update('PURGED', total_purged))
+        # loop.run_until_complete(stats.update('UNSNPURGED', unsent_purged))
+
         loop.run_until_complete(statistics.update_statistics_value('PURGED', total_purged))
         loop.run_until_complete(statistics.update_statistics_value('UNSNPURGED', unsent_purged))
 
@@ -89,7 +95,7 @@ class Purge:
         return event_loop.run_until_complete(configuration_manager.get_category_all_items(self._CONFIG_CATEGORY_NAME))
 
     def purge_data(self, config):
-        """"Purge readings table based on the set configuration
+        """" Purge readings table based on the set configuration
         :return:
             total rows removed
             rows removed that were not sent to any historian
@@ -107,7 +113,7 @@ class Purge:
         result = self._storage.query_tbl_with_payload("streams", payload)
         last_id = result["rows"][0]["min_last_object"] if result["count"] == 1 else 0
 
-        """Error Levels:
+        """ Error Levels:
             - 0: No errors
             - 1: Rows failed to remove
             - 2: Unsent rows were removed
@@ -137,15 +143,17 @@ class Purge:
 
         return total_rows_removed, unsent_rows_removed
 
+    def start(self):
+        """" Starts the purge task
 
-def start(core_mgt_address, core_mgt_port):
-    """"Entry point of the purge process
-        Configure
-        Collect statistics
-        Write statistics to statistics table
-    """
-
-    purge = Purge(core_mgt_address, core_mgt_port)
-    config = purge.set_configuration()
-    total_purged, unsent_purged = purge.purge_data(config)
-    purge.write_statistics(total_purged, unsent_purged)
+            1. Write and read Purge task configuration
+            2. Purge as per the configuration
+            3. Collect statistics
+            4. Write statistics to statistics table
+        """
+        try:
+            config = self.set_configuration()
+            total_purged, unsent_purged = self.purge_data(config)
+            self.write_statistics(total_purged, unsent_purged)
+        except Exception as ex:
+            self._logger.exception(str(ex))

--- a/src/python/tests/data_purge/test_data_purge.py
+++ b/src/python/tests/data_purge/test_data_purge.py
@@ -28,7 +28,7 @@ __version__ = "${VERSION}"
 class TestPurge:
 
     # TODO: FOGL-510 Hardcoded core_management_port needs to be removed, should be coming form a test configuration file
-    _core_management_port = 36979
+    _core_management_port = 43807
 
     _store = Storage("localhost", _core_management_port)
     _readings = Readings("localhost", _core_management_port)
@@ -168,7 +168,7 @@ class TestPurge:
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 0
         assert log[1]["unsentRowsRemoved"] == 0
-        assert log[1]["rows_retained"] == 0
+        assert log[1]["rowsRetained"] == 0
         assert log[1]["rowsRemaining"] == 0
 
         stats = self._get_stats()
@@ -194,7 +194,7 @@ class TestPurge:
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 0
         assert log[1]["unsentRowsRemoved"] == 0
-        assert log[1]["rows_retained"] == 1
+        assert log[1]["rowsRetained"] == 1
         assert log[1]["rowsRemaining"] == 1
 
         stats = self._get_stats()
@@ -223,7 +223,7 @@ class TestPurge:
         assert log[0] == 2
         assert log[1]["rowsRemoved"] == 1
         assert log[1]["unsentRowsRemoved"] == 1
-        assert log[1]["rows_retained"] == 0
+        assert log[1]["rowsRetained"] == 0
         assert log[1]["rowsRemaining"] == 0
 
         stats = self._get_stats()
@@ -257,7 +257,7 @@ class TestPurge:
         assert log[0] == 2
         assert log[1]["rowsRemoved"] == 1
         assert log[1]["unsentRowsRemoved"] == 1
-        assert log[1]["rows_retained"] == 1
+        assert log[1]["rowsRetained"] == 1
         assert log[1]["rowsRemaining"] == 1
 
         stats = self._get_stats()
@@ -292,7 +292,7 @@ class TestPurge:
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 1
         assert log[1]["unsentRowsRemoved"] == 0
-        assert log[1]["rows_retained"] == 0
+        assert log[1]["rowsRetained"] == 0
         assert log[1]["rowsRemaining"] == 1
 
         stats = self._get_stats()
@@ -324,7 +324,7 @@ class TestPurge:
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 0
         assert log[1]["unsentRowsRemoved"] == 0
-        assert log[1]["rows_retained"] == 2
+        assert log[1]["rowsRetained"] == 2
         assert log[1]["rowsRemaining"] == 2
 
         stats = self._get_stats()
@@ -357,7 +357,7 @@ class TestPurge:
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 0
         assert log[1]["unsentRowsRemoved"] == 0
-        assert log[1]["rows_retained"] == 2
+        assert log[1]["rowsRetained"] == 2
         assert log[1]["rowsRemaining"] == 2
 
         stats = self._get_stats()
@@ -390,7 +390,7 @@ class TestPurge:
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 1
         assert log[1]["unsentRowsRemoved"] == 0
-        assert log[1]["rows_retained"] == 0
+        assert log[1]["rowsRetained"] == 0
         assert log[1]["rowsRemaining"] == 1
 
         stats = self._get_stats()
@@ -422,7 +422,7 @@ class TestPurge:
         assert log[0] == 2
         assert log[1]["rowsRemoved"] == 1
         assert log[1]["unsentRowsRemoved"] == 1
-        assert log[1]["rows_retained"] == 1
+        assert log[1]["rowsRetained"] == 1
         assert log[1]["rowsRemaining"] == 1
 
         stats = self._get_stats()

--- a/src/python/tests/data_purge/test_data_purge.py
+++ b/src/python/tests/data_purge/test_data_purge.py
@@ -5,7 +5,6 @@
 # FOGLAMP_END
 
 import asyncio
-from collections import OrderedDict
 from datetime import datetime, timezone, timedelta
 import pytest
 import random
@@ -28,7 +27,7 @@ __version__ = "${VERSION}"
 class TestPurge:
 
     # TODO: FOGL-510 Hardcoded core_management_port needs to be removed, should be coming form a test configuration file
-    _core_management_port = 43807
+    _core_management_port = 39940
 
     _store = Storage("localhost", _core_management_port)
     _readings = Readings("localhost", _core_management_port)
@@ -91,17 +90,8 @@ class TestPurge:
         """Get values from readings table where asset_code is asset_code of test data
         """
 
-        # TODO: use payload builder
-
-        cond1 = OrderedDict()
-        cond1['column'] = 'asset_code'
-        cond1['condition'] = '='
-        cond1['value'] = 'TEST_PURGE_UNIT'
-    
-        query_payload = OrderedDict()
-        query_payload['where'] = cond1
-    
-        res = cls._readings.query(json.dumps(query_payload))
+        query_payload = PayloadBuilder().WHERE(["asset_code", "=", 'TEST_PURGE_UNIT']).payload()
+        res = cls._readings.query(query_payload)
         return res
     
     @classmethod

--- a/src/python/tests/data_purge/test_data_purge.py
+++ b/src/python/tests/data_purge/test_data_purge.py
@@ -13,7 +13,7 @@ import uuid
 import json
 
 from foglamp import configuration_manager
-from foglamp.data_purge.purge import start
+from foglamp.data_purge.purge import Purge
 from foglamp.storage.payload_builder import PayloadBuilder
 from foglamp.storage.storage import Storage, Readings
 
@@ -26,10 +26,13 @@ __version__ = "${VERSION}"
 @pytest.allure.feature("unit")
 @pytest.allure.story("data_purge")
 class TestPurge:
-    # TODO: FOGL-510:Hardcoded core_management_port needs to be removed, should be coming form a test configuration file
+
+    # TODO: FOGL-510 Hardcoded core_management_port needs to be removed, should be coming form a test configuration file
     _core_management_port = 36979
+
     _store = Storage("localhost", _core_management_port)
     _readings = Readings("localhost", _core_management_port)
+
     _CONFIG_CATEGORY_NAME = 'PURGE_READ'
 
     @classmethod
@@ -49,7 +52,7 @@ class TestPurge:
         # Update streams
         payload = PayloadBuilder().SET(last_object=0).payload()
         cls._store.update_tbl("streams", payload)
-        #
+
         # Restore default configuration
         cls._update_configuration()
     
@@ -63,6 +66,7 @@ class TestPurge:
     
         """
         readings = []
+
         read = dict()
         read["asset_code"] = "TEST_PURGE_UNIT"
         read["read_key"] = str(uuid.uuid4())
@@ -70,10 +74,14 @@ class TestPurge:
         read['reading']['rate'] = random.randint(1, 100)
         ts = str(datetime.now(tz=timezone.utc) - timedelta(hours=hours_delta))
         read["user_ts"] = ts
+
         readings.append(read)
+
         payload = dict()
         payload['readings'] = readings
+
         cls._readings.append(json.dumps(payload))
+
         payload = PayloadBuilder.AGGREGATE(["max", "id"]).payload()
         result = cls._store.query_tbl_with_payload("readings", payload)
         return int(result["rows"][0]["max_id"])
@@ -82,6 +90,9 @@ class TestPurge:
     def _get_reads(cls):
         """Get values from readings table where asset_code is asset_code of test data
         """
+
+        # TODO: use payload builder
+
         cond1 = OrderedDict()
         cond1['column'] = 'asset_code'
         cond1['condition'] = '='
@@ -106,7 +117,7 @@ class TestPurge:
         else:
             payload = PayloadBuilder().SET(last_object=id_last_object).payload()
             cls._store.update_tbl("streams", payload)
-    
+
     @classmethod
     def _update_configuration(cls, age=72, retain_unsent=False) -> dict:
         """"Update the configuration table with the appropriate information regarding "PURE_READ" using pre-existing
@@ -132,8 +143,10 @@ class TestPurge:
         """
         payload = PayloadBuilder().SELECT("value").WHERE(["key", "=", 'PURGED']).payload()
         result_purged = cls._store.query_tbl_with_payload("statistics", payload)
+
         payload = PayloadBuilder().SELECT("value").WHERE(["key", "=", 'UNSNPURGED']).payload()
         result_unsnpurged = cls._store.query_tbl_with_payload("statistics", payload)
+
         return result_purged["rows"][0]["value"], result_unsnpurged["rows"][0]["value"]
     
     @classmethod
@@ -148,13 +161,16 @@ class TestPurge:
     
     def test_no_read_purge(self):
         """Test that when there is no data in readings table, purge process runs but no data is purged"""
-        start("localhost", self._core_management_port)
+        purge = Purge("localhost", self._core_management_port)
+        purge.start()
+
         log = self._get_log()
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 0
         assert log[1]["unsentRowsRemoved"] == 0
         assert log[1]["rows_retained"] == 0
         assert log[1]["rowsRemaining"] == 0
+
         stats = self._get_stats()
         assert stats[0] == 0
         assert stats[1] == 0
@@ -170,16 +186,21 @@ class TestPurge:
         """
         
         last_id = self._insert_readings_data(0)
-        start("localhost", self._core_management_port)
+
+        purge = Purge("localhost", self._core_management_port)
+        purge.start()
+
         log = self._get_log()
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 0
         assert log[1]["unsentRowsRemoved"] == 0
         assert log[1]["rows_retained"] == 1
         assert log[1]["rowsRemaining"] == 1
+
         stats = self._get_stats()
         assert stats[0] == 0
         assert stats[1] == 0
+
         readings = self._get_reads()
         assert readings["count"] == 1
         assert readings["rows"][0]["id"] == last_id
@@ -195,16 +216,20 @@ class TestPurge:
         """
         
         self._insert_readings_data(80)
-        start("localhost", self._core_management_port)
+        purge = Purge("localhost", self._core_management_port)
+        purge.start()
+
         log = self._get_log()
         assert log[0] == 2
         assert log[1]["rowsRemoved"] == 1
         assert log[1]["unsentRowsRemoved"] == 1
         assert log[1]["rows_retained"] == 0
         assert log[1]["rowsRemaining"] == 0
+
         stats = self._get_stats()
         assert stats[0] == 1
         assert stats[1] == 1
+
         readings = self._get_reads()
         assert readings["count"] == 0
 
@@ -224,23 +249,28 @@ class TestPurge:
         self._insert_readings_data(80)
         last_id = self._insert_readings_data(0)
         self._update_streams(rows_to_update=1, id_last_object=last_id)
-        start("localhost", self._core_management_port)
+
+        purge = Purge("localhost", self._core_management_port)
+        purge.start()
+
         log = self._get_log()
         assert log[0] == 2
         assert log[1]["rowsRemoved"] == 1
         assert log[1]["unsentRowsRemoved"] == 1
         assert log[1]["rows_retained"] == 1
         assert log[1]["rowsRemaining"] == 1
+
         stats = self._get_stats()
         assert stats[0] == 1
         assert stats[1] == 1
+
         readings = self._get_reads()
         assert readings["count"] == 1
         assert readings["rows"][0]["id"] == last_id
     
     def test_all_dest_sent_reads_purge(self):
-        """Test that when there is data in readings table which is sent to all historians
-         with user_ts >= configured age and user_ts = now(),
+        """ Test that when there is data in readings table which is sent to all historians
+        with user_ts >= configured age and user_ts = now(),
         purge process runs and data is purged
         If retainUnsent=False then all readings older than the age passed in,
         regardless of the value of sent will be removed
@@ -254,16 +284,21 @@ class TestPurge:
         self._insert_readings_data(80)
         last_id = self._insert_readings_data(0)
         self._update_streams(rows_to_update=-1, id_last_object=last_id)
-        start("localhost", self._core_management_port)
+
+        purge = Purge("localhost", self._core_management_port)
+        purge.start()
+
         log = self._get_log()
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 1
         assert log[1]["unsentRowsRemoved"] == 0
         assert log[1]["rows_retained"] == 0
         assert log[1]["rowsRemaining"] == 1
+
         stats = self._get_stats()
         assert stats[0] == 1
         assert stats[1] == 0
+
         readings = self._get_reads()
         assert readings["count"] == 1
         assert readings["rows"][0]["id"] == last_id
@@ -281,16 +316,21 @@ class TestPurge:
         self._insert_readings_data(80)
         self._insert_readings_data(0)
         self._update_configuration(age=72, retain_unsent=True)
-        start("localhost", self._core_management_port)
+
+        purge = Purge("localhost", self._core_management_port)
+        purge.start()
+
         log = self._get_log()
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 0
         assert log[1]["unsentRowsRemoved"] == 0
         assert log[1]["rows_retained"] == 2
         assert log[1]["rowsRemaining"] == 2
+
         stats = self._get_stats()
         assert stats[0] == 0
         assert stats[1] == 0
+
         readings = self._get_reads()
         assert readings["count"] == 2
 
@@ -309,16 +349,21 @@ class TestPurge:
         last_id = self._insert_readings_data(0)
         self._update_configuration(age=72, retain_unsent=True)
         self._update_streams(rows_to_update=1, id_last_object=last_id)
-        start("localhost", self._core_management_port)
+
+        purge = Purge("localhost", self._core_management_port)
+        purge.start()
+
         log = self._get_log()
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 0
         assert log[1]["unsentRowsRemoved"] == 0
         assert log[1]["rows_retained"] == 2
         assert log[1]["rowsRemaining"] == 2
+
         stats = self._get_stats()
         assert stats[0] == 0
         assert stats[1] == 0
+
         readings = self._get_reads()
         assert readings["count"] == 2
 
@@ -337,16 +382,21 @@ class TestPurge:
         last_id = self._insert_readings_data(0)
         self._update_configuration(age=72, retain_unsent=True)
         self._update_streams(rows_to_update=-1, id_last_object=last_id)
-        start("localhost", self._core_management_port)
+
+        purge = Purge("localhost", self._core_management_port)
+        purge.start()
+
         log = self._get_log()
         assert log[0] == 0
         assert log[1]["rowsRemoved"] == 1
         assert log[1]["unsentRowsRemoved"] == 0
         assert log[1]["rows_retained"] == 0
         assert log[1]["rowsRemaining"] == 1
+
         stats = self._get_stats()
         assert stats[0] == 1
         assert stats[1] == 0
+
         readings = self._get_reads()
         assert readings["count"] == 1
         assert readings["rows"][0]["id"] == last_id
@@ -364,16 +414,21 @@ class TestPurge:
         self._insert_readings_data(15)
         last_id = self._insert_readings_data(0)
         self._update_configuration(age=15, retain_unsent=False)
-        start("localhost", self._core_management_port)
+
+        purge = Purge("localhost", self._core_management_port)
+        purge.start()
+
         log = self._get_log()
         assert log[0] == 2
         assert log[1]["rowsRemoved"] == 1
         assert log[1]["unsentRowsRemoved"] == 1
         assert log[1]["rows_retained"] == 1
         assert log[1]["rowsRemaining"] == 1
+
         stats = self._get_stats()
         assert stats[0] == 1
         assert stats[1] == 1
+
         readings = self._get_reads()
         assert readings["count"] == 1
         assert readings["rows"][0]["id"] == last_id


### PR DESCRIPTION
```
(FOGL-626-fix)$ pytest test_data_purge.py 
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.1.1, py-1.4.34, pluggy-0.4.0
rootdir: /home/foglamp/foglamp/FogLAMP/src/python, inifile:
plugins: cov-2.5.1, asyncio-0.6.0, mock-1.6.0, allure-adaptor-1.7.7
collected 9 items 

test_data_purge.py .........
```

=========================== 9 passed in 2.00 seconds ===========================