### PR TITLE
FOGL-687 - Implement HTTP southern  plugin

### DIFF
--- a/src/python/foglamp/device/coap_device.py
+++ b/src/python/foglamp/device/coap_device.py
@@ -76,6 +76,7 @@ def plugin_shutdown(data):
     pass
 
 
+# TODO: Implement FOGL-701 (implement AuditLogger which logs to DB and can be used by all ) for this class
 class CoAPIngest(aiocoap.resource.Resource):
     """Handles incoming sensor readings from CoAP"""
 

--- a/src/python/foglamp/device/coap_device.py
+++ b/src/python/foglamp/device/coap_device.py
@@ -46,7 +46,7 @@ def plugin_info():
             'interface': '1.0', 'config': _DEFAULT_CONFIG}
 
 
-async def plugin_init(config):
+def plugin_init(config):
     """Registers CoAP handler to accept sensor readings"""
 
     uri = config['uri']['value']
@@ -64,15 +64,15 @@ async def plugin_init(config):
     return {}
 
 
-async def plugin_run(data):
+def plugin_run(data):
     pass
 
 
-async def plugin_reconfigure(config):
+def plugin_reconfigure(config):
     pass
 
 
-async def plugin_shutdown(data):
+def plugin_shutdown(data):
     pass
 
 

--- a/src/python/foglamp/device/coap_device.py
+++ b/src/python/foglamp/device/coap_device.py
@@ -64,7 +64,7 @@ def plugin_init(config):
     return {}
 
 
-def plugin_run(data):
+def plugin_start(data):
     pass
 
 

--- a/src/python/foglamp/device/http_south_device.py
+++ b/src/python/foglamp/device/http_south_device.py
@@ -4,68 +4,78 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-"""CoAP handler for sensor readings"""
+"""HTTP Listener handler for sensor readings"""
 
+from aiohttp import web
 import asyncio
-import json
-
-import aiocoap.resource
-import cbor2
-
 from foglamp import logger
+from foglamp.web import middleware
 from foglamp.device.ingest import Ingest
 
-__author__ = "Terris Linenbach"
+__author__ = "Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 _LOGGER = logger.setup(__name__)
 
+_CONFIG_CATEGORY_NAME = 'http_south'
+_CONFIG_CATEGORY_DESCRIPTION = 'South Plugin HTTP Listener'
 _DEFAULT_CONFIG = {
     'plugin': {
-         'description': 'Python module name of the plugin to load',
+         'description': 'http_south_device',
          'type': 'string',
-         'default': 'coap'
+         'default': 'http_south'
     },
     'port': {
         'description': 'Port to listen on',
         'type': 'integer',
-        'default': '5683',
+        'default': '6683',
     },
     'uri': {
         'description': 'URI to accept data on',
         'type': 'string',
-        'default': 'sensor-values',
+        'default': '0.0.0.0',
     }
 }
 
 
 def plugin_info():
-    return {'name': 'CoAP Server', 'version': '1.0', 'mode': 'async', 'type': 'device',
+    return {'name': 'http_south', 'version': '1.0', 'mode': 'async', 'type': 'device',
             'interface': '1.0', 'config': _DEFAULT_CONFIG}
 
 
 async def plugin_init(config):
-    """Registers CoAP handler to accept sensor readings"""
+    """Registers HTTP Listener handler to accept sensor readings"""
+
+    _LOGGER.info("Retrieve HTTP Listener Configuration %s", config)
 
     uri = config['uri']['value']
     port = config['port']['value']
 
-    root = aiocoap.resource.Site()
-
-    root.add_resource(('.well-known', 'core'),
-                      aiocoap.resource.WKCResource(root.get_resources_as_linkheader))
-
-    root.add_resource(('other', uri), CoAPIngest())
-
-    asyncio.ensure_future(aiocoap.Context.create_server_context(root, bind=('::', int(port))))
-
-    return {}
+    return {'uri': uri, 'port': port}
 
 
 async def plugin_run(data):
-    pass
+    """
+
+    Args:
+        data: dict returned from plugin_init()
+
+    Returns: (server, handler) tuple
+
+    """
+    host = data['uri']
+    port = data['port']
+
+    loop = asyncio.get_event_loop()
+
+    app = web.Application(middlewares=[middleware.error_middleware])
+    app.router.add_route('POST', '/device', HttpSouthIngest.render_post)
+    handler = app.make_handler()
+    coro = loop.create_server(handler, host, port)
+    server = await coro
+    return server, handler
 
 
 async def plugin_reconfigure(config):
@@ -76,8 +86,8 @@ async def plugin_shutdown(data):
     pass
 
 
-class CoAPIngest(aiocoap.resource.Resource):
-    """Handles incoming sensor readings from CoAP"""
+class HttpSouthIngest():
+    """Handles incoming sensor readings from HTTP Listner"""
 
     @staticmethod
     async def render_post(request):
@@ -102,54 +112,52 @@ class CoAPIngest(aiocoap.resource.Resource):
                             }
                         }
                     }
