### PR TITLE
Fogl 850 - Add the ability to enable and disable schedules

### DIFF
--- a/C/plugins/storage/postgres/init.sql
+++ b/C/plugins/storage/postgres/init.sql
@@ -697,6 +697,7 @@ CREATE TABLE foglamp.schedules (
   schedule_day      smallint,                       -- ISO day 1 = Monday, 7 = Sunday
   exclusive         boolean not null default true,  -- true = Only one task can run
                                                     -- at any given time
+  enabled           boolean not null default false, -- false = A given schedule is disabled by default
   CONSTRAINT schedules_pkey PRIMARY KEY (id),
   CONSTRAINT schedules_fk1 FOREIGN KEY (process_name)
   REFERENCES foglamp.scheduled_processes (name) MATCH SIMPLE
@@ -879,105 +880,104 @@ INSERT INTO foglamp.statistics ( key, description, value, previous_value )
 -- Weekly repeat for timed schedules: set schedule_interval to 168:00:00
 
 -- FogLAMP South Microservice - CoAP Listener Plugin
-INSERT INTO foglamp.scheduled_processes ( name, script ) values ( 'COAP', '["services/south"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) VALUES ( 'COAP', '["services/south"]' );
 -- FogLAMP South Microservice - POLL Plugin template
-insert into foglamp.scheduled_processes ( name, script ) values ( 'POLL', '["services/south"]' );
-insert into foglamp.scheduled_processes ( name, script ) values ( 'CC2650POLL', '["services/south"]');
-insert into foglamp.scheduled_processes ( name, script ) values ( 'CC2650ASYN', '["services/south"]');
-insert into foglamp.scheduled_processes ( name, script ) values ( 'HTTP_SOUTH', '["services/south"]');
-insert into foglamp.scheduled_processes ( name, script ) values ( 'purge', '["tasks/purge"]' );
-insert into foglamp.scheduled_processes ( name, script ) values ( 'stats collector', '["tasks/statistics"]' );
-insert into foglamp.scheduled_processes ( name, script ) values ( 'sending process', '["tasks/north", "--stream_id", "1", "--debug_level", "1"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) VALUES ( 'POLL', '["services/south"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) VALUES ( 'CC2650POLL', '["services/south"]');
+INSERT INTO foglamp.scheduled_processes ( name, script ) VALUES ( 'CC2650ASYN', '["services/south"]');
+INSERT INTO foglamp.scheduled_processes ( name, script ) VALUES ( 'HTTP_SOUTH', '["services/south"]');
+INSERT INTO foglamp.scheduled_processes ( name, script ) VALUES ( 'purge', '["tasks/purge"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) VALUES ( 'stats collector', '["tasks/statistics"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) VALUES ( 'sending process', '["tasks/north", "--stream_id", "1", "--debug_level", "1"]' );
 
 -- FogLAMP statistics into PI
-INSERT INTO foglamp.scheduled_processes ( name, script ) values ( 'statistics to pi','["tasks/north", "--stream_id", "2", "--debug_level", "1"]' );
+INSERT INTO foglamp.scheduled_processes ( name, script ) VALUES ( 'statistics to pi','["tasks/north", "--stream_id", "2", "--debug_level", "1"]' );
 
 -- Send readings via HTTP
-INSERT INTO foglamp.scheduled_processes (name, script) values ('sending HTTP', '["tasks/north", "--stream_id", "3", "--debug_level", "1"]');
+INSERT INTO foglamp.scheduled_processes (name, script) VALUES ('sending HTTP', '["tasks/north", "--stream_id", "3", "--debug_level", "1"]');
 
 -- FogLAMP Backup
-INSERT INTO foglamp.scheduled_processes (name, script) values ('backup','["tasks/backup_postgres"]' );
+INSERT INTO foglamp.scheduled_processes (name, script) VALUES ('backup','["tasks/backup_postgres"]' );
 -- FogLAMP Restore
-INSERT INTO foglamp.scheduled_processes (name, script) values ('restore','["tasks/restore_postgres"]' );
+INSERT INTO foglamp.scheduled_processes (name, script) VALUES ('restore','["tasks/restore_postgres"]' );
 
 -- Execute a Backup every 1 hour
--- insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
--- schedule_time, schedule_interval, exclusive)
--- values ('d1631422-9ec6-11e7-abc4-cec278b6b50a', 'backup', 'backup', 3,
--- NULL, '01:00:00', true);
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
+schedule_time, schedule_interval, exclusive, enabled)
+VALUES ('d1631422-9ec6-11e7-abc4-cec278b6b50a', 'backup', 'backup', 3,
+NULL, '01:00:00', true, false);
 
 -- Used to execute an on demand Backup
-insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
-schedule_time, schedule_interval, exclusive)
-values ('fac8dae6-d8d1-11e7-9296-cec278b6b50a', 'backup on demand', 'backup', 4,
-NULL, '00:00:00', true);
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
+schedule_time, schedule_interval, exclusive, enabled)
+VALUES ('fac8dae6-d8d1-11e7-9296-cec278b6b50a', 'backup on demand', 'backup', 4,
+NULL, '00:00:00', true, true);
 
 -- Used to execute an on demand Restore
-insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
-schedule_time, schedule_interval, exclusive)
-values ('8d4d3ca0-de80-11e7-80c1-9a214cf093ae', 'restore on demand', 'restore', 4,
-NULL, '00:00:00', true);
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
+schedule_time, schedule_interval, exclusive, enabled)
+VALUES ('8d4d3ca0-de80-11e7-80c1-9a214cf093ae', 'restore on demand', 'restore', 4,
+NULL, '00:00:00', true, true);
 
 -- Start the south server at start-up
 INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
-schedule_interval, exclusive)
-values ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'south', 'COAP', 1,
-'0:0', true);
+schedule_interval, exclusive, enabled)
+VALUES ('ada12840-68d3-11e7-907b-a6006ad3dba0', 'south', 'COAP', 1,
+'0:0', true, true);
 
 -- Start the Poll mode south server at start-up
-insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
-schedule_interval, exclusive)
-values ('543a59ce-a9ca-11e7-abc4-cec278b6b50a', 'south', 'CC2650POLL', 1,
-'0:0', true);
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
+schedule_interval, exclusive, enabled)
+VALUES ('543a59ce-a9ca-11e7-abc4-cec278b6b50a', 'south', 'CC2650POLL', 1,
+'0:0', true, true);
 
--- Start the South async mode CC2650 Sensortag at start-up
---insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
---schedule_interval, exclusive)
---values ('716a16ea-c736-490b-86d5-10204585ca8c', 'south', 'CC2650ASYN', 1,
---'0:0', true);
+-- Start the async mode CC2650 Sensortag at start-up
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
+schedule_interval, exclusive, enabled)
+VALUES ('716a16ea-c736-490b-86d5-10204585ca8c', 'south', 'CC2650ASYN', 1,
+'0:0', true, false);
 
--- Start the South Poll mode south server at start-up
--- insert into foglamp.schedules(id, schedule_name, process_name, schedule_type,
--- schedule_interval, exclusive)
--- values ('543a59ce-a9ca-11e7-abc4-cec278b6b50a', 'south', 'POLL', 1,
--- '0:0', true);
+-- Start the Poll mode south server at start-up
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
+schedule_interval, exclusive, enabled)
+VALUES ('543a59ce-a9ca-11e7-abc4-cec278b6b50b', 'south', 'POLL', 1,
+'0:0', true, false);
 
-
----- Start the South HTTP Listener at start-up
--- INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
---  schedule_interval, exclusive)
---  values ('a2caca59-1241-478d-925a-79584e7096e0', 'south', 'HTTP_SOUTH', 1,
---  '0:0', true);
+---- Start the south server HTTP Listener at start-up
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
+schedule_interval, exclusive, enabled)
+VALUES ('a2caca59-1241-478d-925a-79584e7096e0', 'south', 'HTTP_SOUTH', 1,
+'0:0', true, false);
 
 -- Run the purge process every 5 minutes
 INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
-schedule_time, schedule_interval, exclusive)
-values ('cea17db8-6ccc-11e7-907b-a6006ad3dba0', 'purge', 'purge', 3,
-NULL, '00:05:00', true);
-
--- Run the statistics collector every 15 seconds
-INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
-schedule_time, schedule_interval, exclusive)
-values ('2176eb68-7303-11e7-8cf7-a6006ad3dba0', 'stats collector', 'stats collector', 3,
-NULL, '00:00:15', true);
+schedule_time, schedule_interval, exclusive, enabled)
+VALUES ('cea17db8-6ccc-11e7-907b-a6006ad3dba0', 'purge', 'purge', 3,
+NULL, '00:05:00', true, true);
 
 -- Run the North sending process every 15 seconds
 INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
-schedule_time, schedule_interval, exclusive)
-values ('2b614d26-760f-11e7-b5a5-be2e44b06b34', 'sending process', 'sending process', 3,
-NULL, '00:00:15', true);
+schedule_time, schedule_interval, exclusive, enabled)
+VALUES ('2b614d26-760f-11e7-b5a5-be2e44b06b34', 'sending process', 'sending process', 3,
+NULL, '00:00:15', true, true);
 
--- Run the North sending process using HTTP north every 15 seconds
--- INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
--- schedule_time, schedule_interval, exclusive)
--- values ('81bdf749-8aa0-468e-b229-9ff695668e8c', 'sending via HTTP', 'sending HTTP', 3,
--- NULL, '00:00:15', true);
+-- Run the statistics collector every 15 seconds
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
+schedule_time, schedule_interval, exclusive, enabled)
+VALUES ('2176eb68-7303-11e7-8cf7-a6006ad3dba0', 'stats collector', 'stats collector', 3,
+NULL, '00:00:15', true, true);
 
 -- Run FogLAMP statistics into PI every 25 seconds
 INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
-schedule_time, schedule_interval, exclusive)
-values ('1d7c327e-7dae-11e7-bb31-be2e44b06b34', 'statistics to pi', 'statistics to pi', 3,
-NULL, '00:00:25', true);
+schedule_time, schedule_interval, exclusive, enabled)
+VALUES ('1d7c327e-7dae-11e7-bb31-be2e44b06b34', 'statistics to pi', 'statistics to pi', 3,
+NULL, '00:00:25', true, true);
+
+-- Run the sending process using HTTP North translator every 15 seconds
+INSERT INTO foglamp.schedules(id, schedule_name, process_name, schedule_type,
+schedule_time, schedule_interval, exclusive, enabled)
+VALUES ('81bdf749-8aa0-468e-b229-9ff695668e8c', 'sending via HTTP', 'sending HTTP', 3,
+NULL, '00:00:15', true, false);
 
 -- OMF north configuration
 INSERT INTO foglamp.destinations(id,description, ts) VALUES (1,'OMF', now());

--- a/python/foglamp/services/core/api/scheduler.py
+++ b/python/foglamp/services/core/api/scheduler.py
@@ -326,7 +326,7 @@ async def enable_schedule(request):
         schedule = {
             'scheduleId': schedule_id,
             'status': status,
-            'reason': reason
+            'message': reason
         }
 
         return web.json_response(schedule)
@@ -357,7 +357,7 @@ async def disable_schedule(request):
         schedule = {
             'scheduleId': schedule_id,
             'status': status,
-            'reason': reason
+            'message': reason
         }
 
         return web.json_response(schedule)

--- a/python/foglamp/services/core/api/scheduler.py
+++ b/python/foglamp/services/core/api/scheduler.py
@@ -321,11 +321,12 @@ async def enable_schedule(request):
         except ValueError as ex:
             raise web.HTTPNotFound(reason="Invalid Schedule ID {}".format(schedule_id))
 
-        status = await server.Server.scheduler.enable_schedule(uuid.UUID(schedule_id))
+        status, reason = await server.Server.scheduler.enable_schedule(uuid.UUID(schedule_id))
 
         schedule = {
             'scheduleId': schedule_id,
-            'status': status
+            'status': status,
+            'reason': reason
         }
 
         return web.json_response(schedule)
@@ -351,11 +352,12 @@ async def disable_schedule(request):
         except ValueError as ex:
             raise web.HTTPNotFound(reason="Invalid Schedule ID {}".format(schedule_id))
 
