### PR TITLE
task json response fixes as per 792 with their REST Api tests

### DIFF
--- a/python/foglamp/services/core/api/scheduler.py
+++ b/python/foglamp/services/core/api/scheduler.py
@@ -484,8 +484,8 @@ async def get_task(request):
 
         task = {
             'id': str(tsk.task_id),
-            'processName': tsk.process_name,
-            'state': Task.State(int(tsk.state)).name,
+            'name': tsk.process_name,
+            'state': Task.State(int(tsk.state)).name.capitalize(),
             'startTime': str(tsk.start_time),
             'endTime': str(tsk.end_time),
             'exitCode': tsk.exit_code,
@@ -546,8 +546,8 @@ async def get_tasks(request):
         for task in tasks:
             new_tasks.append(
                 {'id': str(task.task_id),
-                 'processName': task.process_name,
-                 'state': Task.State(int(task.state)).name,
+                 'name': task.process_name,
+                 'state': Task.State(int(task.state)).name.capitalize(),
                  'startTime': str(task.start_time),
                  'endTime': str(task.end_time),
                  'exitCode': task.exit_code,
@@ -595,8 +595,8 @@ async def get_tasks_latest(request):
         for task in tasks:
             new_tasks.append(
                 {'id': str(task['id']),
-                 'processName': task['process_name'],
-                 'state': [t.name for t in list(Task.State)][int(task['state']) - 1],
+                 'name': task['process_name'],
+                 'state': [t.name.capitalize() for t in list(Task.State)][int(task['state']) - 1],
                  'startTime': str(task['start_time']),
                  'endTime': str(task['end_time']),
                  'exitCode': task['exit_code'],
@@ -648,7 +648,7 @@ async def get_task_state(request):
 
     results = []
     for _state in Task.State:
-        data = {'index': _state.value, 'name': _state.name}
+        data = {'index': _state.value, 'name': _state.name.capitalize()}
         results.append(data)
 
     return web.json_response({'taskState': results})

--- a/tests/unit-tests/python/foglamp_test/services/core/api/test_task.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/api/test_task.py
@@ -108,7 +108,7 @@ class TestTask:
     async def test_cancel_task(self):
         # First create a schedule to get the schedule_id
         data = {"type": 3, "name": "test_task_1", "process_name": "testsleep30", "repeat": "3600"}
-        schedule_id = self._schedule_task(data)
+        self._schedule_task(data)
 
         # Allow sufficient time for task record to be created
         await asyncio.sleep(4)
@@ -118,8 +118,8 @@ class TestTask:
         retval = dict(r.json())
         task_id = retval['tasks'][0]['id']
         assert 1 == len(retval['tasks'])
-        assert retval['tasks'][0]['state'] == 'RUNNING'
-        assert retval['tasks'][0]['processName'] == 'testsleep30'
+        assert retval['tasks'][0]['state'] == 'Running'
+        assert retval['tasks'][0]['name'] == 'testsleep30'
 
         # Now cancel the runnung task
         r = requests.put(BASE_URL+'/task/cancel/' + task_id)
@@ -136,15 +136,15 @@ class TestTask:
 
         assert 200 == r.status_code
         assert retval['id'] == task_id
-        assert retval['state'] == 'CANCELED'
+        assert retval['state'] == 'Canceled'
 
     async def test_get_tasks_latest(self):
         # First create two schedules to get the schedule_id
         data = {"type": 3, "name": "test_get_task2a", "process_name": "testsleep30", "repeat": 2}
-        schedule_id1 = self._schedule_task(data)
+        self._schedule_task(data)
 
         data = {"type": 3, "name": "test_get_task2b", "process_name": "echo_test", "repeat": 10}
-        schedule_id2 = self._schedule_task(data)
+        self._schedule_task(data)
 
         # Allow multiple tasks to be created
         await asyncio.sleep(4)
@@ -160,13 +160,13 @@ class TestTask:
 
         assert 200 == r.status_code
         assert 2 == len(retval['tasks'])
-        assert retval['tasks'][1]['processName'] == 'testsleep30'
-        assert retval['tasks'][0]['processName'] == 'echo_test'
+        assert retval['tasks'][1]['name'] == 'testsleep30'
+        assert retval['tasks'][0]['name'] == 'echo_test'
 
     async def test_get_tasks(self):
         # First create a schedule to get the schedule_id
         data = {"type": 3, "name": "test_get_task3", "process_name": "echo_test", "repeat": 2}
-        schedule_id = self._schedule_task(data)
+        self._schedule_task(data)
 
         # Allow multiple task records to be created
         await asyncio.sleep(4)
@@ -176,14 +176,14 @@ class TestTask:
         retvall = dict(rr.json())
 
         assert 200 == rr.status_code
-        list_tasks = [tasks['processName'] for tasks in retvall['tasks']]
+        list_tasks = [tasks['name'] for tasks in retvall['tasks']]
         # Due to async processing, ascertining exact no. of tasks is not possible
         assert list_tasks.count(data['process_name']) >= 3
 
     async def test_get_task(self):
         # First create a schedule to get the schedule_id
         data = {"type": 3, "name": "test_get_task4", "process_name": "testsleep30", "repeat": 200}
-        schedule_id = self._schedule_task(data)
+        self._schedule_task(data)
 
         # Allow sufficient time for task record to be created
         await asyncio.sleep(4)
@@ -199,3 +199,26 @@ class TestTask:
 
         assert 200 == r.status_code
         assert retval['id'] == task_id
+
+    async def test_get_state(self):
+        r = requests.get(BASE_URL + '/task/state')
+        retval = dict(r.json())
+        task_state = retval['taskState']
+
+        # verify the task state count
+        assert 4 == len(task_state)
+
+        # verify the name and value of task state
+        for i in range(len(task_state)):
+            if task_state[i]['index'] == 1:
+                assert 1 == task_state[i]['index']
+                assert 'Running' == task_state[i]['name']
+            elif task_state[i]['index'] == 2:
+                assert 2 == task_state[i]['index']
+                assert 'Complete' == task_state[i]['name']
+            elif task_state[i]['index'] == 3:
+                assert 3 == task_state[i]['index']
+                assert 'Canceled' == task_state[i]['name']
+            elif task_state[i]['index'] == 4:
+                assert 4 == task_state[i]['index']
+                assert 'Interrupted' == task_state[i]['name']


### PR DESCRIPTION
**Tests O/P**:

```
collected 5 items 

test_task.py::TestTask::test_cancel_task FogLAMP started.
PASSED
test_task.py::TestTask::test_get_tasks_latest FAILED
test_task.py::TestTask::test_get_tasks PASSED
test_task.py::TestTask::test_get_task PASSED
test_task.py::TestTask::test_get_state PASSED

========= 1 failed, 4 passed in 69.08 seconds =======
```
_NOTE_: One test was failing before as well, so no regression as such with new changes for the PR.

Also @MarkRiddoch please update the REST API doc for [task](https://docs.google.com/document/d/1JJDP7g25SWerNVCxgff02qp9msHbqA9nt3RAFx8-Qng/edit#heading=h.pdkhd1a1ibnb) endpoints such as **exit_code** key etc. and have a look upon the [deviations](https://docs.google.com/document/d/1cECJJEslmlN4S9qRgDjszHucy4vj9HrGmqJ4En5UD2M/edit#heading=h.dn07oy7gnx6t) w.r.t to original doc