+        Example: curl -X POST http://localhost:6683 -d '{"timestamp": "2017-01-02T01:02:03.23232Z-05:00", "asset": "pump1", "key": "80a43623-ebe5-40d6-8d80-3f892da9b3b4", "readings": {"velocity": "500", "temperature": {"value": "32", "unit": "kelvin"}}}'
         """
-        # aiocoap handlers must be defensive about exceptions. If an exception
-        # is raised out of a handler, it is permanently disabled by aiocoap.
-        # Therefore, Exception is caught instead of specific exceptions.
-
         # TODO: The payload is documented at
         # https://docs.google.com/document/d/1rJXlOqCGomPKEKx2ReoofZTXQt9dtDiW_BHU7FYsj-k/edit#
         # and will be moved to a .rst file
 
-        code = aiocoap.numbers.codes.Code.INTERNAL_SERVER_ERROR
+        code = web.HTTPInternalServerError.status_code
         increment_discarded_counter = True
         message = ''
 
         try:
             if not Ingest.is_available():
-                message = '{"busy": true}'
+                message = {"busy": True}
             else:
-                payload = cbor2.loads(request.payload)
+                payload = await request.json()
 
                 if not isinstance(payload, dict):
                     raise ValueError('Payload must be a dictionary')
 
                 asset = payload.get('asset')
                 timestamp = payload.get('timestamp')
-
                 key = payload.get('key')
 
                 # readings and sensor_readings are optional
                 try:
-                    readings = payload['readings']
+                    readings = payload.get('readings')
                 except KeyError:
                     readings = payload.get('sensor_values')  # sensor_values is deprecated
 
                 increment_discarded_counter = False
 
-                await Ingest.add_readings(asset=asset, timestamp=timestamp, key=key,
-                                          readings=readings)
+                await Ingest.add_readings(asset=asset, timestamp=timestamp, key=key, readings=readings)
 
                 # Success
-                code = aiocoap.numbers.codes.Code.VALID
+                message = readings
+                code = web.HTTPOk.status_code
         except (ValueError, TypeError) as e:
-            code = aiocoap.numbers.codes.Code.BAD_REQUEST
-            message = json.dumps({message: str(e)})
-        except Exception:
-            _LOGGER.exception('Add readings failed')
+            code = web.HTTPBadRequest.status_code
+            message = {'error': str(e)}
+            _LOGGER.exception('ValueError/TypeError in Add readings - failed')
+        except Exception as e:
+            message = {'error': str(e)}
+            _LOGGER.exception('Exception in Add readings - failed')
 
         if increment_discarded_counter:
             Ingest.increment_discarded_readings()
 
-        return aiocoap.Message(payload=message.encode('utf-8'), code=code)
+        return web.json_response({'message':message, 'status':code})
 

--- a/src/python/foglamp/device/http_south_device.py
+++ b/src/python/foglamp/device/http_south_device.py
@@ -56,7 +56,7 @@ def plugin_init(config):
     return {'host': host, 'port': port}
 
 
-async def plugin_start(data):
+def plugin_start(data):
 
     host = data['host']
     port = data['port']
@@ -67,27 +67,26 @@ async def plugin_start(data):
     app.router.add_route('POST', '/', HttpSouthIngest.render_post)
     handler = app.make_handler()
     coro = loop.create_server(handler, host, port)
-    server = await coro
+    server = asyncio.ensure_future(coro)
 
     data['app'] = app
     data['handler'] = handler
     data['server'] = server
-    return data
 
 def plugin_reconfigure(config):
     pass
 
 
-async def plugin_shutdown(data):
+def plugin_shutdown(data):
     app = data['app']
     handler = data['handler']
     server = data['server']
 
     server.close()
-    await server.wait_closed()
-    await app.shutdown()
-    await handler.shutdown(60.0)
-    await app.cleanup()
+    asyncio.ensure_future(server.wait_closed())
+    asyncio.ensure_future(app.shutdown())
+    asyncio.ensure_future(handler.shutdown(60.0))
+    asyncio.ensure_future(app.cleanup())
 
 
 class HttpSouthIngest():

--- a/src/python/foglamp/device/http_south_device.py
+++ b/src/python/foglamp/device/http_south_device.py
@@ -19,7 +19,7 @@ __version__ = "${VERSION}"
 
 _LOGGER = logger.setup(__name__)
 
-_CONFIG_CATEGORY_NAME = 'http_south'
+_CONFIG_CATEGORY_NAME = 'HTTP_SOUTH'
 _CONFIG_CATEGORY_DESCRIPTION = 'South Plugin HTTP Listener'
 _DEFAULT_CONFIG = {
     'plugin': {

--- a/src/python/foglamp/device/http_south_device.py
+++ b/src/python/foglamp/device/http_south_device.py
@@ -165,6 +165,9 @@ class HttpSouthIngest(object):
                 except KeyError:
                     readings = payload.get('sensor_values')  # sensor_values is deprecated
 
+                if not isinstance(readings, dict):
+                    raise ValueError('readings must be a dictionary')
+
                 await Ingest.add_readings(asset=asset, timestamp=timestamp, key=key, readings=readings)
         except (ValueError, TypeError) as e:
             increment_discarded_counter = True

--- a/src/python/foglamp/device/http_south_device.py
+++ b/src/python/foglamp/device/http_south_device.py
@@ -104,6 +104,7 @@ def plugin_shutdown(data):
         raise
 
 
+# TODO: Implement FOGL-701 (implement AuditLogger which logs to DB and can be used by all ) for this class
 class HttpSouthIngest(object):
     """Handles incoming sensor readings from HTTP Listener"""
 

--- a/src/python/foglamp/device/http_south_device.py
+++ b/src/python/foglamp/device/http_south_device.py
@@ -150,7 +150,7 @@ class HttpSouthIngest():
                 await Ingest.add_readings(asset=asset, timestamp=timestamp, key=key, readings=readings)
 
                 # Success
-                message = readings
+                message = "success"
                 code = web.HTTPOk.status_code
         except (ValueError, TypeError) as e:
             code = web.HTTPBadRequest.status_code

--- a/src/python/foglamp/device/http_south_device.py
+++ b/src/python/foglamp/device/http_south_device.py
@@ -124,6 +124,7 @@ class HttpSouthIngest():
 
         code = web.HTTPInternalServerError.status_code
         increment_discarded_counter = True
+        # TODO: Decide upon the correct format of message
         message = {'error': 'Exception in Add readings - failed'}
 
         try:

--- a/src/python/foglamp/device/http_south_device.py
+++ b/src/python/foglamp/device/http_south_device.py
@@ -45,7 +45,7 @@ def plugin_info():
             'interface': '1.0', 'config': _DEFAULT_CONFIG}
 
 
-async def plugin_init(config):
+def plugin_init(config):
     """Registers HTTP Listener handler to accept sensor readings"""
 
     _LOGGER.info("Retrieve HTTP Listener Configuration %s", config)
@@ -53,36 +53,24 @@ async def plugin_init(config):
     uri = config['uri']['value']
     port = config['port']['value']
 
-    return {'uri': uri, 'port': port}
-
-
-async def plugin_run(data):
-    """
-
-    Args:
-        data: dict returned from plugin_init()
-
-    Returns: (server, handler) tuple
-
-    """
-    host = data['uri']
-    port = data['port']
-
     loop = asyncio.get_event_loop()
 
     app = web.Application(middlewares=[middleware.error_middleware])
-    app.router.add_route('POST', '/device', HttpSouthIngest.render_post)
+    app.router.add_route('POST', '/', HttpSouthIngest.render_post)
     handler = app.make_handler()
-    coro = loop.create_server(handler, host, port)
-    server = await coro
-    return server, handler
+    coro = loop.create_server(handler, uri, port)
+
+    return coro, handler
 
 
-async def plugin_reconfigure(config):
+def plugin_run(data):
+    pass
+
+def plugin_reconfigure(config):
     pass
 
 
-async def plugin_shutdown(data):
+def plugin_shutdown(data):
     pass
 
 

--- a/src/python/foglamp/device/server.py
+++ b/src/python/foglamp/device/server.py
@@ -18,8 +18,6 @@ from foglamp import logger
 from foglamp.device.ingest import Ingest
 from foglamp.microservice_management import routes
 from foglamp.web import middleware
-from foglamp.microservice_management.service_registry.instance import Service
-
 
 __author__ = "Terris Linenbach"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -30,7 +28,6 @@ _LOGGER = logger.setup(__name__, level=20)
 
 
 class Server:
-
     _core_management_host = None
     _core_management_port = None
     """ address of core microservice management api """
@@ -74,7 +71,7 @@ class Server:
         try:
             await Ingest.stop()
         except Exception:
-            _LOGGER.exception("Unable to stop the Ingest server. Plugin {}".format(cls._plugin_name))
+            _LOGGER.exception('Unable to stop the Ingest server')
             return
 
         # Stop all pending asyncio tasks
@@ -88,29 +85,31 @@ class Server:
         error = None
 
         try:
-            # Create Category before loading the plugin
             config = {}
             storage = Storage(cls._core_management_host, cls._core_management_port, svc=None)
             cfg_manager = ConfigurationManager(storage)
-            await cfg_manager.create_category(cls._plugin_name, config, '{} Device'.format(cls._plugin_name), True)
+            await cfg_manager.create_category(cls._plugin_name, config,
+                                              '{} Device'.format(cls._plugin_name), True)
+
             config = await cfg_manager.get_category_all_items(cls._plugin_name)
 
             try:
                 plugin_module_name = config['plugin']['value']
             except KeyError:
-                _LOGGER.exception("Unable to obtain configuration of module for plugin {}".format(cls._plugin_name))
+                _LOGGER.warning("Unable to obtain configuration of module for plugin {}".format(cls._plugin_name))
                 raise
 
             try:
                 cls._plugin = __import__("foglamp.device.{}_device".format(plugin_module_name), fromlist=[''])
             except Exception:
-                error = 'Unable to load module {} for device plugin {}'.format(plugin_module_name, cls._plugin_name)
+                error = 'Unable to load module {} for device plugin {}'.format(plugin_module_name,
+                                                                               cls._plugin_name)
                 raise
+
             default_config = cls._plugin.plugin_info()['config']
 
-            # Complete the Component definition with config info from the plugin
             await cfg_manager.create_category(cls._plugin_name, default_config,
-                                                        '{} Device'.format(cls._plugin_name))
+                                              '{} Device'.format(cls._plugin_name))
 
             config = await cfg_manager.get_category_all_items(cls._plugin_name)
 
@@ -124,6 +123,7 @@ class Server:
             if error is None:
                 error = 'Failed to initialize plugin {}'.format(cls._plugin_name)
             _LOGGER.exception(error)
+            print(error)
             asyncio.ensure_future(cls._stop(loop))
 
     @classmethod
@@ -135,26 +135,26 @@ class Server:
         # create http protocol factory for handling requests
         cls._microservice_management_handler = cls._microservice_management_app.make_handler()
 
-
     @classmethod
     def _run_microservice_management_app(cls, loop):
         # run microservice_management_app
         coro = loop.create_server(cls._microservice_management_handler, '0.0.0.0', 0)
         cls._microservice_management_server = loop.run_until_complete(coro)
-        cls._microservice_management_host, cls._microservice_management_port = cls._microservice_management_server.sockets[0].getsockname()
-        _LOGGER.info("Device Plugin {} - Management API started on http://%s:%s".format(cls._plugin_name), cls._microservice_management_host, cls._microservice_management_port)
-
+        cls._microservice_management_host, cls._microservice_management_port = \
+        cls._microservice_management_server.sockets[0].getsockname()
+        _LOGGER.info('Device - Management API started on http://%s:%s', cls._microservice_management_host,
+                     cls._microservice_management_port)
 
     @classmethod
     def _get_service_registration_payload(cls):
         service_registration_payload = {
-                "name"            : cls._plugin_name,
-                "type"            : "Southbound",
-                "management_port" : int(cls._microservice_management_port),
-                "service_port"    : 0,
-                "address"         : "127.0.0.1",
-                "protocol"        : "http"
-            }
+            "name": cls._plugin_name,
+            "type": "Southbound",
+            "management_port": int(cls._microservice_management_port),
+            "service_port": 0,
+            "address": "127.0.0.1",
+            "protocol": "http"
+        }
         return service_registration_payload
 
     @classmethod
@@ -165,21 +165,18 @@ class Server:
         conn.request(method='POST', url='/foglamp/service', body=json.dumps(service_registration_payload))
         r = conn.getresponse()
         if r.status in range(400, 500):
-            _LOGGER.error("Client error code: %d. Plugin {}".format(cls._plugin_name), r.status)
+            _LOGGER.error("Client error code: %d", r.status)
         if r.status in range(500, 600):
-            _LOGGER.error("Server error code: %d. Plugin {}".format(cls._plugin_name), r.status)
+            _LOGGER.error("Server error code: %d", r.status)
         res = r.read().decode()
         conn.close()
         response = json.loads(res)
         try:
             cls._microservice_id = response["id"]
             _LOGGER.info('Device - Registered Service %s', response["id"])
-        except Service.AlreadyExistsWithTheSameAddressAndManagementPort as ex:
-            _LOGGER.error("Device - Service already registered. Plugin {}".format(cls._plugin_name))
         except:
-            _LOGGER.error("Device - Could not register. Plugin {}".format(cls._plugin_name))
+            _LOGGER.error("Device - Could not register")
             raise
-
 
     @classmethod
     def start(cls, plugin, core_mgt_host, core_mgt_port):
@@ -205,19 +202,19 @@ class Server:
         try:
             cls._make_microservice_management_app()
         except Exception:
-            _LOGGER.exception("Unable to create microservice management app. Plugin {}".format(cls._plugin_name))
+            _LOGGER.exception("Unable to create microservice management app")
             raise
 
         try:
             cls._run_microservice_management_app(loop)
         except Exception:
-            _LOGGER.exception("Unable to run microservice management app. Plugin {}".format(cls._plugin_name))
+            _LOGGER.exception("Unable to run microservice management app")
             raise
 
         try:
             cls._register_microservice()
         except Exception:
-            _LOGGER.exception("Unable to register. Plugin {}".format(cls._plugin_name))
+            _LOGGER.exception("Unable to register")
             raise
 
         asyncio.ensure_future(cls._start(loop))

--- a/src/python/foglamp/device/server.py
+++ b/src/python/foglamp/device/server.py
@@ -64,10 +64,7 @@ class Server:
     async def _stop(cls, loop):
         if cls._plugin is not None:
             try:
-                if asyncio.iscoroutinefunction(cls._plugin.plugin_shutdown):
-                    await cls._plugin.plugin_shutdown(cls._plugin_data)
-                else:
-                    cls._plugin.plugin_shutdown(cls._plugin_data)
+                cls._plugin.plugin_shutdown(cls._plugin_data)
             except Exception:
                 _LOGGER.exception("Unable to shut down plugin '{}'".format(cls._plugin_name))
             finally:
@@ -121,12 +118,7 @@ class Server:
             # TODO: Register for config changes
 
             cls._plugin_data = cls._plugin.plugin_init(config)
-
-            if asyncio.iscoroutinefunction(cls._plugin.plugin_start):
-                # plugin_start() may return additional data which then can be used elsewhere e.g. plugin_shutdown
-                cls._plugin_data = await cls._plugin.plugin_start(cls._plugin_data)
-            else:
-                cls._plugin.plugin_start(cls._plugin_data)
+            cls._plugin.plugin_start(cls._plugin_data)
 
             await Ingest.start(cls._core_management_host,cls._core_management_port)
         except Exception:

--- a/src/python/foglamp/device/server.py
+++ b/src/python/foglamp/device/server.py
@@ -19,6 +19,7 @@ from foglamp.device.ingest import Ingest
 from foglamp.microservice_management import routes
 from foglamp.web import middleware
 
+
 __author__ = "Terris Linenbach"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
@@ -28,13 +29,14 @@ _LOGGER = logger.setup(__name__, level=20)
 
 
 class Server:
+
     _core_management_host = None
     _core_management_port = None
     """ address of core microservice management api """
 
     _plugin_name = None  # type:str
     """"The name of the plugin"""
