### PR TITLE
Removed duplicate psycopg2 requirement

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 
-# Postgres for backup
+# PostreSQL Storage Plugin
 psycopg2==2.7.1
 
 
@@ -12,9 +12,6 @@ aiohttp==2.3.6
 aiohttp_cors==0.5.3
 cchardet==2.1.1
 requests==2.18.4
-
-# PostreSQL Storage Plugin
-psycopg2
 
 # CoAP South Microservice Plugin
 aiocoap==0.3


### PR DESCRIPTION
Resolved to fix the error while make:

```
pip3 install -Ir python/requirements.txt --user
Double requirement given: psycopg2 (from -r python/requirements.txt (line 17)) (already in psycopg2==2.7.1 (from -r python/requirements.txt (line 3)), name='psycopg2')
```