### PR TITLE
FOGL-858 (Part-A)

### DIFF
--- a/python/foglamp/common/web/middleware.py
+++ b/python/foglamp/common/web/middleware.py
@@ -23,12 +23,8 @@ async def error_middleware(app, handler):
 
         try:
             response = await handler(request)
-            if response.status == 404:
-                return handle_api_exception({"code": response.status, "message": response.message}, ex.__class__.__name__, if_trace)
             return response
-        except (web.HTTPNotFound, web.HTTPBadRequest) as ex:
-            return handle_api_exception({"code": ex.status_code, "message": ex.reason}, ex.__class__.__name__, if_trace)
-        except web.HTTPException as ex:
+        except (web.HTTPException, web.HTTPBadRequest, web.HTTPNotFound) as ex:
             raise
         # Below Exception must come last as it is the super class of all exceptions
         except Exception as ex:

--- a/python/foglamp/services/core/api/backup_restore.py
+++ b/python/foglamp/services/core/api/backup_restore.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 
 from foglamp.services.core import connect
 from foglamp.plugins.storage.postgres.backup_restore.backup_postgres import Backup
-from foglamp.plugins.storage.postgres.backup_restore.restore_postgres import Restore
+# from foglamp.plugins.storage.postgres.backup_restore.restore_postgres import Restore
 from foglamp.plugins.storage.postgres.backup_restore import exceptions
 
 
@@ -25,11 +25,12 @@ __DEFAULT_LIMIT = 20
 __DEFAULT_OFFSET = 0
 
 _help = """
-    -----------------------------------------------------------------------------------
+    ------------------------------------------------------------------------------------
     | GET, POST       | /foglamp/backup                                                |
     | GET, DELETE     | /foglamp/backup/{backup-id}                                    |
     | PUT             | /foglamp/backup/{backup-id}/restore                            |
-    -----------------------------------------------------------------------------------
+    | GET             | /foglamp/backup/status                                         |
+    ------------------------------------------------------------------------------------
 """
 
 
@@ -37,10 +38,16 @@ class Status(IntEnum):
     """Enumeration for backup.status"""
     RUNNING = 1
     COMPLETED = 2
-    CANCELLED = 3
+    CANCELED = 3
     INTERRUPTED = 4
     FAILED = 5
     RESTORED = 6
+
+
+def _get_status(status_code):
+    if status_code not in range(1, 7):
+        return "UNKNOWN"
+    return Status(status_code).name
 
 
 async def get_backups(request):
@@ -50,25 +57,29 @@ async def get_backups(request):
     :Example: curl -X GET http://localhost:8081/foglamp/backup?limit=2&skip=1&status=completed
     """
     limit = __DEFAULT_LIMIT
-    if 'limit' in request.query:
+    if 'limit' in request.query and request.query['limit'] != '':
         try:
             limit = int(request.query['limit'])
+            if limit < 0:
+                raise ValueError
         except ValueError:
-            raise web.HTTPBadRequest(reason="limit must be an integer")
+            raise web.HTTPBadRequest(reason="Limit must be a positive integer")
 
     skip = __DEFAULT_OFFSET
-    if 'skip' in request.query:
+    if 'skip' in request.query and request.query['skip'] != '':
         try:
             skip = int(request.query['skip'])
+            if skip < 0:
+                raise ValueError
         except ValueError:
-            raise web.HTTPBadRequest(reason="skip must be an integer")
+            raise web.HTTPBadRequest(reason="Skip/Offset must be a positive integer")
 
     status = None
-    if 'status' in request.query:
+    if 'status' in request.query and request.query['status'] != '':
         try:
             status = Status[request.query['status'].upper()].value
         except KeyError as ex:
-            raise web.HTTPBadRequest(reason="{} not a valid status".format(ex))
+            raise web.HTTPBadRequest(reason="{} is not a valid status".format(ex))
     try:
         backup = Backup(connect.get_storage())
         backup_json = backup.get_all_backups(limit=limit, skip=skip, status=status)
@@ -150,12 +161,6 @@ async def delete_backup(request):
         raise web.HTTPException(reason=str(ex))
 
 
-def _get_status(status_code):
-    if status_code not in range(1, 7):
-        return "UNKNOWN"
-    return Status(status_code).name
-
-
 async def restore_backup(request):
     """
     Restore from a backup
