### PR TITLE
fixed invalid input syntax for type json - patch for FOGL-805

### DIFF
--- a/C/plugins/storage/postgres/init.sql
+++ b/C/plugins/storage/postgres/init.sql
@@ -807,7 +807,7 @@ INSERT INTO foglamp.configuration ( key, description, value )
                 "description": "The name of the translator to use to translate the readings into the output format and send them",
                 "type": "string",
                 "default": "http_translator",
-                "value": "http_translator",
+                "value": "http_translator"
         }
 } ');
 


### PR DESCRIPTION
Below error fixed
```
psql:init.sql:812: ERROR:  invalid input syntax for type json
LINE 2: ...VALUES ( 'HTTP_TR_3', 'HTTP North Plugin Configuration', ' {
                                                                    ^
DETAIL:  Expected string, but found "}".
CONTEXT:  JSON data, line 12: ...            "value": "http_translator",
        }

```