### PR TITLE
FOGL-805 regression fixes for north http_translator

### DIFF
--- a/C/plugins/storage/postgres/init.sql
+++ b/C/plugins/storage/postgres/init.sql
@@ -799,14 +799,15 @@ INSERT INTO foglamp.configuration ( key, description, value )
      VALUES ( 'HTTP_TR_3', 'HTTP North Plugin Configuration', ' {
         "plugin": {
                 "type": "string",
-                "value": "http_translator",
                 "default": "http_translator",
+                "value": "http_translator",
                 "description": "Python module name of the plugin to load"
         },
         "translator": {
                 "description": "The name of the translator to use to translate the readings into the output format and send them",
                 "type": "string",
-                "default": "http_translator"
+                "default": "http_translator",
+                "value": "http_translator",
         }
 } ');
 
@@ -866,6 +867,7 @@ INSERT INTO foglamp.statistics ( key, description, value, previous_value )
             ( 'BUFFERED',   'The number of readings currently in the FogLAMP buffer', 0, 0 ),
             ( 'SENT_1',     'The number of readings sent to the historian', 0, 0 ),
             ( 'SENT_2',     'The number of statistics data sent to the historian', 0, 0 ),
+            ( 'SENT_3',     'The number of readings data sent to the HTTP translator', 0, 0 ),
             ( 'UNSENT',     'The number of readings filtered out in the send process', 0, 0 ),
             ( 'PURGED',     'The number of readings removed from the buffer by the purge process', 0, 0 ),
             ( 'UNSNPURGED', 'The number of readings that were purged from the buffer before being sent', 0, 0 ),
@@ -876,27 +878,29 @@ INSERT INTO foglamp.statistics ( key, description, value, previous_value )
 -- Weekly repeat for timed schedules: set schedule_interval to 168:00:00
 
 -- FogLAMP South Microservice - CoAP Listener Plugin
-insert into foglamp.scheduled_processes ( name, script ) values ( 'COAP', '["services/south"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) values ( 'COAP', '["services/south"]' );
 -- FogLAMP South Microservice - POLL Plugin template
-insert into foglamp.scheduled_processes ( name, script ) values ( 'POLL', '["services/south"]' );
-insert into foglamp.scheduled_processes ( name, script ) values ( 'HTTP_SOUTH', '["services/south"]');
-insert into foglamp.scheduled_processes ( name, script ) values ( 'purge', '["tasks/purge"]' );
-insert into foglamp.scheduled_processes ( name, script ) values ( 'stats collector', '["tasks/statistics"]' );
-insert into foglamp.scheduled_processes ( name, script ) values ( 'sending process', '["tasks/north", "--stream_id", "1", "--debug_level", "1"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) values ( 'POLL', '["services/south"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) values ( 'HTTP_SOUTH', '["services/south"]');
+INSERT INTO foglamp.scheduled_processes ( name, script ) values ( 'purge', '["tasks/purge"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) values ( 'stats collector', '["tasks/statistics"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) values ( 'sending process', '["tasks/north", "--stream_id", "1", "--debug_level", "1"]' );
+
 -- FogLAMP statistics into PI
-insert into foglamp.scheduled_processes ( name, script ) values ( 'statistics to pi','["tasks/north", "--stream_id", "2", "--debug_level", "1"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) values ( 'statistics to pi','["tasks/north", "--stream_id", "2", "--debug_level", "1"]' );
+
 -- Send readings via HTTP
-insert into foglamp.scheduled_processes (name, script) values ('sending HTTP', '["tasks/north", "--stream_id", "3", "--debug_level", "1"]');
+INSERT INTO foglamp.scheduled_processes (name, script) values ('sending HTTP', '["tasks/north", "--stream_id", "3", "--debug_level", "1"]');
 
 -- FogLAMP Backup
-insert into foglamp.scheduled_processes (name, script) values ('backup','["tasks/backup_postgres"]' );
+INSERT INTO foglamp.scheduled_processes (name, script) values ('backup','["tasks/backup_postgres"]' );
 -- FogLAMP Restore
-insert into foglamp.scheduled_processes (name, script) values ('restore','["tasks/restore_postgres"]' );
+INSERT INTO foglamp.scheduled_processes (name, script) values ('restore','["tasks/restore_postgres"]' );
 
 
 
 -- Start the device server at start-up
-insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
 schedule_interval, exclusive)
 values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'COAP', 1,
 '0:0', true);
@@ -914,37 +918,43 @@ values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'device', 'COAP', 1,
 -- '0:0', true);
 
 ---- Start the device server HTTP Listener at start-up
- insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
  schedule_interval, exclusive)
  values ('a2caca59-1241-478d-925a-79584e7096e0', 'device', 'HTTP_SOUTH', 1,
  '0:0', true);
 
 -- Run the purge process every 5 minutes
-insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
 schedule_time, schedule_interval, exclusive)
 values ('cea17db8-6ccc-11e7-907b-a6006ad3dba0', 'purge', 'purge', 3,
 NULL, '00:05:00', true);
 
 -- Run the statistics collector every 15 seconds
-insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
 schedule_time, schedule_interval, exclusive)
 values ('2176eb68-7303-11e7-8cf7-a6006ad3dba0', 'stats collector', 'stats collector', 3,
 NULL, '00:00:15', true);
 
 -- Run the sending process every 15 seconds
-insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
 schedule_time, schedule_interval, exclusive)
 values ('2b614d26-760f-11e7-b5a5-be2e44b06b34', 'sending process', 'sending process', 3,
 NULL, '00:00:15', true);
 
+-- Run the sending process using HTTP translator every 15 seconds
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
+schedule_time, schedule_interval, exclusive)
+values ('81bdf749-8aa0-468e-b229-9ff695668e8c', 'sending via HTTP', 'sending HTTP', 3,
+NULL, '00:00:15', true);
+
 -- Run FogLAMP statistics into PI every 25 seconds
-insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
 schedule_time, schedule_interval, exclusive)
 values ('1d7c327e-7dae-11e7-bb31-be2e44b06b34', 'statistics to pi', 'statistics to pi', 3,
 NULL, '00:00:25', true);
 
 -- OMF translator configuration
-INSERT INTO foglamp.destinations(id,description, ts)                       VALUES (1,'OMF', now());
+INSERT INTO foglamp.destinations(id,description, ts) VALUES (1,'OMF', now());
 INSERT INTO foglamp.streams(id,destination_id,description, last_object,ts) VALUES (1,1,'OMF translator', 0,now());  
 
 -- FogLAMP statistics into PI configuration

--- a/python/foglamp/plugins/north/http_translator/http_translator.py
+++ b/python/foglamp/plugins/north/http_translator/http_translator.py
@@ -10,9 +10,9 @@ import aiohttp
 import asyncio
 import json
 
-from foglamp import logger
-from foglamp.configuration_manager import ConfigurationManager
-from foglamp.translators.exceptions import *
+from foglamp.common import logger
+from foglamp.common.configuration_manager import ConfigurationManager
+from foglamp.plugins.north.common.exceptions import *
 
 __author__ = "Ashish Jabble"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"


