### PR TITLE
statistics and statistics history test fixes after the merge of PR#362

### DIFF
--- a/tests/unit-tests/python/foglamp_test/services/core/api/test_statistics.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/api/test_statistics.py
@@ -56,9 +56,8 @@ class TestStatistics:
         # curl -X GET http://localhost:8081/foglamp/statistics
         r = requests.get(BASE_URL+'/statistics')
         res = r.json()
-
         assert 200 == r.status_code
-        assert 8 == len(res)
+        assert 9 == len(res)
 
         # sorted by key
         assert res[0]['key'] == 'BUFFERED'
@@ -85,13 +84,17 @@ class TestStatistics:
         assert res[5]['value'] == 0
         assert len(res[5]['description']) > 0
 
-        assert res[6]['key'] == 'UNSENT'
+        assert res[6]['key'] == 'SENT_3'
         assert res[6]['value'] == 0
         assert len(res[6]['description']) > 0
 
-        assert res[7]['key'] == 'UNSNPURGED'
+        assert res[7]['key'] == 'UNSENT'
         assert res[7]['value'] == 0
         assert len(res[7]['description']) > 0
+
+        assert res[8]['key'] == 'UNSNPURGED'
+        assert res[8]['value'] == 0
+        assert len(res[8]['description']) > 0
 
     async def test_get_updated_statistics(self):
         await update_statistics(3)
@@ -100,7 +103,7 @@ class TestStatistics:
         res = r.json()
 
         assert 200 == r.status_code
-        assert 8 == len(res)
+        assert 9 == len(res)
 
         assert res[3]['key'] == 'READINGS'
         assert res[3]['value'] == 3
@@ -114,7 +117,7 @@ class TestStatistics:
         res = r.json()
 
         assert 200 == r.status_code
-        assert 9 == len(res)
+        assert 10 == len(res)
 
         # READINGS_X must exists IN keys
         key_entries = [keys["key"] for keys in res]

--- a/tests/unit-tests/python/foglamp_test/services/core/api/test_statistics_history.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/api/test_statistics_history.py
@@ -95,6 +95,7 @@ class TestStatisticsHistory:
         assert 10 == res2['statistics'][-1]['UNSENT']
         assert 10 == res2['statistics'][-1]['SENT_1']
         assert 10 == res2['statistics'][-1]['SENT_2']
+        assert 10 == res2['statistics'][-1]['SENT_3']
         assert 10 == res2['statistics'][-1]['UNSNPURGED']
         assert 10 == res2['statistics'][-1]['READINGS']
         assert 10 == res2['statistics'][-1]['PURGED']


### PR DESCRIPTION
**Reason for failing**: addition of **SENT_3** key in statistics

**Test O/P**

```
foglamp@nerd-034:~/Development/FogLAMP/tests/unit-tests/python/foglamp_test$ pytest -s -v services/core/api/test_statistics_history.py
============================================================= test session starts =============================================================
platform linux -- Python 3.5.2, pytest-3.1.1, py-1.5.2, pluggy-0.4.0 -- /usr/bin/python3
cachedir: .cache
rootdir: /home/foglamp/Development/FogLAMP/tests/unit-tests/python/foglamp_test, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.6.0, allure-adaptor-1.7.7
collected 3 items 

services/core/api/test_statistics_history.py::TestStatisticsHistory::test_get_statistics_history PASSED
services/core/api/test_statistics_history.py::TestStatisticsHistory::test_get_statistics_history_with_limit PASSED
services/core/api/test_statistics_history.py::TestStatisticsHistory::test_get_statistics_history_limit_with_bad_data PASSED

=== 3 passed in 45.30 seconds ===

foglamp@nerd-034:~/Development/FogLAMP/tests/unit-tests/python/foglamp_test$ pytest -s -v services/core/api/test_statistics.py 
============================================================= test session starts =============================================================
platform linux -- Python 3.5.2, pytest-3.1.1, py-1.5.2, pluggy-0.4.0 -- /usr/bin/python3
cachedir: .cache
rootdir: /home/foglamp/Development/FogLAMP/tests/unit-tests/python/foglamp_test, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.6.0, allure-adaptor-1.7.7
collected 3 items 

services/core/api/test_statistics.py::TestStatistics::test_get_statistics PASSED
services/core/api/test_statistics.py::TestStatistics::test_get_updated_statistics PASSED
services/core/api/test_statistics.py::TestStatistics::test_get_statistics_with_new_key_entry PASSED

===== 3 passed in 0.21 seconds ===== 
```