### PR TITLE
FOGL-884 - South micro service misuses the plugin handle, Now fixed

### DIFF
--- a/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
+++ b/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
@@ -8,13 +8,11 @@
 
 import copy
 import datetime
-import uuid
 import json
 import asyncio
 from foglamp.plugins.south.common.sensortag_cc2650 import *
 from foglamp.services.south import exceptions
 from foglamp.common import logger
-from foglamp.services.south.ingest import Ingest
 
 __author__ = "Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -124,15 +122,10 @@ def plugin_poll(handle):
         DataRetrievalError
     """
     if 'tag' not in handle:
-        return {}
+        raise RuntimeError
 
     time_stamp = str(datetime.datetime.now(tz=datetime.timezone.utc))
-    data = {
-        'asset': 'TI Sensortag CC2650',
-        'timestamp': time_stamp,
-        'key': str(uuid.uuid4()),
-        'readings': {}
-    }
+    data = {}
     bluetooth_adr = handle['bluetoothAddress']['value']
     tag = handle['tag']
     object_temp_celsius = None
@@ -209,7 +202,7 @@ def plugin_poll(handle):
         tag.char_write_cmd(handle['characteristics']['movement']['configuration']['handle'], movement_disable)
 
         # "values" (and not "readings") denotes that this reading needs to be further broken down to components.
-        data['readings'] = {
+        readings = {
             'temperature': {
                 "object": object_temp_celsius,
                 'ambient': ambient_temp_celsius
@@ -237,11 +230,12 @@ def plugin_poll(handle):
             },
             'battery': {"percentage": battery_level},
         }
-        for reading_key in data['readings']:
-            asyncio.ensure_future(Ingest.add_readings(asset=data['asset'] + '/' + reading_key,
-                                                                timestamp=data['timestamp'],
-                                                                key=str(uuid.uuid4()),
-                                                                readings=data['readings'][reading_key]))
+
+        data = {
+            'asset': 'TI Sensortag CC2650/',
+            'timestamp': time_stamp,
+            'readings': readings
+        }
     except (Exception, RuntimeError) as ex:
         _LOGGER.exception("SensorTagCC2650 {} exception: {}".format(bluetooth_adr, str(ex)))
         raise exceptions.DataRetrievalError(ex)


### PR DESCRIPTION
@MarkRiddoch as discussed, I have modified the south service as follows:
- plugin_handle is now completely opaque. The earlier use of it in server.py is now being taken care by RuntimeError exception.
- Ingest->add_readings() from cc2560poll.py has been moved to server.py.

However, for uniformity sake, we should examine if we also need to move Ingest->add_readings() from cc2560async.py + coap_listen.py as well.