-        status = await server.Server.scheduler.disable_schedule(uuid.UUID(schedule_id))
+        status, reason = await server.Server.scheduler.disable_schedule(uuid.UUID(schedule_id))
 
         schedule = {
             'scheduleId': schedule_id,
-            'status': status
+            'status': status,
+            'reason': reason
         }
 
         return web.json_response(schedule)

--- a/python/foglamp/services/core/routes.py
+++ b/python/foglamp/services/core/routes.py
@@ -38,6 +38,8 @@ def setup(app):
     app.router.add_route('POST', '/foglamp/schedule', api_scheduler.post_schedule)
     app.router.add_route('GET', '/foglamp/schedule/type', api_scheduler.get_schedule_type)
     app.router.add_route('GET', '/foglamp/schedule/{schedule_id}', api_scheduler.get_schedule)
+    app.router.add_route('PUT', '/foglamp/schedule/{schedule_id}/enable', api_scheduler.enable_schedule)
+    app.router.add_route('PUT', '/foglamp/schedule/{schedule_id}/disable', api_scheduler.disable_schedule)
     app.router.add_route('POST', '/foglamp/schedule/start/{schedule_id}', api_scheduler.start_schedule)
     app.router.add_route('PUT', '/foglamp/schedule/{schedule_id}', api_scheduler.update_schedule)
     app.router.add_route('DELETE', '/foglamp/schedule/{schedule_id}', api_scheduler.delete_schedule)

--- a/python/foglamp/services/core/scheduler/entities.py
+++ b/python/foglamp/services/core/scheduler/entities.py
@@ -37,12 +37,13 @@ class Schedule(object):
         MANUAL = 4
 
     """Schedule base class"""
-    __slots__ = ['schedule_id', 'name', 'process_name', 'exclusive', 'repeat', 'schedule_type']
+    __slots__ = ['schedule_id', 'name', 'process_name', 'exclusive', 'enabled', 'repeat', 'schedule_type']
 
     def __init__(self, schedule_type: Type):
         self.schedule_id = None  # type: uuid.UUID
         self.name = None  # type: str
         self.exclusive = True
+        self.enabled = False
         self.repeat = None  # type: datetime.timedelta
         self.process_name = None  # type: str
         self.schedule_type = schedule_type  # type: Schedule.Type

--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -61,12 +61,12 @@ class Scheduler(object):
     # TODO: Document the fields
     _ScheduleRow = collections.namedtuple('ScheduleRow', ['id', 'name', 'type', 'time', 'day',
                                                           'repeat', 'repeat_seconds', 'exclusive',
-                                                          'process_name'])
+                                                          'enabled', 'process_name'])
     """Represents a row in the schedules table"""
 
     class _TaskProcess(object):
         """Tracks a running task with some flags"""
-        __slots__ = ['task_id', 'process', 'cancel_requested', 'schedule', 'start_time']
+        __slots__ = ['task_id', 'process', 'cancel_requested', 'schedule', 'start_time', 'future']
 
         def __init__(self):
             self.task_id = None  # type: uuid.UUID
@@ -76,6 +76,7 @@ class Scheduler(object):
             self.schedule = None  # Schedule._ScheduleRow
             self.start_time = None  # type: int
             """Epoch time when the task was started"""
+            self.future = None
 
     # TODO: Methods that accept a schedule and look in _schedule_executions
     # should accept schedule_execution instead. Add reference to schedule
@@ -315,6 +316,7 @@ class Scheduler(object):
         task_process.schedule = schedule
         task_process.task_id = task_id
 
+        # All tasks including STARTUP tasks go into both self._task_processes and self._schedule_executions
         self._task_processes[task_id] = task_process
         self._schedule_executions[schedule.id].task_processes[task_id] = task_process
 
@@ -341,7 +343,44 @@ class Scheduler(object):
                 self._logger.exception('Insert failed: %s', insert_payload)
                 # The process has started. Regardless of this error it must be waited on.
 
-        asyncio.ensure_future(self._wait_for_task_completion(task_process))
+        self._task_processes[task_id].future = asyncio.ensure_future(self._wait_for_task_completion(task_process))
+
+    async def purge_tasks(self):
+        """Deletes rows from the tasks table"""
+        if self._paused:
+            return
+
+        if not self._ready:
+            raise NotReadyError()
+
+        delete_payload = PayloadBuilder() \
+            .WHERE(["state", "!=", int(Task.State.RUNNING)]) \
+            .AND_WHERE(["start_time", "<", str(datetime.datetime.now() - self._max_completed_task_age)]) \
+            .LIMIT(self._DELETE_TASKS_LIMIT) \
+            .payload()
+        try:
+            self._logger.debug('Database command: %s', delete_payload)
+            while not self._paused:
+                res = self._storage.delete_from_tbl("tasks", delete_payload)
+                # TODO: Uncomment below when delete count becomes available in storage layer
+                # if res.get("count") < self._DELETE_TASKS_LIMIT:
+                break
+        except Exception:
+            self._logger.exception('Delete failed: %s', delete_payload)
+            raise
+        finally:
+            self._purge_tasks_task = None
+
+        self._last_task_purge_time = time.time()
+
+    def _check_purge_tasks(self):
+        """Schedules :meth:`_purge_tasks` to run if sufficient time has elapsed
+        since it last ran
+        """
+
+        if self._purge_tasks_task is None and (self._last_task_purge_time is None or (
+                    time.time() - self._last_task_purge_time) >= self._PURGE_TASKS_FREQUENCY_SECONDS):
+            self._purge_tasks_task = asyncio.ensure_future(self.purge_tasks())
 
     async def _check_schedules(self):
         """Starts tasks according to schedules based on the current time"""
@@ -360,6 +399,9 @@ class Scheduler(object):
                 # The schedule has been deleted
                 if not schedule_execution.task_processes:
                     del self._schedule_executions[schedule_id]
+                continue
+
+            if schedule.enabled is False:
                 continue
 
             if schedule.exclusive and schedule_execution.task_processes:
@@ -497,6 +539,9 @@ class Scheduler(object):
         For exclusive schedules, this method is called after the task
         has completed.
         """
+        if schedule.enabled is False:
+            return
+
         schedule_execution = self._schedule_executions[schedule.id]
         advance_seconds = schedule.repeat_seconds
 
@@ -551,6 +596,9 @@ class Scheduler(object):
                 when to schedule tasks
 
         """