### PR DESCRIPTION
[FOGL-805](https://scaledb.atlassian.net/browse/FOGL-805)

**Fixed items**
- [x] Regression fixes for north http_translator
- [x] other code refactoring

**How to test?**
IN _sending_process.py_ file,  translator default value set to "**http_translator**" as there is no such mechanism to pick dynamic configuration (this thing will fix by [FOGL-732](https://scaledb.atlassian.net/browse/FOGL-732))


**Syslog**
```
Dec  6 12:42:15 nerd-034 [FOGLAMP] 12-06-2017 12:42:15 - INFO :: server: foglamp.services.core.server: start core
Dec  6 12:42:15 nerd-034 [FOGLAMP] 12-06-2017 12:42:15 - INFO :: server: foglamp.services.core.server: Management API started on http://0.0.0.0:42739
Dec  6 12:42:15 nerd-034 [FOGLAMP] 12-06-2017 12:42:15 - INFO :: server: foglamp.services.core.server: start storage, from directory /home/foglamp/Development/FogLAMP/scripts
Dec  6 12:42:15 nerd-034 storage: Using default configuration:  { "plugin" : {  "value" : "postgres" }, "threads" : { "value" : "1" },  "port" : { "value" : "0" }, "managementPort" : { "value" : "0" } }.
Dec  6 12:42:15 nerd-034 port[6375]: Load storage plugin postgres.
Dec  6 12:42:15 nerd-034 [FOGLAMP] 12-06-2017 12:42:15 - INFO :: server: foglamp.services.core.server: start scheduler
Dec  6 12:42:15 nerd-034 [FOGLAMP] 12-06-2017 12:42:15 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Starting
Dec  6 12:42:15 nerd-034 port[6375]: Loaded storage plugin postgres.
Dec  6 12:42:15 nerd-034 port[6375]: Starting management api on port 0.
Dec  6 12:42:15 nerd-034 port[6375]: Starting service...
Dec  6 12:42:25 nerd-034 [FOGLAMP] 12-06-2017 12:42:25 - INFO :: instance: foglamp.services.common.microservice_management.service_registry.instance: Registered service instance id=9df54486-22cf-4ecf-95c1-02cb9b7f53e1: <FogLAMP Storage, type=Storage, protocol=http, address=localhost, service port=39871, management port=42605, status=0>
Dec  6 12:42:25 nerd-034 port[6375]: Registered service 9df54486-22cf-4ecf-95c1-02cb9b7f53e1.
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Starting Scheduler: Management port received is 42739
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'device' to start at 2017-12-06 12:42:15.436406
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'device' to start at 2017-12-06 12:42:15.436406
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'purge' to start at 2017-12-06 12:47:15.436406
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collector' to start at 2017-12-06 12:42:30.436406
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'sending process' to start at 2017-12-06 12:42:30.436406
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'sending via HTTP' to start at 2017-12-06 12:42:30.436406
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'statistics to pi' to start at 2017-12-06 12:42:40.436406
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'sending via HTTP' process 'sending HTTP' task 01c1bf22-805c-4b12-9fa0-c9f8b5c833cf pid 6394, 1 running tasks#012['tasks/north', '--stream_id', '3', '--debug_level', '1', '--port=42739', '--address=127.0.0.1', '--name=sending HTTP']
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collector' process 'stats collector' task 1201276c-2eac-486c-a183-4933d65bccdd pid 6396, 2 running tasks#012['tasks/statistics', '--port=42739', '--address=127.0.0.1', '--name=stats collector']
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'device' process 'HTTP_SOUTH' task 0844f680-67df-41f8-ae19-28dd3ced1cae pid 6399, 3 running tasks#012['services/south', '--port=42739', '--address=127.0.0.1', '--name=HTTP_SOUTH']
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: server: foglamp.services.core.server: Rest Server started on http://0.0.0.0:8081
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: instance: foglamp.services.common.microservice_management.service_registry.instance: Registered service instance id=03964864-76ed-4dd3-93eb-7cb6d33fe728: <FogLAMP Core, type=Core, protocol=http, address=0.0.0.0, service port=8081, management port=42739, status=0>
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'device' process 'COAP' task 426871c0-8d91-4e48-b042-490a5345d33b pid 6401, 4 running tasks#012['services/south', '--port=42739', '--address=127.0.0.1', '--name=COAP']
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'sending process' process 'sending process' task e71ed566-58b1-4470-a42c-c9c68779a8e7 pid 6402, 5 running tasks#012['tasks/north', '--stream_id', '1', '--debug_level', '1', '--port=42739', '--address=127.0.0.1', '--name=sending process']
Dec  6 12:42:30 nerd-034 [FOGLAMP] 12-06-2017 12:42:30 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 9.880951404571533 seconds
Dec  6 12:42:31 nerd-034 [FOGLAMP] 12-06-2017 12:42:31 - INFO :: sending_process: sending_process_1: sending_process, for Linux (x86_64) Copyright (c) 2017 OSIsoft, LLC
Dec  6 12:42:31 nerd-034 [FOGLAMP] 12-06-2017 12:42:31 - INFO :: sending_process: sending_process_1: Started.
Dec  6 12:42:31 nerd-034 [FOGLAMP] 12-06-2017 12:42:31 - INFO :: sending_process: sending_process_3: sending_process, for Linux (x86_64) Copyright (c) 2017 OSIsoft, LLC
Dec  6 12:42:31 nerd-034 [FOGLAMP] 12-06-2017 12:42:31 - INFO :: sending_process: sending_process_3: Started.
Dec  6 12:42:31 nerd-034 [FOGLAMP] 12-06-2017 12:42:31 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collector' process 'stats collector' task 1201276c-2eac-486c-a183-4933d65bccdd pid 6396 exit 0, 4 running tasks#012['tasks/statistics']
Dec  6 12:42:31 nerd-034 [FOGLAMP] 12-06-2017 12:42:31 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collector' to start at 2017-12-06 12:42:45.436406
Dec  6 12:42:31 nerd-034 [FOGLAMP] 12-06-2017 12:42:31 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 9.263766288757324 seconds
Dec  6 12:42:40 nerd-034 [FOGLAMP] 12-06-2017 12:42:40 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'statistics to pi' process 'statistics to pi' task 52da6a07-3131-45a7-bbf0-2144fa9bcc27 pid 6412, 5 running tasks#012['tasks/north', '--stream_id', '2', '--debug_level', '1', '--port=42739', '--address=127.0.0.1', '--name=statistics to pi']
Dec  6 12:42:40 nerd-034 [FOGLAMP] 12-06-2017 12:42:40 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 4.972470045089722 seconds
Dec  6 12:42:40 nerd-034 [FOGLAMP] 12-06-2017 12:42:40 - INFO :: sending_process: sending_process_2: sending_process, for Linux (x86_64) Copyright (c) 2017 OSIsoft, LLC
Dec  6 12:42:40 nerd-034 [FOGLAMP] 12-06-2017 12:42:40 - INFO :: sending_process: sending_process_2: Started.
Dec  6 12:42:45 nerd-034 [FOGLAMP] 12-06-2017 12:42:45 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collector' process 'stats collector' task f2e1a90a-9a75-40bb-8392-be581ba7d015 pid 6416, 6 running tasks#012['tasks/statistics', '--port=42739', '--address=127.0.0.1', '--name=stats collector']
Dec  6 12:42:45 nerd-034 [FOGLAMP] 12-06-2017 12:42:45 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 269.9730260372162 seconds
Dec  6 12:42:45 nerd-034 [FOGLAMP] 12-06-2017 12:42:45 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collector' process 'stats collector' task f2e1a90a-9a75-40bb-8392-be581ba7d015 pid 6416 exit 0, 5 running tasks#012['tasks/statistics']
Dec  6 12:42:45 nerd-034 [FOGLAMP] 12-06-2017 12:42:45 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collector' to start at 2017-12-06 12:43:00.436406
Dec  6 12:42:45 nerd-034 [FOGLAMP] 12-06-2017 12:42:45 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 14.547791719436646 seconds
Dec  6 12:43:00 nerd-034 [FOGLAMP] 12-06-2017 12:43:00 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collector' process 'stats collector' task c2a77574-ebbd-4eac-b221-17f394b2ae99 pid 6426, 6 running tasks#012['tasks/statistics', '--port=42739', '--address=127.0.0.1', '--name=stats collector']
Dec  6 12:43:00 nerd-034 [FOGLAMP] 12-06-2017 12:43:00 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 254.97072219848633 seconds
Dec  6 12:43:00 nerd-034 [FOGLAMP] 12-06-2017 12:43:00 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collector' process 'stats collector' task c2a77574-ebbd-4eac-b221-17f394b2ae99 pid 6426 exit 0, 5 running tasks#012['tasks/statistics']
Dec  6 12:43:00 nerd-034 [FOGLAMP] 12-06-2017 12:43:00 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collector' to start at 2017-12-06 12:43:15.436406
Dec  6 12:43:00 nerd-034 [FOGLAMP] 12-06-2017 12:43:00 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 14.562427043914795 seconds
Dec  6 12:43:15 nerd-034 [FOGLAMP] 12-06-2017 12:43:15 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collector' process 'stats collector' task f8add5a6-ba8c-4d98-9862-66040de5757d pid 6438, 6 running tasks#012['tasks/statistics', '--port=42739', '--address=127.0.0.1', '--name=stats collector']
Dec  6 12:43:15 nerd-034 [FOGLAMP] 12-06-2017 12:43:15 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 239.97929406166077 seconds
Dec  6 12:43:15 nerd-034 [FOGLAMP] 12-06-2017 12:43:15 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collector' process 'stats collector' task f8add5a6-ba8c-4d98-9862-66040de5757d pid 6438 exit 0, 5 running tasks#012['tasks/statistics']
Dec  6 12:43:15 nerd-034 [FOGLAMP] 12-06-2017 12:43:15 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collector' to start at 2017-12-06 12:43:30.436406
Dec  6 12:43:15 nerd-034 [FOGLAMP] 12-06-2017 12:43:15 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 14.554418802261353 seconds

```

**readings sent by fogbench**
1) readings inserted properly, Total **10**
2) statistics also updated

```
"SENT_3    " | "The number of readings data sent to the HTTP translator" | 10 |  10 |  "2017-12-06 12:42:10.771377+05:30 |"
```

**Readings received at foglcoud**

```

> fogcloud@1.0.0 start /home/foglamp/Development/fogcloud
> node .

Fog(Test)Cloud listening on port 8118!
Valid Block payload { asset_code: 'TI sensorTag/luxometer',
  readings: 
   [ { user_ts: '2017-12-06 12:43:13.481743+05:30',
       reading: [Object],
       read_key: 'd0d34c10-c565-4884-9426-0a1669380e31' } ] }
Valid Block payload { asset_code: 'TI sensorTag/pressure',
  readings: 
   [ { user_ts: '2017-12-06 12:43:13.481813+05:30',
       reading: [Object],
       read_key: 'c4ae1c27-0df6-40a4-b0c6-71ef90930cd5' } ] }
Valid Block payload { asset_code: 'TI sensorTag/humidity',
  readings: 
   [ { user_ts: '2017-12-06 12:43:13.481855+05:30',
       reading: [Object],
       read_key: '30292b35-625a-436c-818a-1855ba8d6e0b' } ] }
Valid Block payload { asset_code: 'TI sensorTag/temperature',
  readings: 
   [ { user_ts: '2017-12-06 12:43:13.481901+05:30',
       reading: [Object],
       read_key: '4565d104-793a-46f3-bf4c-3441724c8a21' } ] }
Valid Block payload { asset_code: 'TI sensorTag/accelerometer',
  readings: 
   [ { user_ts: '2017-12-06 12:43:13.481958+05:30',
       reading: [Object],
       read_key: 'a7589897-be04-4eeb-afb5-b684f0c9d1da' } ] }
Valid Block payload { asset_code: 'mouse',
  readings: 
   [ { user_ts: '2017-12-06 12:43:13.482078+05:30',
       reading: [Object],
       read_key: 'a44c327e-234f-40c5-b830-061605c06cbf' } ] }
Valid Block payload { asset_code: 'TI sensorTag/magnetometer',
  readings: 
   [ { user_ts: '2017-12-06 12:43:13.482036+05:30',
       reading: [Object],
       read_key: '215f7932-6fad-4639-a853-766f98f954c9' } ] }
Valid Block payload { asset_code: 'wall clock',
  readings: 
   [ { user_ts: '2017-12-06 12:43:13.482147+05:30',
       reading: [Object],
       read_key: '9088dfdd-6c72-4d64-a0db-148404d4cdbe' } ] }
Valid Block payload { asset_code: 'TI sensorTag/gyroscope',
  readings: 
   [ { user_ts: '2017-12-06 12:43:13.481999+05:30',
       reading: [Object],
       read_key: 'f616275a-fbc0-49c9-92c4-d9be1abb7f4d' } ] }
Valid Block payload { asset_code: 'mouse',
  readings: 
   [ { user_ts: '2017-12-06 12:43:13.482114+05:30',
       reading: [Object],
       read_key: 'e58edd1a-c775-4575-be22-e92d917f490f' } ] }
Valid Block payload { readings: 
   [ { user_ts: '2017-12-06 12:43:13.481743+05:30',
       reading: [Object],
       read_key: 'd0d34c10-c565-4884-9426-0a1669380e31' } ],
  asset_code: 'TI sensorTag/luxometer' }
Valid Block payload { readings: 
   [ { user_ts: '2017-12-06 12:43:13.481813+05:30',
       reading: [Object],
       read_key: 'c4ae1c27-0df6-40a4-b0c6-71ef90930cd5' } ],
  asset_code: 'TI sensorTag/pressure' }
Valid Block payload { readings: 
   [ { user_ts: '2017-12-06 12:43:13.481855+05:30',
       reading: [Object],
       read_key: '30292b35-625a-436c-818a-1855ba8d6e0b' } ],
  asset_code: 'TI sensorTag/humidity' }
Valid Block payload { readings: 
   [ { user_ts: '2017-12-06 12:43:13.481901+05:30',
       reading: [Object],
       read_key: '4565d104-793a-46f3-bf4c-3441724c8a21' } ],
  asset_code: 'TI sensorTag/temperature' }
Valid Block payload { readings: 
   [ { user_ts: '2017-12-06 12:43:13.481999+05:30',
       reading: [Object],
       read_key: 'f616275a-fbc0-49c9-92c4-d9be1abb7f4d' } ],
  asset_code: 'TI sensorTag/gyroscope' }
Valid Block payload { readings: 
   [ { user_ts: '2017-12-06 12:43:13.482036+05:30',
       reading: [Object],
       read_key: '215f7932-6fad-4639-a853-766f98f954c9' } ],
  asset_code: 'TI sensorTag/magnetometer' }
Valid Block payload { readings: 
   [ { user_ts: '2017-12-06 12:43:13.482078+05:30',
       reading: [Object],
       read_key: 'a44c327e-234f-40c5-b830-061605c06cbf' } ],
  asset_code: 'mouse' }
Valid Block payload { readings: 
   [ { user_ts: '2017-12-06 12:43:13.482114+05:30',
       reading: [Object],
       read_key: 'e58edd1a-c775-4575-be22-e92d917f490f' } ],
  asset_code: 'mouse' }
Valid Block payload { readings: 
   [ { user_ts: '2017-12-06 12:43:13.481958+05:30',
       reading: [Object],
       read_key: 'a7589897-be04-4eeb-afb5-b684f0c9d1da' } ],
  asset_code: 'TI sensorTag/accelerometer' }
Valid Block payload { readings: 
   [ { user_ts: '2017-12-06 12:43:13.482147+05:30',
       reading: [Object],
       read_key: '9088dfdd-6c72-4d64-a0db-148404d4cdbe' } ],
  asset_code: 'wall clock' }
Valid Block payload { asset_code: 'TI sensorTag/luxometer',
  readings: 
   [ { reading: [Object],
       read_key: 'd0d34c10-c565-4884-9426-0a1669380e31',
       user_ts: '2017-12-06 12:43:13.481743+05:30' } ] }
Valid Block payload { asset_code: 'TI sensorTag/pressure',
  readings: 
   [ { reading: [Object],
       read_key: 'c4ae1c27-0df6-40a4-b0c6-71ef90930cd5',
       user_ts: '2017-12-06 12:43:13.481813+05:30' } ] }
Valid Block payload { asset_code: 'TI sensorTag/humidity',
  readings: 
   [ { reading: [Object],
       read_key: '30292b35-625a-436c-818a-1855ba8d6e0b',
       user_ts: '2017-12-06 12:43:13.481855+05:30' } ] }
Valid Block payload { asset_code: 'TI sensorTag/temperature',
  readings: 
   [ { reading: [Object],
       read_key: '4565d104-793a-46f3-bf4c-3441724c8a21',
       user_ts: '2017-12-06 12:43:13.481901+05:30' } ] }
Valid Block payload { asset_code: 'TI sensorTag/accelerometer',
  readings: 
   [ { reading: [Object],
       read_key: 'a7589897-be04-4eeb-afb5-b684f0c9d1da',
       user_ts: '2017-12-06 12:43:13.481958+05:30' } ] }
Valid Block payload { asset_code: 'TI sensorTag/gyroscope',
  readings: 
   [ { reading: [Object],
       read_key: 'f616275a-fbc0-49c9-92c4-d9be1abb7f4d',
       user_ts: '2017-12-06 12:43:13.481999+05:30' } ] }
Valid Block payload { asset_code: 'mouse',
  readings: 
   [ { reading: [Object],
       read_key: 'a44c327e-234f-40c5-b830-061605c06cbf',
       user_ts: '2017-12-06 12:43:13.482078+05:30' } ] }
Valid Block payload { asset_code: 'mouse',
  readings: 
   [ { reading: [Object],
       read_key: 'e58edd1a-c775-4575-be22-e92d917f490f',
       user_ts: '2017-12-06 12:43:13.482114+05:30' } ] }
Valid Block payload { asset_code: 'TI sensorTag/magnetometer',
  readings: 
   [ { reading: [Object],
       read_key: '215f7932-6fad-4639-a853-766f98f954c9',
       user_ts: '2017-12-06 12:43:13.482036+05:30' } ] }
Valid Block payload { asset_code: 'wall clock',
  readings: 
   [ { reading: [Object],
       read_key: '9088dfdd-6c72-4d64-a0db-148404d4cdbe',
       user_ts: '2017-12-06 12:43:13.482147+05:30' } ] }

```