-
+    
     _plugin = None
     """The plugin's module'"""
 
@@ -81,7 +83,7 @@ class Server:
         loop.stop()
 
     @classmethod
-    async def _start(cls, loop) -> None:
+    async def _start(cls, loop)->None:
         error = None
 
         try:
@@ -89,7 +91,7 @@ class Server:
             storage = Storage(cls._core_management_host, cls._core_management_port, svc=None)
             cfg_manager = ConfigurationManager(storage)
             await cfg_manager.create_category(cls._plugin_name, config,
-                                              '{} Device'.format(cls._plugin_name), True)
+                                                        '{} Device'.format(cls._plugin_name), True)
 
             config = await cfg_manager.get_category_all_items(cls._plugin_name)
 
@@ -109,7 +111,7 @@ class Server:
             default_config = cls._plugin.plugin_info()['config']
 
             await cfg_manager.create_category(cls._plugin_name, default_config,
-                                              '{} Device'.format(cls._plugin_name))
+                                                        '{} Device'.format(cls._plugin_name))
 
             config = await cfg_manager.get_category_all_items(cls._plugin_name)
 
@@ -118,7 +120,7 @@ class Server:
             cls._plugin_data = cls._plugin.plugin_init(config)
             cls._plugin.plugin_start(cls._plugin_data)
 