@@ -164,20 +169,38 @@ async def restore_backup(request):
 
     raise web.HTTPNotImplemented(reason='Restore backup method is not implemented yet.')
 
-    backup_id = request.match_info.get('backup_id', None)
+    # TODO: FOGL-861
+    # backup_id = request.match_info.get('backup_id', None)
+    #
+    # if not backup_id:
+    #     raise web.HTTPBadRequest(reason='Backup id is required')
+    #
+    # try:
+    #     backup_id = int(backup_id, 10)
+    #     restore = Restore(connect.get_storage())
+    #     status = restore.restore_backup(backup_id)
+    #     return web.json_response({'status': status})
+    # except ValueError:
+    #     raise web.HTTPBadRequest(reason='Invalid backup id')
+    # except exceptions.DoesNotExist:
+    #     raise web.HTTPNotFound(reason='Backup with {} does not exist'.format(backup_id))
+    # except Exception as ex:
+    #     raise web.HTTPException(reason=str(ex))
 
-    if not backup_id:
-        raise web.HTTPBadRequest(reason='Backup id is required')
 
-    try:
-        backup_id = int(backup_id, 10)
-        # TODO: FOGL-861
-        # restore = Restore(connect.get_storage())
-        # status = restore.restore_backup(backup_id)
-        # return web.json_response({'status': status})
-    except ValueError:
-        raise web.HTTPBadRequest(reason='Invalid backup id')
-    except exceptions.DoesNotExist:
-        raise web.HTTPNotFound(reason='Backup with {} does not exist'.format(backup_id))
-    except Exception as ex:
-        raise web.HTTPException(reason=str(ex))
+async def get_backup_status(request):
+    """
+
+    Returns:
+           an array of backup status enumeration key index values
+
+    :Example:
+
+        curl -X GET http://localhost:8081/foglamp/backup/status
+    """
+    results = []
+    for _status in Status:
+        data = {'index': _status.value, 'name': _status.name}
+        results.append(data)
+
+    return web.json_response({"backupStatus": results})

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -15,7 +15,7 @@ __version__ = "${VERSION}"
 
 _help = """
     -------------------------------------------------------------------------------
-    | GET             | /foglamp/categories                                       |
+    | GET             | /foglamp/category                                         |
     | GET             | /foglamp/category/{category_name}                         |
     | GET PUT         | /foglamp/category/{category_name}/{config_item}           |
     | DELETE          | /foglamp/category/{category_name}/{config_item}/value     |
@@ -60,14 +60,14 @@ async def get_category(request):
     category_name = request.match_info.get('category_name', None)
 
     if not category_name:
-        raise web.HTTPBadRequest(reason="Category Name is required")
+        raise web.HTTPBadRequest(reason="Category name is required")
 
     # TODO: make it optimized and elegant
     cf_mgr = ConfigurationManager(connect.get_storage())
     category = await cf_mgr.get_category_all_items(category_name)
 
     if category is None:
-        raise web.HTTPNotFound(reason="No such Category Found for {}".format(category_name))
+        raise web.HTTPNotFound(reason="No such Category found for {}".format(category_name))
 
     return web.json_response(category)
 
@@ -87,14 +87,14 @@ async def get_category_item(request):
     config_item = request.match_info.get('config_item', None)
 
     if not category_name or not config_item:
-        raise web.HTTPBadRequest(reason="Both Category Name and Config items are required")
+        raise web.HTTPBadRequest(reason="Both Category name and Config items are required")
 
     # TODO: make it optimized and elegant
     cf_mgr = ConfigurationManager(connect.get_storage())
     category_item = await cf_mgr.get_category_item(category_name, config_item)
 
     if category_item is None:
-        raise web.HTTPNotFound(reason="No Category Item Found")
+        raise web.HTTPNotFound(reason="No Category item found")
 
     return web.json_response(category_item)
 
@@ -154,7 +154,7 @@ async def delete_configuration_item_value(request):
     config_item = request.match_info.get('config_item', None)
 
     if not category_name or not config_item:
-        raise web.HTTPBadRequest(reason="Both Category Name and Config items are required")
+        raise web.HTTPBadRequest(reason="Both Category name and Config items are required")
 
     # TODO: make it optimized and elegant
     cf_mgr = ConfigurationManager(connect.get_storage())

--- a/python/foglamp/services/core/api/statistics.py
+++ b/python/foglamp/services/core/api/statistics.py
@@ -61,9 +61,11 @@ async def get_statistics_history(request):
     storage_client = connect.get_storage()
     payload = PayloadBuilder().SELECT(("history_ts", "key", "value")).payload()
 
-    if 'limit' in request.query:
-        if request.query.get('limit').isdigit():
-            limit = int(request.query.get('limit'))
+    if 'limit' in request.query and request.query['limit'] != '':
+        try:
+            limit = int(request.query['limit'])
+            if limit < 0:
+                raise ValueError
             # FIXME: Hack straight away multiply the LIMIT by the group count
             # i.e. there are 8 records per distinct (stats_key), so if limit supplied is 2
             # then internally, we should calculate LIMIT *8
@@ -76,8 +78,9 @@ async def get_statistics_history(request):
             key_count = result['rows'][0]['count_*']
 
             payload = PayloadBuilder().SELECT(("history_ts", "key", "value")).LIMIT(limit * key_count).payload()
-        else:
-            raise web.HTTPBadRequest(reason="limit must be an integer")
+
+        except ValueError:
+            raise web.HTTPBadRequest(reason="Limit must be a positive integer")
 
     result_from_storage = storage_client.query_tbl_with_payload('statistics_history', payload)
 
@@ -111,8 +114,11 @@ async def get_statistics_history(request):
     # SELECT schedule_interval FROM schedules WHERE process_name='stats collector'
     payload = PayloadBuilder().SELECT("schedule_interval").WHERE(['process_name', '=', 'stats collector']).payload()
     result = storage_client.query_tbl_with_payload('schedules', payload)
-    time_str = result['rows'][0]['schedule_interval']
-    ftr = [3600, 60, 1]
-    interval_in_secs = sum([a * b for a, b in zip(ftr, map(int, time_str.split(':')))])
+    if len(result['rows']) > 0:
+        time_str = result['rows'][0]['schedule_interval']
+        ftr = [3600, 60, 1]
+        interval_in_secs = sum([a * b for a, b in zip(ftr, map(int, time_str.split(':')))])
+    else:
+        raise web.HTTPBadRequest(reason="No schedules")
 
     return web.json_response({"interval": interval_in_secs, 'statistics': results})

--- a/python/foglamp/services/core/routes.py
+++ b/python/foglamp/services/core/routes.py
@@ -22,7 +22,7 @@ def setup(app):
     app.router.add_route('GET', '/foglamp/ping', api_common.ping)
 
     # Configuration
-    app.router.add_route('GET', '/foglamp/categories', api_configuration.get_categories)
+    app.router.add_route('GET', '/foglamp/category', api_configuration.get_categories)
     app.router.add_route('GET', '/foglamp/category/{category_name}', api_configuration.get_category)
     app.router.add_route('GET', '/foglamp/category/{category_name}/{config_item}', api_configuration.get_category_item)
     app.router.add_route('PUT', '/foglamp/category/{category_name}/{config_item}', api_configuration.set_configuration_item)
@@ -63,6 +63,7 @@ def setup(app):
     # Backup & Restore - As per doc
     app.router.add_route('GET', '/foglamp/backup', backup_restore.get_backups)
     app.router.add_route('POST', '/foglamp/backup', backup_restore.create_backup)
+    app.router.add_route('GET', '/foglamp/backup/status', backup_restore.get_backup_status)
     app.router.add_route('GET', '/foglamp/backup/{backup_id}', backup_restore.get_backup_details)
     app.router.add_route('DELETE', '/foglamp/backup/{backup_id}', backup_restore.delete_backup)
     app.router.add_route('PUT', '/foglamp/backup/{backup_id}/restore', backup_restore.restore_backup)

--- a/tests/unit-tests/python/foglamp_test/services/core/api/test_statistics.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/api/test_statistics.py
@@ -56,8 +56,8 @@ class TestStatistics:
         # curl -X GET http://localhost:8081/foglamp/statistics
         r = requests.get(BASE_URL+'/statistics')
         res = r.json()
-        assert 200 == r.status_code
-        assert 9 == len(res)
+        assert r.status_code == 200
+        assert len(res) == 9
 
         # sorted by key
         assert res[0]['key'] == 'BUFFERED'
@@ -102,8 +102,8 @@ class TestStatistics:
         r = requests.get(BASE_URL + '/statistics')
         res = r.json()
 
-        assert 200 == r.status_code
-        assert 9 == len(res)
+        assert r.status_code == 200
+        assert len(res) == 9
 
         assert res[3]['key'] == 'READINGS'
         assert res[3]['value'] == 3
@@ -116,8 +116,8 @@ class TestStatistics:
         r = requests.get(BASE_URL + '/statistics')
         res = r.json()
 
-        assert 200 == r.status_code
-        assert 10 == len(res)
+        assert r.status_code == 200
+        assert len(res) == 10
 
         # READINGS_X must exists IN keys
         key_entries = [keys["key"] for keys in res]

--- a/tests/unit-tests/python/foglamp_test/services/core/api/test_statistics_history.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/api/test_statistics_history.py
@@ -6,7 +6,7 @@
 
 import asyncpg
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime
 import requests
 import pytest
 
@@ -142,7 +142,11 @@ class TestStatisticsHistory:
 
         assert is_greater_time is True
 
-    async def test_get_statistics_history_limit_with_bad_data(self):
-        r = requests.get(BASE_URL + '/statistics/history?limit=x')
-        res = r.json()
-        assert 400 == res['error']['code']
+    @pytest.mark.parametrize("request_params, response_code, response_message", [
+        ('?limit=invalid', 400, "Limit must be a positive integer"),
+        ('?limit=-1', 400, "Limit must be a positive integer")
+    ])
+    async def test_get_statistics_history_limit_with_bad_data(self, request_params, response_code, response_message):
+        r = requests.get(BASE_URL + '/statistics/history{}'.format(request_params))
+        assert response_code == r.status_code
+        assert response_message == r.reason


### PR DESCRIPTION
- [x] audit.py
- [x] backup_restore.py
- [x] browser.py
- [ ] common.py --- **_No ACTION required_**
- [x] configuration.py
- [ ] scheduler.py -- **To avoid conflicts, will take up later once https://github.com/foglamp/FogLAMP/pull/411 merged**
- [x] statistics.py


**TESTS O/P**
- [x] test_audit.py
```
collected 22 items 

test_audit.py::TestAudit::test_get_severity PASSED
test_audit.py::TestAudit::test_get_log_codes PASSED
test_audit.py::TestAudit::test_get_audit_with_params[-6-6] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[?skip=1-6-5] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[?source=PURGE-4-4] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[?source=PURGE&severity=error-3-3] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[?source=PURGE&severity=ERROR&limit=1-3-1] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[?source=PURGE&severity=INFORMATION&limit=1&skip=1-1-0] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[?source=LOGGN&severity=FATAL-0-0] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[?source=&severity=&limit=&skip=-6-6] PASSED
test_audit.py::TestAudit::test_params_with_bad_data[?limit=invalid-400-Limit must be a positive integer] PASSED
test_audit.py::TestAudit::test_params_with_bad_data[?limit=-1-400-Limit must be a positive integer] PASSED
test_audit.py::TestAudit::test_params_with_bad_data[?skip=invalid-400-Skip/Offset must be a positive integer] PASSED
test_audit.py::TestAudit::test_params_with_bad_data[?skip=-1-400-Skip/Offset must be a positive integer] PASSED
test_audit.py::TestAudit::test_params_with_bad_data[?severity=BLA-400-'BLA' is not a valid severity] PASSED
test_audit.py::TestAudit::test_params_with_bad_data[?source=blah-400-blah is not a valid source] PASSED
test_audit.py::TestAudit::test_post_audit SKIPPED
test_audit.py::TestAudit::test_get_all_notifications SKIPPED
test_audit.py::TestAudit::test_get_notification SKIPPED
test_audit.py::TestAudit::test_post_notification SKIPPED
test_audit.py::TestAudit::test_update_notification SKIPPED
test_audit.py::TestAudit::test_delete_notification SKIPPED

===== 16 passed, 6 skipped in 0.67 seconds ====
```
- [x] test_backup_restore.py
```
collected 19 items 

test_backup_restore.py::TestBackup::test_get_backups[-4-exp_output0] PASSED
test_backup_restore.py::TestBackup::test_get_backups[?limit=1-1-exp_output1] PASSED
test_backup_restore.py::TestBackup::test_get_backups[?skip=3-1-exp_output2] PASSED
test_backup_restore.py::TestBackup::test_get_backups[?limit=2&skip=1-2-exp_output3] PASSED
test_backup_restore.py::TestBackup::test_get_backups[?status=failed-1-exp_output4] PASSED
test_backup_restore.py::TestBackup::test_get_backups[?limit=2&skip=1&status=completed-1-exp_output5] PASSED
test_backup_restore.py::TestBackup::test_get_backups[?limit=&skip=&status=-4-exp_output6] PASSED
test_backup_restore.py::TestBackup::test_get_backups_invalid[?limit=invalid-400-Limit must be a positive integer] PASSED
test_backup_restore.py::TestBackup::test_get_backups_invalid[?limit=-10-400-Limit must be a positive integer] PASSED
test_backup_restore.py::TestBackup::test_get_backups_invalid[?skip=invalid-400-Skip/Offset must be a positive integer] PASSED
test_backup_restore.py::TestBackup::test_get_backups_invalid[?skip=-1-400-Skip/Offset must be a positive integer] PASSED
test_backup_restore.py::TestBackup::test_get_backups_invalid[?status=invalid-400-'INVALID' is not a valid status] PASSED
test_backup_restore.py::TestBackup::test_get_backup_details[request_params0-output0] PASSED
test_backup_restore.py::TestBackup::test_get_backup_details_invalid[invalid-400-Invalid backup id] PASSED
test_backup_restore.py::TestBackup::test_get_backup_details_invalid[-1-404-Backup with -1 does not exist] PASSED
test_backup_restore.py::TestBackup::test_create_backup SKIPPED
test_backup_restore.py::TestBackup::test_delete_backup SKIPPED
test_backup_restore.py::TestBackup::test_get_backup_status PASSED
test_backup_restore.py::TestRestore::test_restore SKIPPED

=== 16 passed, 3 skipped in 0.41 seconds ===
```
- [x] test_browser_assets.py
```
collected 38 items 

test_browser_assets.py::TestBrowseAssets::test_get_all_assets PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_limit PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_sec PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_min PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_hrs PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_time_complex PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_with_empty_params PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_limit PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_sec PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_min PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_hrs PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_time_complex PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_sec xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_min xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_hrs xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_time_complex xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_invalid_group PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_sec xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_min xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_hrs xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_limit_group_hrs xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_time xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_time_limit xfail
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?limit=invalid-400-Limit must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?limit=-1-400-Limit must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?skip=invalid-400-Skip/Offset must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?skip=-1-400-Skip/Offset must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?minutes=-1-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?minutes=blah-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?seconds=-1-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?seconds=blah-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?hours=-1-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?hours=blah-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_error_when_no_rows_key_available PASSED

==== 26 passed, 12 xfailed in 0.96 seconds ====
```
- [x] test_configuration.py
```
collected 10 items 

test_configuration.py::TestConfigMgr::test_get_categories PASSED
test_configuration.py::TestConfigMgr::test_get_category PASSED
test_configuration.py::TestConfigMgr::test_get_invalid_category PASSED
test_configuration.py::TestConfigMgr::test_get_invalid_category_item SKIPPED
test_configuration.py::TestConfigMgr::test_get_category_item PASSED
test_configuration.py::TestConfigMgr::test_set_category_item_value PASSED
test_configuration.py::TestConfigMgr::test_edit_category_item_value PASSED
test_configuration.py::TestConfigMgr::test_unset_config_item PASSED
test_configuration.py::TestConfigMgr::test_merge_category SKIPPED
test_configuration.py::TestConfigMgr::test_check_error_code_message PASSED

===== 8 passed, 2 skipped in 0.19 seconds ====
```
- [x] test_statistics_history.py
```
collected 4 items 

test_statistics_history.py::TestStatisticsHistory::test_get_statistics_history PASSED
test_statistics_history.py::TestStatisticsHistory::test_get_statistics_history_with_limit PASSED
test_statistics_history.py::TestStatisticsHistory::test_get_statistics_history_limit_with_bad_data[?limit=invalid-400-Limit must be a positive integer] PASSED
test_statistics_history.py::TestStatisticsHistory::test_get_statistics_history_limit_with_bad_data[?limit=-1-400-Limit must be a positive integer] PASSED

=== 4 passed in 45.30 seconds ===
```
- [x] test_statistics.py
```
collected 3 items 

test_statistics.py::TestStatistics::test_get_statistics PASSED
test_statistics.py::TestStatistics::test_get_updated_statistics PASSED
test_statistics.py::TestStatistics::test_get_statistics_with_new_key_entry PASSED

==== 3 passed in 0.20 seconds ====
```
  