+        if schedule.enabled is False:
+            return
+
         if schedule.type == Schedule.Type.MANUAL:
             return
 
@@ -629,6 +677,7 @@ class Scheduler(object):
                     repeat=interval,
                     repeat_seconds=repeat_seconds,
                     exclusive=True if row.get('exclusive') == 't' else False,
+                    enabled=True if row.get('enabled') == 't' else False,
                     process_name=row.get('process_name'))
 
                 self._schedules[schedule_id] = schedule
@@ -866,6 +915,7 @@ class Scheduler(object):
 
         schedule.schedule_id = schedule_id
         schedule.exclusive = schedule_row.exclusive
+        schedule.enabled = schedule_row.enabled
         schedule.name = schedule_row.name
         schedule.process_name = schedule_row.process_name
         schedule.repeat = schedule_row.repeat
@@ -966,6 +1016,7 @@ class Scheduler(object):
                      schedule_day=day if day else 0,
                      schedule_time=str(schedule_time) if schedule_time else '00:00:00',
                      exclusive='t' if schedule.exclusive else 'f',
+                     enabled='t' if schedule.enabled else 'f',
                      process_name=schedule.process_name) \
                 .WHERE(['id', '=', str(schedule.schedule_id)]) \
                 .payload()
@@ -987,6 +1038,7 @@ class Scheduler(object):
                         schedule_day=day if day else 0,
                         schedule_time=str(schedule_time) if schedule_time else '00:00:00',
                         exclusive='t' if schedule.exclusive else 'f',
+                        enabled='t' if schedule.enabled else 'f',
                         process_name=schedule.process_name) \
                 .payload()
             try:
@@ -1009,6 +1061,7 @@ class Scheduler(object):
             repeat=schedule.repeat,
             repeat_seconds=repeat_seconds,
             exclusive=schedule.exclusive,
+            enabled=schedule.enabled,
             process_name=schedule.process_name)
 
         self._schedules[schedule.schedule_id] = schedule_row
@@ -1023,6 +1076,168 @@ class Scheduler(object):
             now = self.current_time if self.current_time else time.time()
             self._schedule_first_task(schedule_row, now)
             self._resume_check_schedules()