-            await Ingest.start(cls._core_management_host, cls._core_management_port)
+            await Ingest.start(cls._core_management_host,cls._core_management_port)
         except Exception:
             if error is None:
                 error = 'Failed to initialize plugin {}'.format(cls._plugin_name)
@@ -135,26 +137,26 @@ class Server:
         # create http protocol factory for handling requests
         cls._microservice_management_handler = cls._microservice_management_app.make_handler()
 
+
     @classmethod
     def _run_microservice_management_app(cls, loop):
         # run microservice_management_app
         coro = loop.create_server(cls._microservice_management_handler, '0.0.0.0', 0)
         cls._microservice_management_server = loop.run_until_complete(coro)
-        cls._microservice_management_host, cls._microservice_management_port = \
-        cls._microservice_management_server.sockets[0].getsockname()
-        _LOGGER.info('Device - Management API started on http://%s:%s', cls._microservice_management_host,
-                     cls._microservice_management_port)
+        cls._microservice_management_host, cls._microservice_management_port = cls._microservice_management_server.sockets[0].getsockname()
+        _LOGGER.info('Device - Management API started on http://%s:%s', cls._microservice_management_host, cls._microservice_management_port)
+
 
     @classmethod
     def _get_service_registration_payload(cls):
         service_registration_payload = {
-            "name": cls._plugin_name,
-            "type": "Southbound",
-            "management_port": int(cls._microservice_management_port),
-            "service_port": 0,
-            "address": "127.0.0.1",
-            "protocol": "http"
-        }
+                "name"            : cls._plugin_name,
+                "type"            : "Southbound",
+                "management_port" : int(cls._microservice_management_port),
+                "service_port"    : 0,
+                "address"         : "127.0.0.1",
+                "protocol"        : "http"
+            }
         return service_registration_payload
 
     @classmethod
