### PR TITLE
FOGL-812 - Native sensortag poll mode plugin improvements

### DIFF
--- a/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
+++ b/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
@@ -72,25 +72,29 @@ def plugin_init(config):
     Raises:
     """
     global sensortag_characteristics
+    data = copy.deepcopy(config)
 
     bluetooth_adr = config['bluetoothAddress']['value']
     tag = SensorTagCC2650(bluetooth_adr)
 
-    # The GATT table can change for different firmware revisions, so it is important to do a proper characteristic
-    # discovery rather than hard-coding the attribute handles.
-    for char in sensortag_characteristics.keys():
-        for _type in ['data', 'configuration', 'period']:
-            handle = tag.get_char_handle(sensortag_characteristics[char][_type]['uuid'])
-            sensortag_characteristics[char][_type]['handle'] = handle
+    data['is_connected'] = tag.is_connected
+    if data['is_connected'] is True:
+        # The GATT table can change for different firmware revisions, so it is important to do a proper characteristic
+        # discovery rather than hard-coding the attribute handles.
+        for char in sensortag_characteristics.keys():
+            for _type in ['data', 'configuration', 'period']:
+                handle = tag.get_char_handle(sensortag_characteristics[char][_type]['uuid'])
+                sensortag_characteristics[char][_type]['handle'] = handle
 
-    # print(json.dumps(sensortag_characteristics))
+        # Get Battery handle
+        handle = tag.get_char_handle(battery['data']['uuid'])
+        battery['data']['handle'] = handle
+        sensortag_characteristics['battery'] = battery
 
-    data = copy.deepcopy(config)
-    data['characteristics'] = sensortag_characteristics
-    data['bluetooth_adr'] = bluetooth_adr
-    data['tag'] = tag
-
-    _LOGGER.info('SensorTagCC2650 {} Polling initialized'.format(bluetooth_adr))
+        data['characteristics'] = sensortag_characteristics
+        data['bluetooth_adr'] = bluetooth_adr
+        data['tag'] = tag
+        _LOGGER.info('SensorTagCC2650 {} Polling initialized'.format(bluetooth_adr))
 
     return data
 
@@ -125,6 +129,8 @@ def plugin_poll(handle):
     rel_temperature = None
     bar_pressure = None
     movement = None
+    battery_level = None
+    keypress_state = None
 
     try:
         if not tag.is_connected:
@@ -179,6 +185,9 @@ def plugin_poll(handle):
             'acc_range': acc_range
         }
 
+        battery_level = tag.get_battery_level(
+            tag.char_read_hnd(handle['characteristics']['battery']['data']['handle'], "battery"))
+
         # Disable sensors
         tag.char_write_cmd(handle['characteristics']['temperature']['configuration']['handle'], char_disable)
         tag.char_write_cmd(handle['characteristics']['luminance']['configuration']['handle'], char_disable)
@@ -212,7 +221,8 @@ def plugin_poll(handle):
                 "x": mag_x,
                 "y": mag_y,
                 "z": mag_z
-            }
+            },
+            'battery': {"percentage": battery_level},
         }
         for reading_key in data['readings']:
             asyncio.ensure_future(handle['ingest'].add_readings(asset=data['asset'] + '/' + reading_key,

--- a/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
+++ b/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
@@ -35,6 +35,11 @@ _DEFAULT_CONFIG = {
         'description': 'Bluetooth MAC address',
         'type': 'string',
         'default': 'B0:91:22:EA:79:04'
+    },
+    'connectionTimeout': {
+        'description': 'BLE Device timeout value in seconds',
+        'type': 'integer',
+        'default': '10'
     }
 }
 
@@ -75,7 +80,8 @@ def plugin_init(config):
     data = copy.deepcopy(config)
 
     bluetooth_adr = config['bluetoothAddress']['value']
-    tag = SensorTagCC2650(bluetooth_adr)
+    timeout = config['connectionTimeout']['value']
+    tag = SensorTagCC2650(bluetooth_adr, timeout)
 
     data['is_connected'] = tag.is_connected
     if data['is_connected'] is True:

--- a/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
+++ b/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
@@ -235,7 +235,7 @@ def plugin_poll(handle):
 
     _LOGGER.debug("SensorTagCC2650 {} reading: {}".format(bluetooth_adr, json.dumps(data)))
     return data
-
+import bluepy
 
 def plugin_reconfigure(handle, new_config):
     """ Reconfigures the plugin, it should be called when the configuration of the plugin is changed during the