+
+    async def disable_schedule(self, schedule_id):
+        """
+        Find running Schedule, Terminate running process, Disable Schedule, Update database
+
+        Args: schedule_id:
+        Returns:
+        """
+        # Find running task for the schedule.
+        # self._task_processes contains ALL tasks including STARTUP tasks.
+        try:
+            schedule = await self.get_schedule(schedule_id)
+        except KeyError:
+            self._logger.info("No such Schedule %s", schedule_id)
+            return False
+
+        try:
+            task_id = None
+            for key in list(self._task_processes.keys()):
+                if self._task_processes[key].schedule.id == schedule_id:
+                    task_id = key
+                    break
+            if task_id is None:
+                raise KeyError
+            task_process = self._task_processes[task_id]
+        except KeyError:
+            self._logger.info("No Task running for Schedule %s", schedule_id)
+            return False
+
+        schedule = task_process.schedule
+        if schedule.enabled is False:
+            self._logger.info("Schedule %s already disabled", schedule_id)
+            return True
+
+        # TODO: FOGL-356 track the last time TERM was sent to each task
+        task_process.cancel_requested = time.time()
+
+        # Terminate process
+        del self._schedules[schedule.id]
+        try:
+            # KNOWN ISSUE: Does not work well with microservices e.g. COAP etc
+            # TODO: If schedule is a microservice, then deal with shutdown, unregister etc.
+            task_process.process.terminate()
+            task_future = task_process.future
+            if schedule.type == Schedule.Type.STARTUP and task_future.cancel() is True:
+                await self._wait_for_task_completion(task_process)
+            self._logger.info(
+                "Disabled Schedule '%s/%s' process '%s' task %s pid %s\n%s",
+                schedule.name,
+                schedule.id,
+                schedule.process_name,
+                task_id,
+                task_process.process.pid,
+                self._process_scripts[schedule.process_name])
+        except ProcessLookupError:
+            pass  # Process has terminated
+
+        # Disable Schedule
+        # We need to recreate the _ScheduleRow for just one change - enabled = False. This is required as _ScheduleRow
+        # is of named tuple type which does not allow updation.
+        schedule_row = self._ScheduleRow(
+            id=schedule.id,
+            name=schedule.name,
+            type=schedule.type,
+            time=schedule.time,
+            day=schedule.day,
+            repeat=schedule.repeat,
+            repeat_seconds=schedule.repeat_seconds,
+            exclusive=schedule.exclusive,
+            enabled=False,
+            process_name=schedule.process_name)
+
+        self._schedules[schedule.id] = schedule_row
+
+        # Update database
+        update_payload = PayloadBuilder() \
+            .SET(enabled='f') \
+            .WHERE(['id', '=', str(schedule.id)]) \
+            .payload()
+        try:
+            self._logger.debug('Database command: %s', update_payload)
+            res = self._storage.update_tbl("schedules", update_payload)
+        except Exception:
+            self._logger.exception('Update failed: %s', update_payload)
+            raise RuntimeError('Update failed: %s', update_payload)
+        await asyncio.sleep(1)
+
+        return True
+
+    async def enable_schedule(self, schedule_id):
+        """
+        Get Schedule, Enable Schedule, Update database, Start Schedule
+
+        Args: schedule_id:
+        Returns:
+        """
+        try:
+            schedule = await self.get_schedule(schedule_id)
+        except KeyError:
+            self._logger.info("No such Schedule %s", schedule_id)
+            return False
+
+        if schedule.enabled is True:
+            self._logger.info("Schedule %s already enabled", schedule_id)
+            return True
+
+        # Enable Schedule
+        # We need to recreate the _ScheduleRow for just one change - enabled = True. This is required as _ScheduleRow
+        # is of named tuple type which does not allow updation.
+        if isinstance(schedule, TimedSchedule):
+            schedule_time = schedule.time
+            if schedule_time is not None and not isinstance(schedule_time, datetime.time):
+                raise ValueError('time must be of type datetime.time')
+            day = schedule.day
+            # TODO Remove this check when the database has constraint
+            if day is not None and (day < 1 or day > 7):
+                raise ValueError('day must be between 1 and 7')
+        else:
+            day = None
+            schedule_time = None
+
+        repeat_seconds = None
+        if schedule.repeat is not None:
+            repeat_seconds = schedule.repeat.total_seconds()
+
+        schedule_row = self._ScheduleRow(
+            id=schedule.schedule_id,
+            name=schedule.name,
+            type=schedule.schedule_type,
+            time=schedule_time,
+            day=day,
+            repeat=schedule.repeat,
+            repeat_seconds=repeat_seconds,
+            exclusive=schedule.exclusive,
+            enabled=True,
+            process_name=schedule.process_name)
+
+        del self._schedules[schedule.schedule_id]
+        self._schedules[schedule.schedule_id] = schedule_row
+
+        # Update database
+        update_payload = PayloadBuilder() \
+            .SET(enabled='t') \
+            .WHERE(['id', '=', str(schedule.schedule_id)]) \
+            .payload()
+        try:
+            self._logger.debug('Database command: %s', update_payload)
+            res = self._storage.update_tbl("schedules", update_payload)
+        except Exception:
+            self._logger.exception('Update failed: %s', update_payload)
+            raise RuntimeError('Update failed: %s', update_payload)
+        await asyncio.sleep(1)
+
+        # Start schedule
+        await self.queue_task(schedule_id)
+        self._logger.info(
+            "Enabled Schedule '%s/%s' process '%s'\n",
+            schedule.name,
+            schedule.schedule_id,
+            schedule.process_name)
+
+        return True
 
     async def queue_task(self, schedule_id: uuid.UUID) -> None:
         """Requests a task to be started for a schedule
@@ -1221,41 +1436,3 @@ class Scheduler(object):
             task_process.process.terminate()
         except ProcessLookupError:
             pass  # Process has terminated
-
-    def _check_purge_tasks(self):
-        """Schedules :meth:`_purge_tasks` to run if sufficient time has elapsed
-        since it last ran
-        """
-
-        if self._purge_tasks_task is None and (self._last_task_purge_time is None or (
-                    time.time() - self._last_task_purge_time) >= self._PURGE_TASKS_FREQUENCY_SECONDS):
-            self._purge_tasks_task = asyncio.ensure_future(self.purge_tasks())
-
-    async def purge_tasks(self):
-        """Deletes rows from the tasks table"""
-        if self._paused:
-            return
-
-        if not self._ready:
-            raise NotReadyError()
-
-        delete_payload = PayloadBuilder() \
-            .WHERE(["state", "!=", int(Task.State.RUNNING)]) \
-            .AND_WHERE(["start_time", "<", str(datetime.datetime.now() - self._max_completed_task_age)]) \
-            .LIMIT(self._DELETE_TASKS_LIMIT) \
-            .payload()
-        try:
-            self._logger.debug('Database command: %s', delete_payload)
-            while not self._paused:
-                res = self._storage.delete_from_tbl("tasks", delete_payload)
-                # TODO: Uncomment below when delete count becomes available in storage layer
-                # if res.get("count") < self._DELETE_TASKS_LIMIT:
-                break
-        except Exception:
-            self._logger.exception('Delete failed: %s', delete_payload)
-            raise
-        finally:
-            self._purge_tasks_task = None
-
-        self._last_task_purge_time = time.time()
-

--- a/tests/unit-tests/python/foglamp_test/services/core/api/test_scheduler.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/api/test_scheduler.py
@@ -79,9 +79,9 @@ class TestScheduler:
     def teardown_class(cls):
         # TODO: Separate test db from a production/dev db as other running tasks interfere in the test execution
         # TODO: Figure out how to do a "foglamp stop" in the new dir structure
-        # from subprocess import call
-        # call(["scripts/foglamp", "stop"])
-        # time.sleep(10)
+        from subprocess import call
+        call([_SCRIPTS_DIR + "/foglamp", "stop"])
+        time.sleep(10)
         asyncio.get_event_loop().run_until_complete(delete_master_data())
 
     def setup_method(self):
@@ -118,7 +118,7 @@ class TestScheduler:
 
     async def test_post_schedule(self):
         await add_master_data()
-        data = {"type": 3, "name": "test_post_sch", "process_name": "testsleep30", "repeat": 3600}
+        data = {"type": 3, "name": "test_post_sch", "process_name": "testsleep30", "repeat": 3600, "enabled": "t"}
         r = requests.post(BASE_URL+'/schedule', data=json.dumps(data), headers=headers)
         retval = dict(r.json())
 
@@ -126,6 +126,7 @@ class TestScheduler:
         assert 200 == r.status_code
         assert uuid.UUID(retval['schedule']['id'], version=4)
         assert retval['schedule']['exclusive'] is True
+        assert retval['schedule']['enabled'] is True
         assert retval['schedule']['type'] == Schedule.Type(int(data['type'])).name
         assert retval['schedule']['time'] == 0
         assert retval['schedule']['day'] is None
@@ -141,7 +142,7 @@ class TestScheduler:
 
     async def test_update_schedule(self):
         # First create a schedule to get the schedule_id
-        data = {"type": 3, "name": "test_update_sch", "process_name": "testsleep30", "repeat": 3600}
+        data = {"type": 3, "name": "test_update_sch", "process_name": "testsleep30", "repeat": 3600, "enabled": "t"}
         schedule_id = self._create_schedule(data)
 
         # Secondly, update the schedule
@@ -163,7 +164,7 @@ class TestScheduler:
 
     async def test_delete_schedule(self):
         # First create a schedule to get the schedule_id
-        data = {"type": 3, "name": "test_delete_sch", "process_name": "testsleep30", "repeat": 3600}
+        data = {"type": 3, "name": "test_delete_sch", "process_name": "testsleep30", "repeat": 3600, "enabled": "t"}
         schedule_id = self._create_schedule(data)
 
         # Now check the schedules
@@ -183,7 +184,7 @@ class TestScheduler:
 
     async def test_get_schedule(self):
         # First create a schedule to get the schedule_id
-        data = {"type": 3, "name": "test_get_sch", "process_name": "testsleep30", "repeat": 3600}
+        data = {"type": 3, "name": "test_get_sch", "process_name": "testsleep30", "repeat": 3600, "enabled": "t"}
         schedule_id = self._create_schedule(data)
 
         # Now check the schedule
@@ -193,6 +194,7 @@ class TestScheduler:
         assert 200 == r.status_code
         assert retval['id'] == schedule_id
         assert retval['exclusive'] is True
+        assert retval['enabled'] is True
         assert retval['type'] == Schedule.Type(int(data['type'])).name
         assert retval['time'] == 0
         assert retval['day'] is None
@@ -202,12 +204,12 @@ class TestScheduler:
 
     async def test_get_schedules(self):
         # First create two schedules to get the schedule_id
-        data1 = {"type": 3, "name": "test_get_schA", "process_name": "testsleep30", "repeat": 3600}
+        data1 = {"type": 3, "name": "test_get_schA", "process_name": "testsleep30", "repeat": 3600, "enabled": "t"}
         schedule_id1 = self._create_schedule(data1)
 
         await asyncio.sleep(4)
 
-        data2 = {"type": 2, "name": "test_get_schB", "process_name": "testsleep30", "day": 5, "time": 44500}
+        data2 = {"type": 2, "name": "test_get_schB", "process_name": "testsleep30", "day": 5, "time": 44500, "enabled": "t"}
         schedule_id2 = self._create_schedule(data2)
 
         await asyncio.sleep(4)
@@ -222,7 +224,7 @@ class TestScheduler:
 
     async def test_start_schedule(self):
         # First create a schedule to get the schedule_id
-        data = {"type": 3, "name": "test_start_sch", "process_name": "testsleep30", "repeat": "30"}
+        data = {"type": 3, "name": "test_start_sch", "process_name": "testsleep30", "repeat": "30", "enabled": "t"}
         schedule_id = self._create_schedule(data)
 
         # Now start the schedules
@@ -245,3 +247,41 @@ class TestScheduler:
             if tasks['processName'] == data['process_name']:
                 l_task_state.append(tasks['state'])
         assert 1 == l_task_state.count('RUNNING')
+
+    async def test_enable_schedule(self):
+        # First create a schedule to get the schedule_id
+        data = {"type": 3, "name": "test_enable_sch", "process_name": "testsleep30", "repeat": "30", "enabled": "f"}
+        schedule_id = self._create_schedule(data)
+
+        # Now enable the schedules
+        r = requests.put(BASE_URL+'/schedule/' + schedule_id + '/enable')
+        retval = dict(r.json())
+
+        assert retval['scheduleId'] == schedule_id
+        assert retval['status'] is True
+
+        # Allow sufficient time for task record to be created
+        await asyncio.sleep(4)
+
+    async def test_disable_schedule(self):
+        # First create a schedule to get the schedule_id
+        data = {"type": 3, "name": "test_enable_sch", "process_name": "testsleep30", "repeat": "30", "enabled": "t"}
+        schedule_id = self._create_schedule(data)
+
+        # Now start the schedules
+        r = requests.post(BASE_URL+'/schedule/start/' + schedule_id)
+        retval = dict(r.json())
+
+        assert retval['id'] == schedule_id
+        assert retval['message'] == "Schedule started successfully"
+
+        # Allow sufficient time for task record to be created
+        await asyncio.sleep(4)
+
+        # Now disable the schedules
+        r = requests.put(BASE_URL+'/schedule/' + schedule_id + '/disable')
+        retval = dict(r.json())
+
+        assert retval['scheduleId'] == schedule_id
+        assert retval['status'] is True
+

--- a/tests/unit-tests/python/foglamp_test/services/core/test_scheduler.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/test_scheduler.py
@@ -12,7 +12,7 @@ import uuid
 import aiopg
 import aiopg.sa
 import pytest
-from foglamp.services.core.scheduler.scheduler import Scheduler
+from foglamp.services.core.scheduler.scheduler import Scheduler, _FOGLAMP_ROOT
 from foglamp.services.core.scheduler.entities import IntervalSchedule, Task, Schedule, TimedSchedule, ManualSchedule, \
     StartUpSchedule
 from foglamp.services.core.scheduler.exceptions import ScheduleNotFoundError
@@ -24,13 +24,13 @@ __version__ = "${VERSION}"
 
 _CONNECTION_STRING = "dbname='foglamp' user='foglamp'"
 # TODO: To run this test,
-#       1) Do 'foglamp start' and note the management_port from syslog
+#       1) Do 'scripts/foglamp start' and note the management_port from syslog
 #       2) Change _m_port below with the management_port
 #       3) Execute this command: FOGLAMP_ENV=TEST pytest -s -vv tests/unit-tests/python/foglamp_test/services/core/test_scheduler.py
 
 # TODO: How to eliminate manual intervention as below when tests will run unattended at CI?
 _address = '0.0.0.0'
-_m_port = 45004
+_m_port = 41644
 
 
 @pytest.allure.feature("unit")
@@ -54,17 +54,17 @@ class TestScheduler:
             await conn.execute('delete from foglamp.schedules')
             await conn.execute('delete from foglamp.scheduled_processes')
             await conn.execute(
-                '''insert into foglamp.scheduled_processes(name, script)
-                values('sleep1', '["python3", "../scripts/sleep.py", "1"]')''')
+                "insert into foglamp.scheduled_processes(name, script) values('sleep1', '[\"python3\", " + '"' +
+                _FOGLAMP_ROOT + "/scripts/sleep.py\", \"1\"]')")
             await conn.execute(
-                '''insert into foglamp.scheduled_processes(name, script)
-                values('sleep10', '["python3", "../scripts/sleep.py", "10"]')''')
+                "insert into foglamp.scheduled_processes(name, script) values('sleep10', '[\"python3\",  " +  '"' +
+                _FOGLAMP_ROOT + "/scripts/sleep.py\", \"10\"]')")
             await conn.execute(
-                '''insert into foglamp.scheduled_processes(name, script)
-                values('sleep30', '["python3", "../scripts/sleep.py", "30"]')''')
+                "insert into foglamp.scheduled_processes(name, script) values('sleep30', '[\"python3\", " +  '"' +
+                _FOGLAMP_ROOT + "/scripts/sleep.py\", \"30\"]')")
             await conn.execute(
-                '''insert into foglamp.scheduled_processes(name, script)
-                values('sleep5', '["python3", "../scripts/sleep.py", "5"]')''')
+                "insert into foglamp.scheduled_processes(name, script) values('sleep5', '[\"python3\",  " +  '"' +
+                _FOGLAMP_ROOT + "/scripts/sleep.py\", \"5\"]')")
 
     @staticmethod
     async def stop_scheduler(scheduler: Scheduler) -> None:
@@ -87,6 +87,7 @@ class TestScheduler:
         # Set schedule interval
         interval_schedule = IntervalSchedule()
         interval_schedule.exclusive = False
+        interval_schedule.enabled = True
         interval_schedule.name = 'sleep1'
         interval_schedule.process_name = "sleep1"
         interval_schedule.repeat = datetime.timedelta(seconds=1)  # Set frequency of
@@ -114,6 +115,7 @@ class TestScheduler:
         interval_schedule.name = 'sleep10'
         interval_schedule.process_name = "sleep10"
         interval_schedule.repeat = datetime.timedelta(seconds=0)
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)
 
@@ -147,6 +149,7 @@ class TestScheduler:
         interval_schedule.name = 'sleep10'
         interval_schedule.process_name = "sleep10"
         interval_schedule.repeat = datetime.timedelta(seconds=1)
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)
 
@@ -165,6 +168,7 @@ class TestScheduler:
         interval_schedule.name = 'sleep10'
         interval_schedule.process_name = 'sleep10'
         interval_schedule.repeat = datetime.timedelta(seconds=0)
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)
 
@@ -173,6 +177,7 @@ class TestScheduler:
         manual_schedule.name = 'manual'
         manual_schedule.process_name = 'sleep10'
         manual_schedule.repeat = datetime.timedelta(seconds=0)
+        manual_schedule.enabled = True
 
         await scheduler.save_schedule(manual_schedule)
 
@@ -199,6 +204,7 @@ class TestScheduler:
         interval_schedule.name = 'sleep10'
         interval_schedule.process_name = "sleep10"
         interval_schedule.repeat = datetime.timedelta(seconds=0)
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)  # Save update on _scheduler
 
@@ -211,6 +217,7 @@ class TestScheduler:
         interval_schedule.name = 'updated'
         interval_schedule.process_name = "sleep1"
         interval_schedule.repeat = datetime.timedelta(seconds=5)  # Set time interval to 5 sec
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)  # Save update on _scheduler
         await asyncio.sleep(6)
@@ -254,6 +261,7 @@ class TestScheduler:
         startup_schedule.name = 'startup schedule'
         startup_schedule.process_name = 'sleep30'
         startup_schedule.repeat = datetime.timedelta(seconds=0)  # set no repeat to startup
+        startup_schedule.enabled = True
 
         await scheduler.save_schedule(startup_schedule)
 
@@ -309,6 +317,7 @@ class TestScheduler:
         manual_schedule.name = 'manual task'
         manual_schedule.process_name = 'sleep10'
         manual_schedule.repeat = datetime.timedelta(seconds=0)
+        manual_schedule.enabled = True
 
         await scheduler.save_schedule(manual_schedule)
         manual_schedule = await scheduler.get_schedule(manual_schedule.schedule_id)
@@ -352,6 +361,7 @@ class TestScheduler:
         interval_schedule.name = 'max active'
         interval_schedule.exclusive = False
         interval_schedule.process_name = 'sleep10'
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)
 
@@ -398,6 +408,7 @@ class TestScheduler:
         timed_schedule.day = 2
         timed_schedule.time = datetime.time(hour=8)
         timed_schedule.repeat = datetime.timedelta(seconds=0)
+        timed_schedule.enabled = True
 
         # Set env timezone
         os.environ["TZ"] = "PST8PDT"
@@ -439,6 +450,7 @@ class TestScheduler:
         interval_schedule.name = 'deletetest'
         interval_schedule.process_name = "sleep1"
         interval_schedule.repeat = datetime.timedelta(seconds=0)
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)
 
@@ -468,6 +480,7 @@ class TestScheduler:
         interval_schedule.name = 'cancel_test'
         interval_schedule.process_name = 'sleep30'
         interval_schedule.repeat = datetime.timedelta(seconds=0)
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)
 
@@ -493,6 +506,7 @@ class TestScheduler:
         interval_schedule.name = 'get_schedule_test'
         interval_schedule.process_name = "sleep30"
         interval_schedule.repeat = datetime.timedelta(seconds=0)
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)
 
@@ -526,6 +540,7 @@ class TestScheduler:
         interval_schedule.name = 'get_task'
         interval_schedule.process_name = "sleep30"
         interval_schedule.repeat = datetime.timedelta(seconds=0)
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)
         await asyncio.sleep(1)
@@ -558,6 +573,7 @@ class TestScheduler:
         interval_schedule.process_name = "sleep5"
         interval_schedule.repeat = datetime.timedelta(seconds=1)
         interval_schedule.exclusive = False
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)
 
@@ -592,12 +608,12 @@ class TestScheduler:
             sort=[["state", "desc"], ["start_time", "asc"]])
         assert tasks
 
-        tasks = await scheduler.get_tasks(or_where_list=[["state", "=", int(Task.State.RUNNING)], \
-                                                         ["state", "=", int(Task.State.RUNNING)]])
+        tasks = await scheduler.get_tasks(
+            or_where=[["state", "=", int(Task.State.RUNNING)], ["state", "=", int(Task.State.RUNNING)]])
         assert tasks
 
-        tasks = await scheduler.get_tasks(and_where_list=[["state", "=", int(Task.State.RUNNING)], \
-                                                          ["state", "=", int(Task.State.RUNNING)]])
+        tasks = await scheduler.get_tasks(
+            and_where=[["state", "=", int(Task.State.RUNNING)], ["state", "=", int(Task.State.RUNNING)]])
         assert tasks
 
         await self.stop_scheduler(scheduler)
@@ -614,6 +630,7 @@ class TestScheduler:
         interval_schedule.process_name = "sleep5"
         interval_schedule.repeat = datetime.timedelta(seconds=0)
         # interval_schedule.repeat = datetime.timedelta(seconds=30)
+        interval_schedule.enabled = True
 
         await scheduler.save_schedule(interval_schedule)
 
@@ -630,3 +647,101 @@ class TestScheduler:
         tasks = await scheduler.get_tasks(5)
         assert not tasks
         await self.stop_scheduler(scheduler)
+
+    @pytest.mark.asyncio
+    async def test_enable_schedule(self):
+        await self.populate_test_data()  # Populate data in foglamp.scheduled_processes
+
+        scheduler = Scheduler(_address, _m_port)
+        await scheduler.start()
+
+        # Declare schedule
+        interval_schedule = IntervalSchedule()
+        interval_schedule.name = 'enable_schedule_test'
+        interval_schedule.process_name = "sleep5"
+        interval_schedule.repeat = datetime.timedelta(seconds=0)
+        interval_schedule.enabled = False
+
+        await scheduler.save_schedule(interval_schedule)
+
+        # Get schedule
+        schedules = await scheduler.get_schedules()
+        assert len(schedules) == 1  # Assert the number of schedules
+        assert schedules[0].enabled is False
+
+        # Enable Schedule
+        retval = await scheduler.enable_schedule(interval_schedule.schedule_id)
+        assert retval
+
+        # Confirm enabled changed
+        schedules = await scheduler.get_schedules()
+        assert len(schedules) == 1  # Assert the number of schedules
+        assert schedules[0].enabled is True
+
+        await asyncio.sleep(5)
+
+        # assert there exists a task
+        tasks = await scheduler.get_running_tasks()  # retrieve list running tasks
+        assert len(tasks)
+
+        task = await scheduler.get_task(tasks[0].task_id)
+        assert task
+
+        await self.stop_scheduler(scheduler)
+
+    @pytest.mark.asyncio
+    async def test_enable_schedule_wrong_schedule_id(self):
+        with pytest.raises(ScheduleNotFoundError) as excinfo:
+            scheduler = Scheduler(_address, _m_port)
+            await scheduler.start()
+            random_schedule_id = uuid.uuid4()
+            await scheduler.enable_schedule(random_schedule_id)
+
+    @pytest.mark.asyncio
+    async def test_disable_schedule(self):
+        await self.populate_test_data()  # Populate data in foglamp.scheduled_processes
+
+        scheduler = Scheduler(_address, _m_port)
+        await scheduler.start()
+
+        # Declare schedule
+        interval_schedule = IntervalSchedule()
+        interval_schedule.name = 'disable_schedule_test'
+        interval_schedule.process_name = "sleep5"
+        interval_schedule.repeat = datetime.timedelta(seconds=0)
+        interval_schedule.enabled = True
+
+        await scheduler.save_schedule(interval_schedule)
+
+        # Get schedule
+        schedules = await scheduler.get_schedules()
+        assert len(schedules) == 1  # Assert the number of schedules
+        assert schedules[0].enabled is True
+
+        await asyncio.sleep(5)
+
+        # assert there exists a task
+        tasks = await scheduler.get_running_tasks()  # retrieve list running tasks
+        assert len(tasks)
+
+        task = await scheduler.get_task(tasks[0].task_id)
+        assert task
+
+        # Disable Schedule
+        retval = await scheduler.disable_schedule(interval_schedule.schedule_id)
+        assert retval
+
+        # Confirm enabled changed
+        schedules = await scheduler.get_schedules()
+        assert len(schedules) == 1  # Assert the number of schedules
+        assert schedules[0].enabled is False
+
+        await self.stop_scheduler(scheduler)
+
+    @pytest.mark.asyncio
+    async def test_disable_schedule_wrong_schedule_id(self):
+        with pytest.raises(ScheduleNotFoundError) as excinfo:
+            scheduler = Scheduler(_address, _m_port)
+            await scheduler.start()
+            random_schedule_id = uuid.uuid4()
+            await scheduler.disable_schedule(random_schedule_id)

--- a/tests/unit-tests/python/foglamp_test/services/core/test_scheduler.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/test_scheduler.py
@@ -30,7 +30,7 @@ _CONNECTION_STRING = "dbname='foglamp' user='foglamp'"
 
 # TODO: How to eliminate manual intervention as below when tests will run unattended at CI?
 _address = '0.0.0.0'
-_m_port = 41644
+_m_port = 46000
 
 
 @pytest.allure.feature("unit")
@@ -670,7 +670,7 @@ class TestScheduler:
         assert schedules[0].enabled is False
 
         # Enable Schedule
-        retval = await scheduler.enable_schedule(interval_schedule.schedule_id)
+        retval, reason = await scheduler.enable_schedule(interval_schedule.schedule_id)
         assert retval
 
         # Confirm enabled changed
@@ -728,7 +728,7 @@ class TestScheduler:
         assert task
 
         # Disable Schedule
-        retval = await scheduler.disable_schedule(interval_schedule.schedule_id)
+        retval, reason = await scheduler.disable_schedule(interval_schedule.schedule_id)
         assert retval
 
         # Confirm enabled changed

--- a/tests/unit-tests/python/foglamp_test/services/core/test_scheduler_get_tasks.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/test_scheduler_get_tasks.py
@@ -56,7 +56,7 @@ _TASKS_TABLE = sqlalchemy.Table('tasks', sqlalchemy.MetaData(),
                                        sqlalchemy.Column('reason', sqlalchemy.types.VARCHAR(255)))
 
 # TODO: To run this test,
-#       1) Do 'foglamp start' and note the management_port from syslog
+#       1) Do 'scripts/foglamp start' and note the management_port from syslog
 #       2) Change _m_port below with the management_port
 #       3) Execute this command: FOGLAMP_ENV=TEST pytest -s -vv tests/unit-tests/python/foglamp_test/services/core/test_scheduler_get_tasks.py
 


### PR DESCRIPTION
- Manually tested OK. Task related schedules being successfully enabled and disabled. Service related schedules being enabled successfully but need fixes for disabling as it requires services shutdown and unregister etc. This is blocked by **FOGL-755**.

- Automated tests ~~pending~~ added.

- Pending Testing with 

    - [ ] "sudo make install", 

   - [ ] "snap"

   - [ ] and on RPi pending. 