@@ -177,6 +179,7 @@ class Server:
         except:
             _LOGGER.error("Device - Could not register")
             raise
+
 
     @classmethod
     def start(cls, plugin, core_mgt_host, core_mgt_port):

--- a/src/python/foglamp/device/server.py
+++ b/src/python/foglamp/device/server.py
@@ -183,7 +183,7 @@ class Server:
         try:
             cls._microservice_id = response["id"]
             _LOGGER.info('Device - Registered Service %s', response["id"])
-        except (Service.AlreadyExistsWithTheSameAddressAndManagementPort, Service.AlreadyExistsWithTheSameAddressAndPort) as ex:
+        except Service.AlreadyExistsWithTheSameAddressAndManagementPort as ex:
             _LOGGER.error("Device - Service already registered. Plugin {}".format(cls._plugin_name))
         except:
             _LOGGER.error("Device - Could not register. Plugin {}".format(cls._plugin_name))

--- a/src/python/foglamp/device/server.py
+++ b/src/python/foglamp/device/server.py
@@ -37,7 +37,7 @@ class Server:
 
     _plugin_name = None  # type:str
     """"The name of the plugin"""
-    
+
     _plugin = None
     """The plugin's module'"""
 
@@ -84,7 +84,7 @@ class Server:
         loop.stop()
 
     @classmethod
