### PR TITLE
FOGL-844 fixes

### DIFF
--- a/tests/unit-tests/python/foglamp_test/common/storage/test_storage_api.py
+++ b/tests/unit-tests/python/foglamp_test/common/storage/test_storage_api.py
@@ -16,7 +16,7 @@ __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
-store = StorageClient("0.0.0.0", core_management_port=37251)
+store = StorageClient("0.0.0.0", core_management_port=37631)
 
 
 # TODO: remove once FOGL-510 is done
@@ -32,8 +32,7 @@ def create_init_data():
     file_path = py.path.local(_dir).join('/foglamp_test_storage_init.sql')
     os.system("psql < {} > /dev/null 2>&1".format(file_path))
     yield
-    os.system("psql < `locate foglamp_ddl.sql | grep 'FogLAMP/src/sql'` > /dev/null 2>&1")
-    os.system("psql < `locate foglamp_init_data.sql | grep 'FogLAMP/src/sql'` > /dev/null 2>&1")
+    os.system("psql < `locate init.sql | grep 'FogLAMP/C/plugins/storage/postgres'` > /dev/null 2>&1")
 
 
 @pytest.allure.feature("api")
@@ -170,7 +169,6 @@ class TestStorageRead:
     def test_multiple_aggregate(self):
         payload = PayloadBuilder().AGGREGATE(["min", "value"], ["max", "value"], ["avg", "value"]).payload()
         result = store.query_tbl_with_payload("statistics", payload)
-        print(result)
         assert len(result["rows"]) == 1
         assert result["count"] == 1
         assert result["rows"][0]["min_value"] == 10


### PR DESCRIPTION
[FOGL-844](https://scaledb.atlassian.net/browse/FOGL-844) - clean up fixes as per new init.sql

```
foglamp@nerd-034:~/Development/FogLAMP/tests/unit-tests/python/foglamp_test$ pytest -s -v common/storage/test_storage_api.py
============================================================= test session starts =============================================================
platform linux -- Python 3.5.2, pytest-3.1.1, py-1.5.2, pluggy-0.4.0 -- /usr/bin/python3
cachedir: ../../.cache
rootdir: /home/foglamp/Development/FogLAMP/tests/unit-tests/python/foglamp_test, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.6.0, allure-adaptor-1.7.7
collected 30 items 

../../common/storage/test_storage_api.py::TestStorageRead::test_select PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_where_query_param PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_where_payload PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_where_invalid_key PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_multiple_and_where PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_multiple_or_where PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_limit PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_offset PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_limit_offset PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_default_order PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_order PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_multiple_order PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_aggregate PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_multiple_aggregate PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_group PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_aggregate_group PASSED
../../common/storage/test_storage_api.py::TestStorageRead::test_aggregate_group_having SKIPPED
../../common/storage/test_storage_api.py::TestStorageRead::test_select_json_data SKIPPED
../../common/storage/test_storage_api.py::TestStorageRead::test_select_date SKIPPED
../../common/storage/test_storage_api.py::TestStorageRead::test_select_column_alias SKIPPED
../../common/storage/test_storage_api.py::TestStorageInsert::test_insert PASSED
../../common/storage/test_storage_api.py::TestStorageInsert::test_invalid_insert PASSED
../../common/storage/test_storage_api.py::TestStorageInsert::test_insert_json_data PASSED
../../common/storage/test_storage_api.py::TestStorageUpdate::test_valid_update_with_condition PASSED
../../common/storage/test_storage_api.py::TestStorageUpdate::test_invalid_key_update PASSED
../../common/storage/test_storage_api.py::TestStorageUpdate::test_invalid_type_update PASSED
../../common/storage/test_storage_api.py::TestStorageUpdate::test_update_without_key PASSED
../../common/storage/test_storage_api.py::TestStorageDelete::test_delete_with_key PASSED
../../common/storage/test_storage_api.py::TestStorageDelete::test_delete_with_invalid_key PASSED
../../common/storage/test_storage_api.py::TestStorageDelete::test_delete_all PASSED

===== 26 passed, 4 skipped in 5.42 seconds======
```