### PR TITLE
Fogl 793 - camelCase convention fixes for core/api

### DIFF
--- a/python/foglamp/services/core/api/audit.py
+++ b/python/foglamp/services/core/api/audit.py
@@ -30,6 +30,7 @@ _help = """
 
 class Severity(IntEnum):
     """ Enumeration for log.severity """
+    # TODO: FOGL-701
     FATAL = 1
     ERROR = 2
     WARNING = 3
@@ -103,7 +104,6 @@ async def get_audit_entries(request):
         for row in results['rows']:
             r = dict()
             r["details"] = row["log"]
-            # TODO: FOGL-695 fix PURGE logging level
             severity_level = int(row["level"])
             r["severity"] = Severity(severity_level).name if severity_level in range(1, 5) else "UNKNOWN"
             r["source"] = row["code"]
@@ -111,7 +111,7 @@ async def get_audit_entries(request):
 
             res.append(r)
 
-        return web.json_response({'audit': res, 'total_count': total_count})
+        return web.json_response({'audit': res, 'totalCount': total_count})
 
     except ValueError as ex:
         raise web.HTTPNotFound(reason=str(ex))
@@ -132,7 +132,7 @@ async def get_audit_log_codes(request):
     storage_client = connect.get_storage()
     result = storage_client.query_tbl('log_codes')
 
-    return web.json_response({'log_code': result['rows']})
+    return web.json_response({'logCode': result['rows']})
 
 
 async def get_audit_log_severity(request):
@@ -152,4 +152,4 @@ async def get_audit_log_severity(request):
         data = {'index': _severity.value, 'name': _severity.name}
         results.append(data)
 
-    return web.json_response({"log_severity": results})
+    return web.json_response({"logSeverity": results})

--- a/python/foglamp/services/core/api/browser.py
+++ b/python/foglamp/services/core/api/browser.py
@@ -73,7 +73,6 @@ async def asset_counts(request):
 
     # TODO: FOGL-643 - Aggregate with alias support needed to use payload builder
     # PayloadBuilder().AGGREGATE(["count", "*"]).GROUP_BY('asset_code')
-
     aggregate = {"operation": "count", "column": "*", "alias": "count"}
     d = OrderedDict()
     d['aggregate'] = aggregate
@@ -213,7 +212,6 @@ async def asset_summary(request):
     _and_where = where_clause(request, _where)
     d.update(_and_where)
 
-    # TODO: FOGL-548 support limit
     payload = json.dumps(d)
     _storage = connect.get_storage()
     results = _storage.query_tbl_with_payload('readings', payload)

--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -32,8 +32,9 @@ async def ping(request):
             {'uptime': 32892} Time in seconds since FogLAMP started
 
     :Example:
-            curl -X GET http://localhost:8082/foglamp/ping
+            curl -X GET http://localhost:8081/foglamp/ping
     """
     since_started = time.time() - __start_time
 
+    # TODO: FOGL-790 - ping method should return more data
     return web.json_response({'uptime': since_started})

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -55,7 +55,7 @@ async def get_category(request):
             the configuration items in the given category.
 
     :Example:
-            curl -X GET http://localhost:8081/category/PURGE_READ
+            curl -X GET http://localhost:8081/foglamp/category/PURGE_READ
     """
     category_name = request.match_info.get('category_name', None)
 
@@ -111,7 +111,7 @@ async def set_configuration_item(request):
         curl -X PUT -H "Content-Type: application/json" -d '{"value": <some value> }' http://localhost:8081/foglamp/category/{category_name}/{config_item}
 
         For {category_name}=>PURGE update value for {config_item}=>age
-        curl -X PUT -H "Content-Type: application/json" -d '{"value": 24}' http://localhost:8081/foglamp/category/PURGE/age
+        curl -X PUT -H "Content-Type: application/json" -d '{"value": 24}' http://localhost:8081/foglamp/category/PURGE_READ/age
 
     """
     category_name = request.match_info.get('category_name', None)
@@ -147,7 +147,7 @@ async def delete_configuration_item_value(request):
         curl -X DELETE http://localhost:8081/foglamp/category/{category_name}/{config_item}/value
 
         For {category_name}=>PURGE delete value for {config_item}=>age
