### PR TITLE
FOGL-761 service_registry test fixes; device type is Southbound

### DIFF
--- a/tests/unit-tests/python/foglamp_test/services/common/microservice_management/service_registry/test_instance.py
+++ b/tests/unit-tests/python/foglamp_test/services/common/microservice_management/service_registry/test_instance.py
@@ -83,7 +83,7 @@ class TestInstance:
     async def test_get(self):
         s = Service.Instances.register("StorageService", "Storage", "localhost", 8881, 1888)
         c = Service.Instances.register("CoreService", "Core", "localhost", 7771, 1777)
-        d = Service.Instances.register("DeviceService", "Device", "127.0.0.1", 9991, 1999, "https")
+        d = Service.Instances.register("DeviceService", "Southbound", "127.0.0.1", 9991, 1999, "https")
 
         l = Service.Instances.get()
         assert 3 == len(l)
@@ -108,7 +108,7 @@ class TestInstance:
 
         assert d == l[2]._id
         assert "DeviceService" == l[2]._name
-        assert "Device" == l[2]._type
+        assert "Southbound" == l[2]._type
         assert "127.0.0.1" == l[2]._address
         assert 9991 == int(l[2]._port)
         assert 1999 == int(l[2]._management_port)

--- a/tests/unit-tests/python/foglamp_test/services/common/microservice_management/service_registry/test_services_registry_api.py
+++ b/tests/unit-tests/python/foglamp_test/services/common/microservice_management/service_registry/test_services_registry_api.py
@@ -20,8 +20,8 @@ pytestmark = pytest.mark.asyncio
 # Module attributes
 __DB_NAME = "foglamp"
 # Needs foglamp to start,
-# replace 8082 with core_management_port
-BASE_URL = 'http://localhost:8082/foglamp'
+# replace 43325 with core_management_port
+BASE_URL = 'http://localhost:43325/foglamp'
 headers = {'Content-Type': 'application/json'}
 
 
@@ -226,7 +226,7 @@ class TestServicesRegistryApi:
         storage_service_id = retval["id"]
 
         # Create another service
-        data2 = {"type": "Device", "name": "Device Services y", "address": "127.0.0.1", "service_port": 8092, "management_port": 1092, "protocol": "https"}
+        data2 = {"type": "Southbound", "name": "Device Services y", "address": "127.0.0.1", "service_port": 8092, "management_port": 1092, "protocol": "https"}
         r = requests.post(BASE_URL + '/service', data=json.dumps(data2), headers=headers)
         assert 200 == r.status_code
         res = dict(r.json())
@@ -285,7 +285,7 @@ class TestServicesRegistryApi:
         assert data["management_port"] == svc[0]["management_port"]
 
     async def test_get_by_type(self):
-        data = {"type": "Device", "name": "Storage Services A", "address": "127.0.0.1", "service_port": 8091, "management_port": 1091}
+        data = {"type": "Southbound", "name": "Storage Services A", "address": "127.0.0.1", "service_port": 8091, "management_port": 1091}
         r = requests.post(BASE_URL + '/service', data=json.dumps(data), headers=headers)
         assert 200 == r.status_code
 
@@ -303,7 +303,7 @@ class TestServicesRegistryApi:
         assert data["management_port"] == svc[0]["management_port"]
 
     async def test_get_by_name_and_type(self):
-        data0 = {"type": "Device", "name": "D Services", "address": "127.0.0.1", "service_port": 8091, "management_port": 1091}
+        data0 = {"type": "Southbound", "name": "D Services", "address": "127.0.0.1", "service_port": 8091, "management_port": 1091}
         r = requests.post(BASE_URL + '/service', data=json.dumps(data0), headers=headers)
         assert 200 == r.status_code
 


### PR DESCRIPTION
[FOGL-761](https://scaledb.atlassian.net/browse/FOGL-761) - 

These were failing due to invalid service type: `Device vs Southbound`

**Tests O/P:**

**collected 24 items** 

> tests/unit-tests/python/foglamp_test/services/common/microservice_management/service_registry/test_instance.py ..........
tests/unit-tests/python/foglamp_test/services/common/microservice_management/service_registry/test_services_registry_api.py ..............


**========24 passed in 0.56 seconds =====**