### PR TITLE
FOGL-516 service health monitoring

### DIFF
--- a/src/python/foglamp/microservice_management/service_registry/instance.py
+++ b/src/python/foglamp/microservice_management/service_registry/instance.py
@@ -25,7 +25,7 @@ class Service(object):
         Core = 2
         Device = 3
 
-    __slots__ = ['_id', '_name', '_type', '_protocol', '_address', '_port', '_management_port']
+    __slots__ = ['_id', '_name', '_type', '_protocol', '_address', '_port', '_management_port', '_status']
 
     def __init__(self, s_id, s_name, s_type, s_protocol, s_address, s_port, m_port):
         self._id = s_id
@@ -35,12 +35,13 @@ class Service(object):
         self._address = s_address
         self._port = int(s_port)
         self._management_port = int(m_port)
+        self._status = 0
         # TODO: MUST
         # well, reserve the self PORT?
 
     def __repr__(self):
         template = 'service instance id={s._id}: <{s._name}, type={s._type}, protocol={s._protocol}, ' \
-                   'address={s._address}, service port={s._port}, management port={s._management_port}>'
+                   'address={s._address}, service port={s._port}, management port={s._management_port}, status={s._status}>'
         return template.format(s=self)
 
     def __str__(self):

--- a/src/python/foglamp/microservice_management/service_registry/monitor.py
+++ b/src/python/foglamp/microservice_management/service_registry/monitor.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+"""FogLAMP Monitor module"""
+
+import asyncio
+import aiohttp
+import logging
+import os
+import json
+
+from foglamp import logger
+from foglamp import configuration_manager
+from foglamp.microservice_management.service_registry.instance import Service
+
+__author__ = "Ashwin Gopalakrishnan"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+class Monitor(object):
+    # Constant class attributes
+    _DEFAULT_SLEEP_INTERVAL = 5
+    """The time (in seconds) to sleep between health checks"""
+    _DEFAULT_PING_TIMEOUT = 1
+    """Timeout for a response from any given microservice"""
+
+    _logger = None  # type: logging.Logger
+    def __init__(self):
+        """Constructor"""
+
+        cls = Monitor
+
+        # Initialize class attributes
+        if not cls._logger:
+            cls._logger = logger.setup(__name__)
+
+        self._monitor_loop_task = None  # type: asyncio.Task
+        """Task for :meth:`_monitor_loop`, to ensure it has finished"""
+        self._sleep_interval = None  # type: int
+        """The time (in seconds) to sleep between health checks"""
+        self._ping_timeout = None # type: int
+        """Timeout for a response from any given microservice"""
+
+    async def _monitor_loop(self):
+        """Main loop for the scheduler"""
+        # check health of all microservices every N seconds
+        while True:
+            for service in Service.Instances.all():
+                url = "{}://{}:{}/foglamp/service/ping".format(service._protocol, service._address, service._management_port)
+                async with aiohttp.ClientSession() as session:
+                    try:
+                        async with session.get(url, timeout=self._ping_timeout) as resp:
+                            text = await resp.text()
+                            res = json.loads(text)
+                            if res["uptime"] is None:
+                                raise ValueError('Improper Response')
+                    except:
+                        service._status = 0
+                    else:
+                        service._status = 1
+            await asyncio.ensure_future(asyncio.sleep(self._sleep_interval))
+
+    async def _read_config(self):
+        """Reads configuration"""
+        default_config = {
+            "sleep_interval": {
+                "description": "The time (in seconds) to sleep between health checks. (must be greater than 5)",
+                "type": "integer",
+                "default": str(self._DEFAULT_SLEEP_INTERVAL)
+            },
+            "ping_timeout": {
+                "description": "Timeout for a response from any given microservice. (must be greater than 0)",
+                "type": "integer",
+                "default": str(self._DEFAULT_PING_TIMEOUT)
+            },
+        }
+
+        await configuration_manager.create_category('SMNTR', default_config,
+                                                    'Service Monitor configuration')
+
+        config = await configuration_manager.get_category_all_items('SMNTR')
+
+        self._sleep_interval = int(config['sleep_interval']['value'])
+        self._sleep_interval = self._sleep_interval if self._sleep_interval >=5 else 5
+        self._ping_timeout = int(config['ping_timeout']['value'])
+        self._ping_timeout = self._ping_timeout if self._ping_timeout >=0 else 3
+
+
+    async def start(self):
+        await self._read_config()
+        self._monitor_loop_task = asyncio.ensure_future(self._monitor_loop())
+

--- a/src/python/foglamp/microservice_management/service_registry/monitor.py
+++ b/src/python/foglamp/microservice_management/service_registry/monitor.py
@@ -23,7 +23,6 @@ __version__ = "${VERSION}"
 
 
 class Monitor(object):
-    # Constant class attributes
     _DEFAULT_SLEEP_INTERVAL = 5
     """The time (in seconds) to sleep between health checks"""
     _DEFAULT_PING_TIMEOUT = 1
@@ -86,9 +85,7 @@ class Monitor(object):
         config = await configuration_manager.get_category_all_items('SMNTR')
 
         self._sleep_interval = int(config['sleep_interval']['value'])
-        self._sleep_interval = self._sleep_interval if self._sleep_interval >=5 else 5
         self._ping_timeout = int(config['ping_timeout']['value'])
-        self._ping_timeout = self._ping_timeout if self._ping_timeout >=0 else 3
 
 
     async def start(self):

--- a/src/python/foglamp/microservice_management/service_registry/service_registry.py
+++ b/src/python/foglamp/microservice_management/service_registry/service_registry.py
@@ -149,6 +149,7 @@ async def get_service(request):
         svc["address"] = service._address
         svc["management_port"] = service._management_port
         svc["protocol"] = service._protocol
+        svc["status"] =  service._status
         if service._port:
             svc["service_port"] = service._port
         services.append(svc)


### PR DESCRIPTION
TODO:
1. The health monitoring API can be used to view the contents of this in-memory structure.
Unable to find documentation on the API call

2. If the health check detects the failure of a microservce it should send a notification of the failure to the audit log.
Not yet implemented