-        curl -X DELETE http://localhost:8081/foglamp/category/PURGE/age/value
+        curl -X DELETE http://localhost:8081/foglamp/category/PURGE_READ/age/value
 
     """
     category_name = request.match_info.get('category_name', None)

--- a/python/foglamp/services/core/api/scheduler.py
+++ b/python/foglamp/services/core/api/scheduler.py
@@ -68,7 +68,7 @@ async def get_scheduled_process(request):
     if not scheduled_process_name:
         raise web.HTTPBadRequest(reason='No Scheduled Process Name given')
 
-    payload = PayloadBuilder().SELECT(("name")).WHERE(["name", "=", scheduled_process_name]).payload()
+    payload = PayloadBuilder().SELECT("name").WHERE(["name", "=", scheduled_process_name]).payload()
     _storage = connect.get_storage()
     scheduled_process = _storage.query_tbl_with_payload('scheduled_processes', payload)
 
@@ -178,7 +178,7 @@ async def _check_schedule_post_parameters(data, curr_value=None):
         _errors.append('Schedule name and Process name cannot be empty.')
 
     # Raise error if scheduled_process name is wrong
-    payload = PayloadBuilder().SELECT(("name")).WHERE(["name", "=", _schedule.get('schedule_process_name')]).payload()
+    payload = PayloadBuilder().SELECT("name").WHERE(["name", "=", _schedule.get('schedule_process_name')]).payload()
     _storage = connect.get_storage()
     scheduled_process = _storage.query_tbl_with_payload('scheduled_processes', payload)
 
@@ -244,10 +244,10 @@ async def get_schedules(request):
         schedules.append({
             'id': str(sch.schedule_id),
             'name': sch.name,
-            'process_name': sch.process_name,
+            'processName': sch.process_name,
             'type': Schedule.Type(int(sch.schedule_type)).name,
             'repeat': sch.repeat.total_seconds() if sch.repeat else 0,
-            'time': (sch.time.hour * 60 * 60 + sch.time.minute * 60 + sch.time.second) if sch.time else 0 ,
+            'time': (sch.time.hour * 60 * 60 + sch.time.minute * 60 + sch.time.second) if sch.time else 0,
             'day': sch.day,
             'exclusive': sch.exclusive
         })
@@ -278,7 +278,7 @@ async def get_schedule(request):
         schedule = {
             'id': str(sch.schedule_id),
             'name': sch.name,
-            'process_name': sch.process_name,
+            'processName': sch.process_name,
             'type': Schedule.Type(int(sch.schedule_type)).name,
             'repeat': sch.repeat.total_seconds() if sch.repeat else 0,
             'time': (sch.time.hour * 60 * 60 + sch.time.minute * 60 + sch.time.second) if sch.time else 0,
@@ -344,7 +344,7 @@ async def post_schedule(request):
         schedule = {
             'id': str(sch.schedule_id),
             'name': sch.name,
-            'process_name': sch.process_name,
+            'processName': sch.process_name,
             'type': Schedule.Type(int(sch.schedule_type)).name,
             'repeat': sch.repeat.total_seconds() if sch.repeat else 0,
             'time': (sch.time.hour * 60 * 60 + sch.time.minute * 60 + sch.time.second) if sch.time else 0,
@@ -358,8 +358,7 @@ async def post_schedule(request):
 
 
 async def update_schedule(request):
-    """
-    Update a schedule in schedules table
+    """ Update a schedule in schedules table
 
     :Example: curl -d '{"type": 4, "name": "sleep30 updated", "process_name": "sleep30", "repeat": "15"}'  -X PUT  http://localhost:8082/foglamp/schedule/84fe4ea1-df9c-4c87-bb78-cab2e7d5d2cc
     """