--- a/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
+++ b/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
@@ -235,7 +235,7 @@ def plugin_poll(handle):
 
     _LOGGER.debug("SensorTagCC2650 {} reading: {}".format(bluetooth_adr, json.dumps(data)))
     return data
-import bluepy
+
 
 def plugin_reconfigure(handle, new_config):
     """ Reconfigures the plugin, it should be called when the configuration of the plugin is changed during the

--- a/python/foglamp/plugins/south/common/sensortag_cc2650.py
+++ b/python/foglamp/plugins/south/common/sensortag_cc2650.py
@@ -131,7 +131,6 @@ keypress =  {
     },
 }
 
-import bluepy
 char_enable = '01'
 char_disable = '00'
 """

--- a/python/foglamp/plugins/south/common/sensortag_cc2650.py
+++ b/python/foglamp/plugins/south/common/sensortag_cc2650.py
@@ -114,13 +114,13 @@ characteristics = {
         }
     },
 }
-battery =  {
+battery = {
     'data': {
         'uuid': '00002a19-0000-1000-8000-00805f9b34fb',
         'handle': '0x001e'
     },
 }
-keypress =  {
+keypress = {
     'data': {
         'uuid': '0000ffe1-0000-1000-8000-00805f9b34fb',
         'handle': '0x004c'
@@ -157,12 +157,12 @@ class SensorTagCC2650(object):
     reading_iterations = 1  # number of iterations to read data from the TAG
     is_connected = False
 
-    def __init__(self, bluetooth_adr):
+    def __init__(self, bluetooth_adr, timeout):
         try:
             self.bluetooth_adr = bluetooth_adr
 
             self.con = pexpect.spawn('gatttool -b ' + bluetooth_adr + ' --interactive')
-            self.con.expect('\[LE\]>', timeout=10)
+            self.con.expect('\[LE\]>', timeout=int(timeout))
 
             msg_debug = 'SensorTagCC2650 {} Connecting... If nothing happens, please press the power button.'.\
                         format(self.bluetooth_adr)
@@ -170,7 +170,7 @@ class SensorTagCC2650(object):
             _LOGGER.debug(msg_debug)
 
             self.con.sendline('connect')
-            self.con.expect('.*Connection successful.*\[LE\]>', timeout=10)
+            self.con.expect('.*Connection successful.*\[LE\]>', timeout=int(timeout))
             self.is_connected = True
             msg_success = 'SensorTagCC2650 {} connected successfully'.format(self.bluetooth_adr)
             print(msg_success)
@@ -179,7 +179,7 @@ class SensorTagCC2650(object):
             self.is_connected = False
             self.con.sendline('quit')
             # TODO: Investigate why SensorTag goes to sleep often and find a suitable software solution to awake it.
-            msg_failure = 'SensorTagCC2650 {} connection failure.'.format(self.bluetooth_adr)
+            msg_failure = 'SensorTagCC2650 {} connection failure. Timeout={} seconds.'.format(self.bluetooth_adr, timeout)
             print(msg_failure)
             _LOGGER.exception(msg_failure)
 

--- a/python/foglamp/services/south/server.py
+++ b/python/foglamp/services/south/server.py
@@ -164,8 +164,7 @@ class Server(FoglampMicroservice):
         self._plugin_handle['ingest'] = Ingest
         max_retry = 3
         try_count = 1
-        # TODO: CTRL-C does not end it properly
-        while True and try_count <= max_retry:
+        while True and self._plugin_handle['is_connected'] is True and try_count <= max_retry:
             try:
                 data = self._plugin.plugin_poll(self._plugin_handle)
                 # pollInterval is expressed in milliseconds


### PR DESCRIPTION
Addressed below:
1) Examined print statements
2) When bluetooth bad address or not really connected, it should not create any more future task etc. and should always check is_connected
3) Battery level reading added

Not addressed:
1) Up/Down Keypress as this works on notification only and not in polling. This feature will be added in async mode plugin.
2) Shutdown - FOGL-764 will take care of this. However, it has been addressed partially here.