-    async def _start(cls, loop)->None:
+    async def _start(cls, loop) -> None:
         error = None
 
         try:
@@ -99,8 +99,7 @@ class Server:
                 plugin_module_name = config['plugin']['value']
             except KeyError:
                 _LOGGER.exception("Unable to obtain configuration of module for plugin {}".format(cls._plugin_name))
-                # Retrieve the plugin name and hence plugin module name, from the params
-                plugin_module_name = cls._plugin_name
+                raise
 
             try:
                 cls._plugin = __import__("foglamp.device.{}_device".format(plugin_module_name), fromlist=[''])
@@ -111,7 +110,7 @@ class Server:
 
             # Complete the Component definition with config info from the plugin
             await cfg_manager.create_category(cls._plugin_name, default_config,
-                                                        '{} Device'.format(cls._plugin_name, ), True)
+                                                        '{} Device'.format(cls._plugin_name))
 
             config = await cfg_manager.get_category_all_items(cls._plugin_name)
 
@@ -120,7 +119,7 @@ class Server:
             cls._plugin_data = cls._plugin.plugin_init(config)
             cls._plugin.plugin_start(cls._plugin_data)
 
-            await Ingest.start(cls._core_management_host,cls._core_management_port)
+            await Ingest.start(cls._core_management_host, cls._core_management_port)
         except Exception:
             if error is None:
                 error = 'Failed to initialize plugin {}'.format(cls._plugin_name)

--- a/src/python/foglamp/microservice_management/service_registry/instance.py
+++ b/src/python/foglamp/microservice_management/service_registry/instance.py
@@ -97,8 +97,8 @@ class Service(object):
             else:
                 raise Service.AlreadyExistsWithTheSameName
 
-            if cls.check_address_and_port(address, port):
-                raise Service.AlreadyExistsWithTheSameAddressAndPort
+            # if cls.check_address_and_port(address, port):
+            #     raise Service.AlreadyExistsWithTheSameAddressAndPort
 
             if cls.check_address_and_mgt_port(address, management_port):
                 raise Service.AlreadyExistsWithTheSameAddressAndManagementPort

--- a/src/python/foglamp/microservice_management/service_registry/instance.py
+++ b/src/python/foglamp/microservice_management/service_registry/instance.py
@@ -97,9 +97,8 @@ class Service(object):
             else:
                 raise Service.AlreadyExistsWithTheSameName
 
-            # TODO: FOGL-692 - Service Registry should support services that do not have a service port
-            # if cls.check_address_and_port(address, port):
-            #     raise Service.AlreadyExistsWithTheSameAddressAndPort
+            if cls.check_address_and_port(address, port):
+                raise Service.AlreadyExistsWithTheSameAddressAndPort
 
             if cls.check_address_and_mgt_port(address, management_port):
                 raise Service.AlreadyExistsWithTheSameAddressAndManagementPort

