### PR TITLE
FOGL-783 support for newer and older conditions at payload builder side

### DIFF
--- a/python/foglamp/common/storage_client/payload_builder.py
+++ b/python/foglamp/common/storage_client/payload_builder.py
@@ -56,7 +56,7 @@ class PayloadBuilder(object):
         if isinstance(arg, list):
             if len(arg) == 3:
                 # TODO: Implement LIKE and IN later when support becomes available in storage service
-                if arg[1] in ['<', '>', '=', '>=', '<=', '!=']:
+                if arg[1] in ['<', '>', '=', '>=', '<=', '!=', 'newer', 'older']:
                     retval = True
         return retval
 

--- a/tests/unit-tests/python/foglamp_test/common/storage/data/payload_aggregate_where.json
+++ b/tests/unit-tests/python/foglamp_test/common/storage/data/payload_aggregate_where.json
@@ -1,0 +1,11 @@
+{
+  "where": {
+		"column": "ts",
+		"condition": "newer",
+		"value": 60
+	},
+	"aggregate": {
+		"operation": "count",
+		"column": "*"
+	}
+}

--- a/tests/unit-tests/python/foglamp_test/common/storage/data/payload_newer_condition.json
+++ b/tests/unit-tests/python/foglamp_test/common/storage/data/payload_newer_condition.json
@@ -1,0 +1,7 @@
+{
+	"where": {
+		"column": "ts",
+		"condition": "newer",
+		"value": 3600
+	}
+}

--- a/tests/unit-tests/python/foglamp_test/common/storage/data/payload_older_condition.json
+++ b/tests/unit-tests/python/foglamp_test/common/storage/data/payload_older_condition.json
@@ -1,0 +1,7 @@
+{
+	"where": {
+		"column": "ts",
+		"condition": "older",
+		"value": 600
+	}
+}

--- a/tests/unit-tests/python/foglamp_test/common/storage/test_payload_builder.py
+++ b/tests/unit-tests/python/foglamp_test/common/storage/test_payload_builder.py
@@ -53,7 +53,9 @@ class TestPayloadBuilderRead:
         (["id", "<", 1.5], _payload("data/payload_conditions3.json")),
         (["id", ">=", 9], _payload("data/payload_conditions4.json")),
         (["id", "<=", 99], _payload("data/payload_conditions5.json")),
-        (["id", "!=", "False"], _payload("data/payload_conditions6.json"))
+        (["id", "!=", "False"], _payload("data/payload_conditions6.json")),
+        (["ts", "newer", 3600], _payload("data/payload_newer_condition.json")),
+        (["ts", "older", 600], _payload("data/payload_older_condition.json"))
 
     ])
     def test_conditions_payload(self, test_input, expected):
@@ -208,7 +210,6 @@ class TestPayloadBuilderRead:
         assert expected == json.loads(res)
 
     def test_expr_payload(self):
-
         res = PayloadBuilder().WHERE(["key", "=", "READINGS"]).EXPR(["value", "+", 10]).payload()
         assert _payload("data/payload_expr1.json") == json.loads(res)
 
@@ -248,6 +249,10 @@ class TestPayloadBuilderRead:
             .payload()
 
         assert _payload("data/payload_complex_select1.json") == json.loads(res)
+
+    def test_aggregate_with_where(self):
+        res = PayloadBuilder().WHERE(["ts", "newer", 60]).AGGREGATE(["count", "*"]).payload()
+        assert _payload("data/payload_aggregate_where.json") == json.loads(res)
 
 
 @pytest.allure.feature("unit")


### PR DESCRIPTION
[FOGL-783](https://scaledb.atlassian.net/browse/FOGL-783)

**Tests O/P**

```
collected 63 items 

test_payload_builder.py::TestPayloadBuilderRead::test_select_payload[name-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_select_payload[test_input1-expected1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_from_payload[test-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_from_payload[test, test2-expected1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_conditions_payload[test_input0-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_conditions_payload[test_input1-expected1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_conditions_payload[test_input2-expected2] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_conditions_payload[test_input3-expected3] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_conditions_payload[test_input4-expected4] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_conditions_payload[test_input5-expected5] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_conditions_payload[test_input6-expected6] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_conditions_payload[test_input7-expected7] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_where_payload[test_input0-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_and_where_payload[test_input_10-test_input_20-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_multiple_and_where_payload[test_input_10-test_input_20-test_input_30-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_or_where_payload[test_input_10-test_input_20-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_multiple_or_where_payload[test_input_10-test_input_20-test_input_30-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_limit_payload[3-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_limit_payload[3.5-expected1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_limit_payload[invalid-expected2] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_order_by_payload[test_input0-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_order_by_payload[test_input1-expected1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_order_by_payload[test_input2-expected2] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_order_by_payload[test_input3-expected3] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_order_by_payload[test_input4-expected4] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_group_by_payload[name-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_group_by_payload[name,id-expected1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_aggregate_payload[test_input0-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_aggregate_payload[test_input1-expected1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_aggregate_payload[test_input2-expected2] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_aggregate_payload[test_input3-expected3] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_aggregate_payload[test_input4-expected4] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_aggregate_payload[test_input5-expected5] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_aggregate_payload[test_input6-expected6] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_select_all_payload PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_select_distinct_payload PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_offset_payload[3-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_offset_payload[3.5-expected1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_offset_payload[invalid-expected2] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_limit_offset_payload[3-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_limit_offset_payload[3.5-expected1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_limit_offset_payload[invalid-expected2] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_skip_payload[3-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_skip_payload[3.5-expected1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_skip_payload[invalid-expected2] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_limit_skip_payload[3-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_limit_skip_payload[3.5-expected1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_limit_skip_payload[invalid-expected2] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_query_params_payload PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_and_query_params_payload[test_input10-test_input20-key1=value1&key2=2] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_or_query_params_payload[test_input10-test_input20-key1=value1] PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_having_payload SKIPPED
test_payload_builder.py::TestPayloadBuilderRead::test_expr_payload PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_complex_select_payload PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_chain_payload PASSED
test_payload_builder.py::TestPayloadBuilderRead::test_aggregate_with_where PASSED
test_payload_builder.py::TestPayloadBuilderCreate::test_insert_payload PASSED
test_payload_builder.py::TestPayloadBuilderCreate::test_insert_into_payload PASSED
test_payload_builder.py::TestPayloadBuilderUpdate::test_update_table_payload[test-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderUpdate::test_set_payload[test_update-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderUpdate::test_update_set_where_payload[test_update-input_where0-test_tbl-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderDelete::test_delete_payload[test-expected0] PASSED
test_payload_builder.py::TestPayloadBuilderDelete::test_delete_where_payload[input_where0-test_tbl-expected0] PASSED

===== 62 passed, 1 skipped in 0.21 seconds ======
```