### PR TITLE
FOGL-913 Return data in UTC format

### DIFF
--- a/C/plugins/storage/postgres/connection.cpp
+++ b/C/plugins/storage/postgres/connection.cpp
@@ -739,7 +739,7 @@ bool Connection::fetchReadings(unsigned long id, unsigned int blksize, std::stri
 char	sqlbuffer[100];
 
 	snprintf(sqlbuffer, sizeof(sqlbuffer),
-		"SELECT * FROM foglamp.readings WHERE id >= %ld LIMIT %d;", id, blksize);
+		"SELECT id, asset_code, read_key, reading, user_ts AT TIME ZONE 'UTC', ts AT TIME ZONE 'UTC' FROM foglamp.readings WHERE id >= %ld LIMIT %d;", id, blksize);
 	
 	PGresult *res = PQexec(dbConnection, sqlbuffer);
 	if (PQresultStatus(res) == PGRES_TUPLES_OK)


### PR DESCRIPTION
Return data from the ReadingsFetch entry point in UTC format only.