--- a/src/python/foglamp/microservice_management/service_registry/instance.py
+++ b/src/python/foglamp/microservice_management/service_registry/instance.py
@@ -97,6 +97,7 @@ class Service(object):
             else:
                 raise Service.AlreadyExistsWithTheSameName
 
+            # TODO: FOGL-692 - Service Registry should support services that do not have a service port
             # if cls.check_address_and_port(address, port):
             #     raise Service.AlreadyExistsWithTheSameAddressAndPort
 

--- a/src/python/foglamp/microservice_management/service_registry/instance.py
+++ b/src/python/foglamp/microservice_management/service_registry/instance.py
@@ -97,8 +97,8 @@ class Service(object):
             else:
                 raise Service.AlreadyExistsWithTheSameName
 
-            # if cls.check_address_and_port(address, port):
-            #     raise Service.AlreadyExistsWithTheSameAddressAndPort
+            if cls.check_address_and_port(address, port):
+                raise Service.AlreadyExistsWithTheSameAddressAndPort
 
             if cls.check_address_and_mgt_port(address, management_port):
                 raise Service.AlreadyExistsWithTheSameAddressAndManagementPort

--- a/src/sql/foglamp_init_data.sql
+++ b/src/sql/foglamp_init_data.sql
@@ -76,8 +76,10 @@ INSERT INTO foglamp.configuration ( key, description, value )
 -- COAP:  CoAP device server
 --        plugin: python module to load dynamically
 -- FOGL-698 - Fix configuration entry for CoAP plugin (init.sql vs via configuration manager)
---INSERT INTO foglamp.configuration ( key, description, value )
---     VALUES ( 'COAP', 'CoAP Plugin Configuration', ' { "plugin" : { "type" : "string", "value" : "coap", "default" : "coap", "description" : "Python module name of the plugin to load" } } ');
+INSERT INTO foglamp.configuration ( key, description, value )
+     VALUES ( 'COAP', 'CoAP Plugin Configuration', ' { "plugin" : { "type" : "string", "value" : "coap", "default" : "coap", "description" : "Python module name of the plugin to load" } } ');
+INSERT INTO foglamp.configuration ( key, description, value )
+     VALUES ( 'HTTP_SOUTH', 'HTTP South Plugin Configuration', ' { "plugin" : { "type" : "string", "value" : "http_south", "default" : "http_south", "description" : "Python module name of the plugin to load" } } ');
 
 -- DELETE data for roles, resources and permissions
 DELETE FROM foglamp.role_resource_permission;
@@ -119,8 +121,8 @@ INSERT INTO foglamp.statistics ( key, description, value, previous_value )
 -- Use this to create guids: https://www.uuidgenerator.net/version1 */
 -- Weekly repeat for timed schedules: set schedule_interval to 168:00:00
 
-insert into foglamp.scheduled_processes (name, script) values ('coap', '["python3", "-m", "foglamp.device"]');
-insert into foglamp.scheduled_processes (name, script) values ('http_south', '["python3", "-m", "foglamp.device"]');
+insert into foglamp.scheduled_processes (name, script) values ('COAP', '["python3", "-m", "foglamp.device"]');
+insert into foglamp.scheduled_processes (name, script) values ('HTTP_SOUTH', '["python3", "-m", "foglamp.device"]');
 insert into foglamp.scheduled_processes (name, script) values ('purge', '["python3", "-m", "foglamp.data_purge"]');
 insert into foglamp.scheduled_processes (name, script) values ('stats collector', '["python3", "-m", "foglamp.statistics_history"]');
 insert into foglamp.scheduled_processes (name, script) values ('sending process', '["python3", "-m", "foglamp.sending_process", "--stream_id", "1", "--debug_level", "1"]');
@@ -131,13 +133,13 @@ insert into foglamp.scheduled_processes (name, script) values ('statistics to pi
 -- Start the device server COAP at start-up
 insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
 schedule_interval, exclusive)
-values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'coap', 1,
+values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'COAP', 1,
 '0:0', true);
 
 ---- Start the device server HTTP Listener at start-up
 insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
 schedule_interval, exclusive)