@@ -401,7 +400,7 @@ async def update_schedule(request):
         schedule = {
             'id': str(sch.schedule_id),
             'name': sch.name,
-            'process_name': sch.process_name,
+            'processName': sch.process_name,
             'type': Schedule.Type(int(sch.schedule_type)).name,
             'repeat': sch.repeat.total_seconds() if sch.repeat else 0,
             'time': (sch.time.hour * 60 * 60 + sch.time.minute * 60 + sch.time.second) if sch.time else 0,
@@ -438,6 +437,7 @@ async def delete_schedule(request):
     except (ValueError, ScheduleNotFoundError) as ex:
         raise web.HTTPNotFound(reason=str(ex))
 
+
 async def get_schedule_type(request):
     """
     Args:
@@ -454,7 +454,7 @@ async def get_schedule_type(request):
         data = {'index': _type.value, 'name': _type.name}
         results.append(data)
 
-    return web.json_response({'schedule_type': results})
+    return web.json_response({'scheduleType': results})
 
 
 #################################
@@ -484,11 +484,11 @@ async def get_task(request):
 
         task = {
             'id': str(tsk.task_id),
-            'process_name': tsk.process_name,
+            'processName': tsk.process_name,
             'state': Task.State(int(tsk.state)).name,
-            'start_time': str(tsk.start_time),
-            'end_time': str(tsk.end_time),
-            'exit_code': tsk.exit_code,
+            'startTime': str(tsk.start_time),
+            'endTime': str(tsk.end_time),
+            'exitCode': tsk.exit_code,
             'reason': tsk.reason
         }
 
@@ -546,12 +546,12 @@ async def get_tasks(request):
         for task in tasks:
             new_tasks.append(
                 {'id': str(task.task_id),
-                     'process_name': task.process_name,
-                     'state': Task.State(int(task.state)).name,
-                     'start_time': str(task.start_time),
-                     'end_time': str(task.end_time),
-                     'exit_code': task.exit_code,
-                     'reason': task.reason
+                 'processName': task.process_name,
+                 'state': Task.State(int(task.state)).name,
+                 'startTime': str(task.start_time),
+                 'endTime': str(task.end_time),
+                 'exitCode': task.exit_code,
+                 'reason': task.reason
                  }
             )
 
@@ -595,11 +595,11 @@ async def get_tasks_latest(request):
         for task in tasks:
             new_tasks.append(
                 {'id': str(task['id']),
-                 'process_name': task['process_name'],
+                 'processName': task['process_name'],
                  'state': [t.name for t in list(Task.State)][int(task['state']) - 1],
-                 'start_time': str(task['start_time']),
-                 'end_time': str(task['end_time']),
-                 'exit_code': task['exit_code'],
+                 'startTime': str(task['start_time']),
+                 'endTime': str(task['end_time']),
+                 'exitCode': task['exit_code'],
                  'reason': task['reason'],
                  'pid': task['pid']
                  }
@@ -651,4 +651,4 @@ async def get_task_state(request):
         data = {'index': _state.value, 'name': _state.name}
         results.append(data)
 
-    return web.json_response({'task_state': results})
+    return web.json_response({'taskState': results})

--- a/tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py
@@ -20,28 +20,32 @@ __version__ = "${VERSION}"
 BASE_URL = 'localhost:8081'
 pytestmark = pytest.mark.asyncio
 
-storage_client = StorageClient("0.0.0.0", core_management_port=46305)
+storage_client = StorageClient("0.0.0.0", core_management_port=44645)
 
 
 # TODO: remove once FOGL-510 is done
 @pytest.fixture()
 def create_init_data():
-    log = '{"end_time": "2017-07-31 13:52:31", "start_time": "2017-07-31 13:52:31", "rows_removed": 0, "rows_remaining": 0, "unsent_rows_removed": 0, "total_failed_to_remove": 0}'
+    log = '{"end_time": "2017-07-31 13:52:31", "start_time": "2017-07-31 13:52:31", ' \
+          '"rows_removed": 0, "rows_remaining": 0, "unsent_rows_removed": 0, "total_failed_to_remove": 0}'
     payload = PayloadBuilder().INSERT(id='1001', code="PURGE", level='2',
                                       log=log, ts='2017-07-31 13:52:31.290372+05:30').payload()
     storage_client.insert_into_tbl("log", payload)
 
-    log = '{"end_time": "2017-07-31 13:53:31", "start_time": "2017-07-31 13:53:31", "rows_removed": 0, "rows_remaining": 0, "unsent_rows_removed": 0, "total_failed_to_remove": 0}'
+    log = '{"end_time": "2017-07-31 13:53:31", "start_time": "2017-07-31 13:53:31", ' \
+          '"rows_removed": 0, "rows_remaining": 0, "unsent_rows_removed": 0, "total_failed_to_remove": 0}'
     payload = PayloadBuilder().INSERT(id='1002', code="PURGE", level='4',
                                       log=log, ts='2017-07-31 13:53:31.300745+05:30').payload()
     storage_client.insert_into_tbl("log", payload)
 
-    log = '{"end_time": "2017-07-31 13:54:31", "start_time": "2017-07-31 13:54:31", "rows_removed": 0, "rows_remaining": 0, "unsent_rows_removed": 0, "total_failed_to_remove": 0}'
+    log = '{"end_time": "2017-07-31 13:54:31", "start_time": "2017-07-31 13:54:31", ' \
+          '"rows_removed": 0, "rows_remaining": 0, "unsent_rows_removed": 0, "total_failed_to_remove": 0}'
     payload = PayloadBuilder().INSERT(id='1003', code="PURGE", level='2',
                                       log=log, ts='2017-07-31 13:54:31.305959+05:30').payload()
     storage_client.insert_into_tbl("log", payload)
 
-    log = '{"end_time": "2017-07-31 13:55:31", "start_time": "2017-07-31 13:55:31", "rows_removed": 0, "rows_remaining": 0, "unsent_rows_removed": 0, "total_failed_to_remove": 0}'
+    log = '{"end_time": "2017-07-31 13:55:31", "start_time": "2017-07-31 13:55:31", ' \
+          '"rows_removed": 0, "rows_remaining": 0, "unsent_rows_removed": 0, "total_failed_to_remove": 0}'
     payload = PayloadBuilder().INSERT(id='1004', code="PURGE", level='2',
                                       log=log, ts='2017-07-31 13:55:31.306996+05:30').payload()
     storage_client.insert_into_tbl("log", payload)
@@ -51,7 +55,8 @@ def create_init_data():
                                       log=log, ts='2017-07-31 14:05:54.128704+05:30').payload()
     storage_client.insert_into_tbl("log", payload)
 
-    log = '{"end_time": "2017-07-31 14:15:54", "start_time": "2017-07-31 14:15:54", "rows_removed": 0, "rows_remaining": 0, "unsent_rows_removed": 0, "total_failed_to_remove": 0}'
+    log = '{"end_time": "2017-07-31 14:15:54", "start_time": "2017-07-31 14:15:54", ' \
+          '"rows_removed": 0, "rows_remaining": 0, "unsent_rows_removed": 0, "total_failed_to_remove": 0}'
     payload = PayloadBuilder().INSERT(id='1006', code="SYPRG", level='1',
                                       log=log, ts='2017-07-31 14:15:54.131013+05:30').payload()
     storage_client.insert_into_tbl("log", payload)
@@ -64,7 +69,6 @@ def create_init_data():
 @pytest.allure.story("audit")
 class TestAudit:
 
-    # TODO: FOGL-701
     async def test_get_severity(self):
         conn = http.client.HTTPConnection(BASE_URL)
         conn.request("GET", '/foglamp/audit/severity')
@@ -73,7 +77,7 @@ class TestAudit:
         r = r.read().decode()
         conn.close()
         result = json.loads(r)
-        log_severity = result['log_severity']
+        log_severity = result['logSeverity']
 
         # verify the severity count
         assert 4 == len(log_severity)
@@ -101,7 +105,7 @@ class TestAudit:
         r = r.read().decode()
         conn.close()
         result = json.loads(r)
-        log_codes = [key['code'] for key in result['log_code']]
+        log_codes = [key['code'] for key in result['logCode']]
 
         # verify the default log_codes which are defined in init.sql
         assert 4 == len(log_codes)
@@ -121,7 +125,7 @@ class TestAudit:
         r = r.read().decode()
         conn.close()
         result = json.loads(r)
-        assert 6 == result['total_count']
+        assert 6 == result['totalCount']
         assert 6 == len(result['audit'])
 
     @pytest.mark.usefixtures('create_init_data')
@@ -133,7 +137,7 @@ class TestAudit:
         r = r.read().decode()
         conn.close()
         result = json.loads(r)
-        assert 6 == result['total_count']
+        assert 6 == result['totalCount']
         assert 5 == len(result['audit'])
 
     @pytest.mark.usefixtures('create_init_data')
@@ -145,7 +149,7 @@ class TestAudit:
         r = r.read().decode()
         conn.close()
         result = json.loads(r)
-        assert 4 == result['total_count']
+        assert 4 == result['totalCount']
         assert 4 == len(result['audit'])
 
     @pytest.mark.usefixtures('create_init_data')
@@ -157,7 +161,7 @@ class TestAudit:
         r = r.read().decode()
         conn.close()
         result = json.loads(r)
-        assert 3 == result['total_count']
+        assert 3 == result['totalCount']
         assert 3 == len(result['audit'])
 
     @pytest.mark.usefixtures('create_init_data')
@@ -169,7 +173,7 @@ class TestAudit:
         r = r.read().decode()
         conn.close()
         result = json.loads(r)
-        assert 3 == result['total_count']
+        assert 3 == result['totalCount']
         assert 1 == len(result['audit'])
 
     @pytest.mark.usefixtures('create_init_data')
@@ -181,7 +185,7 @@ class TestAudit:
         r = r.read().decode()
         conn.close()
         result = json.loads(r)
-        assert 1 == result['total_count']
+        assert 1 == result['totalCount']
         assert 0 == len(result['audit'])
 
     @pytest.mark.usefixtures('create_init_data')
@@ -193,7 +197,7 @@ class TestAudit:
         r = r.read().decode()
         conn.close()
         result = json.loads(r)
-        # TODO: FOGL-711
+        # TODO: FOGL-858
         assert "[KeyError]'BLA'" in result['error']['message']
 
     @pytest.mark.usefixtures('create_init_data')
@@ -205,7 +209,7 @@ class TestAudit:
         r = r.read().decode()
         conn.close()
         result = json.loads(r)
-        assert 0 == result['total_count']
+        assert 0 == result['totalCount']
         assert 0 == len(result['audit'])
 
     # TODO: Also add negative tests for below skip defs

--- a/tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py
@@ -390,27 +390,6 @@ class TestBrowseAssets:
         assert retval[sensor_code_1]['average'] == sum(self.test_data_x_val_list[1:])/len(self.test_data_x_val_list[1:])
         assert retval[sensor_code_1]['max'] == max(self.test_data_x_val_list[1:])
 
-    @pytest.mark.xfail(reason="FOGL-548")
-    async def test_get_asset_sensor_readings_stats_q_limit(self):
-        """
-        Verify that if more than 20 readings, limited readings summary for a sensor value are returned
-        when querying with limit
-        http://localhost:8082/foglamp/asset/TESTAPI/x/summary?limit=1
-        """
-        conn = http.client.HTTPConnection(BASE_URL)
-        conn.request("GET", '/foglamp/asset/{}/{}/summary?limit={}'.format(test_data_asset_code, sensor_code_1, 1))
-        r = conn.getresponse()
-        assert 200 == r.status
-        r = r.read().decode()
-        conn.close()
-        retval = json.loads(r)
-
-        assert 1 == len(retval)
-        # Verify with last record of test data since we are querying for limit=1
-        assert retval[sensor_code_1]['min'] == self.test_data_x_val_list[-1]
-        assert retval[sensor_code_1]['average'] == self.test_data_x_val_list[-1]
-        assert retval[sensor_code_1]['max'] == self.test_data_x_val_list[-1]
-
     @pytest.mark.xfail(reason="FOGL-547")
     async def test_get_asset_sensor_readings_stats_q_sec(self):
         """

--- a/tests/unit-tests/python/foglamp_test/services/core/api/test_configuration.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/api/test_configuration.py
@@ -4,7 +4,6 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-import time
 import json
 
 import asyncpg
@@ -160,7 +159,8 @@ class TestConfigMgr:
         json_data = json.dumps(test_data_item_value)
         print("PUT", '/foglamp/category/{}/{}'.format(test_data['key'], test_data_item), json_data)
 
-        # TODO: FOGL-481: Returns 500 error, Bug? Endpoint not defined for adding (merging) a new config item to existing config?
+        # TODO: FOGL-481: Returns 500 error, Bug?
+        # Endpoint not defined for adding (merging) a new config item to existing config?
         conn.request("PUT", '/foglamp/category/{}/{}'.format(test_data['key'], test_data_item), json_data)
         r = conn.getresponse()
         assert 200 == r.status


### PR DESCRIPTION
- [x] audit.py -- `totalCount, logCode, logSeverity`
- [ ] backup_restore.py - Fixed by [FOGL-556](https://scaledb.atlassian.net/browse/FOGL-556)
- [ ] browser.py -- _No as such reference found_, but fixed some typos and other code refactoring
- [ ] common.py -- _No as such reference found_, but fixed some typos and other code refactoring
- [ ] configuration.py -- _No as such reference found_, but fixed some typos and other code refactoring
- [x] scheduler.py -- `processName, scheduleType, taskState`
- [ ] statistics.py --  _No as such reference found_. **ALL GOOD**

**scheduler and task api tests fixes - Fixed script directory path. As no such file directory for `scripts/foglamp`**

**REST API TESTS O/P**
- [x] test_audit.py
```
collected 16 items 

../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_severity PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_log_codes PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_audit PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_audit_with_offset PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_audit_by_code PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_audit_by_code_and_level PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_audit_by_code_and_level_with_limit PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_audit_by_code_and_level_with_limit_and_offset PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_audit_with_invalid_severity PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_audit_with_invalid_condition PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_post_audit SKIPPED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_all_notifications SKIPPED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_get_notification SKIPPED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_post_notification SKIPPED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_update_notification SKIPPED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_audit.py::TestAudit::test_delete_notification SKIPPED
========== 10 passed, 6 skipped in 0.75 seconds ========
````
- [x] test_browser_assets.py
```
collected 25 items 

../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_all_assets PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_readings PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_limit PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_sec PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_min PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_hrs PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_time_complex PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_limit PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_sec PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_min PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_hrs PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_time_complex PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats xfail
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_sec xfail
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_min xfail
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_hrs xfail
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_time_complex xfail
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg xfail
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_sec xfail
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_min xfail
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_hrs xfail
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_limit_group_hrs xfail
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_time xfail
../../tests/unit-tests/python/foglamp_test/services/core/api/test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_time_limit xfail

======== 13 passed, 12 xfailed in 0.98 seconds ======
```
- [x] test_configuration.py
```
collected 8 items 

../../tests/unit-tests/python/foglamp_test/services/core/api/test_configuration.py::TestConfigMgr::test_get_categories PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_configuration.py::TestConfigMgr::test_get_category PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_configuration.py::TestConfigMgr::test_get_category_item PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_configuration.py::TestConfigMgr::test_set_category_item_value PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_configuration.py::TestConfigMgr::test_edit_category_item_value PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_configuration.py::TestConfigMgr::test_unset_config_item PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_configuration.py::TestConfigMgr::test_merge_category SKIPPED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_configuration.py::TestConfigMgr::test_check_error_code_message PASSED

===== 7 passed, 1 skipped in 0.19 seconds====
```
- [x] test_scheduler.py
```
collected 8 items 

../../tests/unit-tests/python/foglamp_test/services/core/api/test_scheduler.py::TestScheduler::test_get_scheduled_processes FogLAMP started.
PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_scheduler.py::TestScheduler::test_get_scheduled_process PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_scheduler.py::TestScheduler::test_post_schedule PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_scheduler.py::TestScheduler::test_update_schedule PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_scheduler.py::TestScheduler::test_delete_schedule PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_scheduler.py::TestScheduler::test_get_schedule PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_scheduler.py::TestScheduler::test_get_schedules PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_scheduler.py::TestScheduler::test_start_schedule PASSED

======= 8 passed in 211.10 seconds=====
```
- [ ] test_task.py - As its not regressed by new changes, they were failed before

```
collected 4 items 

../../tests/unit-tests/python/foglamp_test/services/core/api/test_task.py::TestTask::test_cancel_task FogLAMP is already running.
FAILED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_task.py::TestTask::test_get_tasks_latest FAILED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_task.py::TestTask::test_get_tasks PASSED
../../tests/unit-tests/python/foglamp_test/services/core/api/test_task.py::TestTask::test_get_task PASSED

======= 2 failed, 2 passed in 61.00 seconds ====
```

**NOTE** - No regression with new changes, but **UI** needs to be fix as per changes.