-values ('a2caca59-1241-478d-925a-79584e7096e0', 'device', 'http_south', 1,
+values ('a2caca59-1241-478d-925a-79584e7096e0', 'device', 'HTTP_SOUTH', 1,
 '0:0', true);
 
 -- Run the purge process every 5 minutes

--- a/src/sql/foglamp_init_data.sql
+++ b/src/sql/foglamp_init_data.sql
@@ -75,8 +75,8 @@ INSERT INTO foglamp.configuration ( key, description, value )
 
 -- COAP:  CoAP device server
 --        plugin: python module to load dynamically
-INSERT INTO foglamp.configuration ( key, description, value )
-     VALUES ( 'COAP', 'CoAP Plugin Configuration', ' { "plugin" : { "type" : "string", "value" : "coap", "default" : "coap", "description" : "Python module name of the plugin to load" } } ');
+--INSERT INTO foglamp.configuration ( key, description, value )
+--     VALUES ( 'COAP', 'CoAP Plugin Configuration', ' { "plugin" : { "type" : "string", "value" : "coap", "default" : "coap", "description" : "Python module name of the plugin to load" } } ');
 
 -- DELETE data for roles, resources and permissions
 DELETE FROM foglamp.role_resource_permission;
@@ -118,7 +118,8 @@ INSERT INTO foglamp.statistics ( key, description, value, previous_value )
 -- Use this to create guids: https://www.uuidgenerator.net/version1 */
 -- Weekly repeat for timed schedules: set schedule_interval to 168:00:00
 
-insert into foglamp.scheduled_processes (name, script) values ('COAP', '["python3", "-m", "foglamp.device"]');
+insert into foglamp.scheduled_processes (name, script) values ('coap', '["python3", "-m", "foglamp.device"]');
+insert into foglamp.scheduled_processes (name, script) values ('http_south', '["python3", "-m", "foglamp.device"]');
 insert into foglamp.scheduled_processes (name, script) values ('purge', '["python3", "-m", "foglamp.data_purge"]');
 insert into foglamp.scheduled_processes (name, script) values ('stats collector', '["python3", "-m", "foglamp.statistics_history"]');
 insert into foglamp.scheduled_processes (name, script) values ('sending process', '["python3", "-m", "foglamp.sending_process", "--stream_id", "1", "--debug_level", "1"]');
@@ -126,10 +127,16 @@ insert into foglamp.scheduled_processes (name, script) values ('sending process'
 insert into foglamp.scheduled_processes (name, script) values ('statistics to pi','["python3", "-m", "foglamp.sending_process", "--stream_id", "2", "--debug_level", "1"]');
 
 
--- Start the device server at start-up
+-- Start the device server COAP at start-up
 insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
 schedule_interval, exclusive)
-values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'COAP', 1,
+values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'coap', 1,
+'0:0', true);
+
+---- Start the device server HTTP Listener at start-up
+insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
+schedule_interval, exclusive)
+values ('a2caca59-1241-478d-925a-79584e7096e0', 'device', 'http_south', 1,
 '0:0', true);
 
 -- Run the purge process every 5 minutes

--- a/src/sql/foglamp_init_data.sql
+++ b/src/sql/foglamp_init_data.sql
@@ -75,6 +75,7 @@ INSERT INTO foglamp.configuration ( key, description, value )
 
 -- COAP:  CoAP device server
 --        plugin: python module to load dynamically
+-- FOGL-698 - Fix configuration entry for CoAP plugin (init.sql vs via configuration manager)
 --INSERT INTO foglamp.configuration ( key, description, value )
 --     VALUES ( 'COAP', 'CoAP Plugin Configuration', ' { "plugin" : { "type" : "string", "value" : "coap", "default" : "coap", "description" : "Python module name of the plugin to load" } } ');
 


### PR DESCRIPTION
@MarkRiddoch @ashwinscale @praveen-garg, three major changes have been made in this PR along with the new http_south plugin:

1) I have removed Coap related Schedules init data from forlamp_init_data.sql. With a little change in device/server.py/_start(), lines 98-106, this is no longer required. And it is more in tune with the Architecture doc.

2) In device plugins (coap_device.py and http_south.py), except for plugin_info() method, all other plugin...() methods  have been made async because the reason as under:

	For http_south plugin, we need to implement an aiohttp server BUT we cannot use the default server provided by aiohttp as it goes into its own loop.run_forever() WHEREAS we need to execute code after initialisation of this server via plugin i.e. line#125 of device/server.py. Hence, we are forced to use the already running event loop. Since the app, handler and server created in http_south plugin are coro, they need to be awaited and as such method containing these lines must be an async method. Since device/server.py is common for both http_south and coap, it must be modified to await an async method and as such the corresponding methods in coap_device.py also changed to be async methods (although it has nil impact on running of the coap server).

	I already tried passing the current running event_loop into plugin_run and then apply a run_until_complete() but it did not work. 

	It may be noted that this does not impact plugins in other areas e.g. omf_translator, sending_process etc as they work independent of device plugins.

3) device/server.py registers each plugin with core management api via a service_registration_payload. This payload has service_port as 0 and it remains same for all the plugins it calls. This causes Service.AlreadyExistsWithTheSameAddressAndPort exception to be raised at the time of service registration and as such I have temporarily disabled it in instance.py till a solution is worked out.

4) Tests will follow.