### PR TITLE
FOGL-930 get interest endpoint added with interest registry tests

### DIFF
--- a/python/foglamp/services/common/microservice.py
+++ b/python/foglamp/services/common/microservice.py
@@ -120,3 +120,6 @@ class FoglampMicroservice(FoglampProcess):
 
     async def unregister_interest(self, request):
         raise web.HTTPBadRequest(reason='Interest registration requests are handled by core microservice, not by {} microservice'.format(self._name))
+
+    async def get_interest(self, request):
+        raise web.HTTPBadRequest(reason='Interest registration requests are handled by core microservice, not by {} microservice'.format(self._name))

--- a/python/foglamp/services/common/microservice_management/routes.py
+++ b/python/foglamp/services/common/microservice_management/routes.py
@@ -27,6 +27,7 @@ def setup(app, obj):
     # Interest Registration
     app.router.add_route('POST', '/foglamp/interest', obj.register_interest)
     app.router.add_route('DELETE', '/foglamp/interest/{interest_id}', obj.unregister_interest)
+    app.router.add_route('GET', '/foglamp/interest', obj.get_interest)
 
     # enable cors support
     enable_cors(app)

--- a/tests/unit-tests/python/foglamp_test/services/core/interest_registry/test_interest_registry.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/interest_registry/test_interest_registry.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+import json
+import requests
+import pytest
+import uuid
+
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+pytestmark = pytest.mark.asyncio
+
+# Needs foglamp to start,
+# replace 34827 with core_management_port
+BASE_URL = 'http://localhost:34827/foglamp'
+headers = {'Content-Type': 'application/json'}
+
+
+@pytest.allure.feature("api")
+@pytest.allure.story("interest-registry")
+class TestInterestRegistryApi:
+
+    def setup_method(self):
+        pass
+
+    def teardown_method(self):
+        """clean up interest registry storage"""
+
+        r = requests.get(BASE_URL + '/interest')
+        if r.status_code in range(400, 500):
+            return
+        res = dict(r.json())
+        t = res["interests"]
+        for s in t:
+            requests.delete(BASE_URL + '/interest/' + s["registrationId"])
+
+    async def test_register_interest(self):
+        data = {"category": "CC2650POLL", "service": str(uuid.uuid4())}
+        r = requests.post(BASE_URL + '/interest', data=json.dumps(data), headers=headers)
+        res = dict(r.json())
+
+        assert 200 == r.status_code
+        assert uuid.UUID(res["id"])
+        assert "Interest registered successfully" == res["message"]
+
+    async def test_unregister_interest(self):
+        data = {"category": "COAP", "service": str(uuid.uuid4())}
+        r = requests.post(BASE_URL + '/interest', data=json.dumps(data), headers=headers)
+        res = dict(r.json())
+        assert 200 == r.status_code
+        registration_id = res["id"]
+
+        r = requests.delete(BASE_URL + '/interest/' + registration_id)
+        retval = dict(r.json())
+        assert 200 == r.status_code
+        assert registration_id == retval["id"]
+        assert "Interest unregistered" == retval["message"]
+
+    async def test_get(self):
+        data1 = {"category": "CAT1", "service": str(uuid.uuid4())}
+        r = requests.post(BASE_URL + '/interest', data=json.dumps(data1), headers=headers)
+        assert 200 == r.status_code
+        retval = dict(r.json())
+        registration_id1 = retval["id"]
+
+        # Create another interest
+        data2 = {"category": "CAT2", "service": str(uuid.uuid4())}
+        r = requests.post(BASE_URL + '/interest', data=json.dumps(data2), headers=headers)
+        assert 200 == r.status_code
+        retval = dict(r.json())
+        registration_id2 = retval["id"]
+
+        r = requests.get(BASE_URL + '/interest')
+        assert 200 == r.status_code
+
+        retval = dict(r.json())
+        interests = retval["interests"]
+        assert 2 == len(interests)
+
+        data1_interest = data2_interest = None
+        for interest in interests:
+            if interest["registrationId"] == registration_id1:
+                data1_interest = interest
+            if interest["registrationId"] == registration_id2:
+                data2_interest = interest
+
+        assert data1_interest is not None
+        assert data1["category"] == data1_interest["category"]
+        assert data1["service"] == data1_interest["microserviceId"]
+
+        assert data2_interest is not None
+        assert data2["category"] == data2_interest["category"]
+        assert data2["service"] == data2_interest["microserviceId"]
+
+    async def test_get_by_category(self):
+        data = {"category": "CAT1", "service": str(uuid.uuid4())}
+        r = requests.post(BASE_URL + '/interest', data=json.dumps(data), headers=headers)
+        assert 200 == r.status_code
+        retval = dict(r.json())
+        registration_id = retval["id"]
+
+        r = requests.get(BASE_URL + '/interest?category={}'.format(data["category"]))
+        assert 200 == r.status_code
+
+        retval = dict(r.json())
+        interest = retval["interests"]
+        assert 1 == len(interest)
+        assert interest is not None
+        assert data["category"] == interest[0]["category"]
+        assert data["service"] == interest[0]["microserviceId"]
+        assert registration_id == interest[0]["registrationId"]
+
+    async def test_get_by_microservice_id(self):
+        microservice_id = str(uuid.uuid4())
+        data = {"category": "CAT1", "service": microservice_id}
+        r = requests.post(BASE_URL + '/interest', data=json.dumps(data), headers=headers)
+        assert 200 == r.status_code
+        retval = dict(r.json())
+        registration_id = retval["id"]
+
+        r = requests.get(BASE_URL + '/interest?microserviceid={}'.format(microservice_id))
+        assert 200 == r.status_code
+
+        retval = dict(r.json())
+        interest = retval["interests"]
+        assert 1 == len(interest)
+        assert interest is not None
+        assert data["category"] == interest[0]["category"]
+        assert microservice_id == interest[0]["microserviceId"]
+        assert registration_id == interest[0]["registrationId"]
+
+    async def test_get_by_category_and_microservice_id(self):
+        data1 = {"category": "CAT1", "service": str(uuid.uuid4())}
+        r = requests.post(BASE_URL + '/interest', data=json.dumps(data1), headers=headers)
+        assert 200 == r.status_code
+
+        # Create another interest
+        data2 = {"category": "CAT2", "service": str(uuid.uuid4())}
+        r = requests.post(BASE_URL + '/interest', data=json.dumps(data2), headers=headers)
+        assert 200 == r.status_code
+
+        r = requests.get(BASE_URL + '/interest?category={}&microserviceid={}'.format(data2["category"],
+                                                                                     data2["service"]))
+        assert 200 == r.status_code
+
+        res = dict(r.json())
+        interests = res["interests"]
+        assert 1 == len(interests)
+
+        assert data2["category"] == interests[0]["category"]
+        assert data2["service"] == interests[0]["microserviceId"]
+
+    @pytest.mark.parametrize("request_params, response_code, response_message", [
+        ('', 404, "No interest registered"),
+        ('?any=123', 404, "No interest registered"),
+        ('?category=blah', 404, "No interest registered for category blah"),
+        ('?microserviceid=foo', 400, "Invalid microservice id foo"),
+        ('?microserviceid=d2abe6d7-ce77-448a-b13f-b2ada202b63b', 404,
+         'No interest registered microservice id d2abe6d7-ce77-448a-b13f-b2ada202b63b'),
+        ('?microserviceid=d2abe6d7-ce77-448a-b13f-b2ada202b63b&category=foo', 404,
+         'No interest registered for category foo and microservice id d2abe6d7-ce77-448a-b13f-b2ada202b63b')
+    ])
+    async def test_get_params_with_bad_data(self, request_params, response_code, response_message):
+        r = requests.get(BASE_URL + '/interest{}'.format(request_params))
+        assert response_code == r.status_code
+        assert response_message == r.reason
+
+    @pytest.mark.parametrize("registration_id, response_code, response_message", [
+        ('blah', 400, "InterestRecord with registration_id blah does not exist"),
+        ('d2abe6d7-ce77-448a-b13f-b2ada202b63b', 400,
+         "InterestRecord with registration_id d2abe6d7-ce77-448a-b13f-b2ada202b63b does not exist")
+    ])
+    async def test_unregister_with_bad_data(self, registration_id, response_code, response_message):
+        r = requests.delete(BASE_URL + '/interest/' + registration_id)
+        assert response_code == r.status_code
+        assert response_message == r.reason

--- a/tests/unit-tests/python/foglamp_test/services/core/interest_registry/test_interest_registry.py
+++ b/tests/unit-tests/python/foglamp_test/services/core/interest_registry/test_interest_registry.py
@@ -18,8 +18,8 @@ __version__ = "${VERSION}"
 pytestmark = pytest.mark.asyncio
 
 # Needs foglamp to start,
-# replace 34827 with core_management_port
-BASE_URL = 'http://localhost:34827/foglamp'
+# replace 42921 with core_management_port
+BASE_URL = 'http://localhost:42921/foglamp'
 headers = {'Content-Type': 'application/json'}
 
 
@@ -172,9 +172,20 @@ class TestInterestRegistryApi:
         assert response_code == r.status_code
         assert response_message == r.reason
 
+    @pytest.mark.parametrize("data, response_code, response_message", [
+        ({"category": "CAT1"}, 400, "Failed to register interest. microservice_uuid cannot be None"),
+        ({"service": "0xe6ebd0"}, 400, "Invalid microservice id 0xe6ebd0"),
+        ({"service": "d2abe6d7-ce77-448a-b13f-b2ada202b63b"}, 400,
+         "Failed to register interest. category_name cannot be None")
+    ])
+    async def test_register_with_bad_data(self, data, response_code, response_message):
+        r = requests.post(BASE_URL + '/interest', data=json.dumps(data), headers=headers)
+        assert response_code == r.status_code
+        assert response_message == r.reason
+
     @pytest.mark.parametrize("registration_id, response_code, response_message", [
-        ('blah', 400, "InterestRecord with registration_id blah does not exist"),
-        ('d2abe6d7-ce77-448a-b13f-b2ada202b63b', 400,
+        ('blah', 400, "Invalid registration id blah"),
+        ('d2abe6d7-ce77-448a-b13f-b2ada202b63b', 404,
          "InterestRecord with registration_id d2abe6d7-ce77-448a-b13f-b2ada202b63b does not exist")
     ])
     async def test_unregister_with_bad_data(self, registration_id, response_code, response_message):


### PR DESCRIPTION
- [x] GET /foglamp/interest endpoint added
- [x] test_interest_registry

**Tests O/p**

```
collected 17 items 

test_interest_registry.py::TestInterestRegistryApi::test_register_interest PASSED
test_interest_registry.py::TestInterestRegistryApi::test_unregister_interest PASSED
test_interest_registry.py::TestInterestRegistryApi::test_get PASSED
test_interest_registry.py::TestInterestRegistryApi::test_get_by_category PASSED
test_interest_registry.py::TestInterestRegistryApi::test_get_by_microservice_id PASSED
test_interest_registry.py::TestInterestRegistryApi::test_get_by_category_and_microservice_id PASSED
test_interest_registry.py::TestInterestRegistryApi::test_get_params_with_bad_data[-404-No interest registered] PASSED
test_interest_registry.py::TestInterestRegistryApi::test_get_params_with_bad_data[?any=123-404-No interest registered] PASSED
test_interest_registry.py::TestInterestRegistryApi::test_get_params_with_bad_data[?category=blah-404-No interest registered for category blah] PASSED
test_interest_registry.py::TestInterestRegistryApi::test_get_params_with_bad_data[?microserviceid=foo-400-Invalid microservice id foo] PASSED
test_interest_registry.py::TestInterestRegistryApi::test_get_params_with_bad_data[?microserviceid=d2abe6d7-ce77-448a-b13f-b2ada202b63b-404-No interest registered microservice id d2abe6d7-ce77-448a-b13f-b2ada202b63b] PASSED
test_interest_registry.py::TestInterestRegistryApi::test_get_params_with_bad_data[?microserviceid=d2abe6d7-ce77-448a-b13f-b2ada202b63b&category=foo-404-No interest registered for category foo and microservice id d2abe6d7-ce77-448a-b13f-b2ada202b63b] PASSED
test_interest_registry.py::TestInterestRegistryApi::test_register_with_bad_data[data0-400-Failed to register interest. microservice_uuid cannot be None] PASSED
test_interest_registry.py::TestInterestRegistryApi::test_register_with_bad_data[data1-400-Invalid microservice id 0xe6ebd0] PASSED
test_interest_registry.py::TestInterestRegistryApi::test_register_with_bad_data[data2-400-Failed to register interest. category_name cannot be None] PASSED
test_interest_registry.py::TestInterestRegistryApi::test_unregister_with_bad_data[blah-400-Invalid registration id blah] PASSED
test_interest_registry.py::TestInterestRegistryApi::test_unregister_with_bad_data[d2abe6d7-ce77-448a-b13f-b2ada202b63b-404-InterestRecord with registration_id d2abe6d7-ce77-448a-b13f-b2ada202b63b does not exist] PASSED
==== 17 passed in 0.44 seconds ===
```
**Syslog**
```
Jan 11 16:46:51 nerd-034 [FOGLAMP] 01-11-2018 16:46:51 - INFO :: server: foglamp.services.core.server: start core
Jan 11 16:46:51 nerd-034 [FOGLAMP] 01-11-2018 16:46:51 - INFO :: server: foglamp.services.core.server: Management API started on http://0.0.0.0:42921
Jan 11 16:46:51 nerd-034 [FOGLAMP] 01-11-2018 16:46:51 - INFO :: server: foglamp.services.core.server: Announce management API service
Jan 11 16:46:51 nerd-034 [FOGLAMP] 01-11-2018 16:46:51 - INFO :: server: foglamp.services.core.server: start storage, from directory /home/foglamp/Development/FogLAMP/scripts
Jan 11 16:46:51 nerd-034 storage: Using default configuration:  { "plugin" : {  "value" : "postgres" }, "threads" : { "value" : "1" },  "port" : { "value" : "0" }, "managementPort" : { "value" : "0" } }.
Jan 11 16:46:51 nerd-034 port[20000]: Load storage plugin postgres.
Jan 11 16:46:51 nerd-034 port[20000]: Loaded storage plugin postgres.
Jan 11 16:46:51 nerd-034 port[20000]: Starting management api on port 0.
Jan 11 16:46:51 nerd-034 port[20000]: Starting service...
Jan 11 16:47:01 nerd-034 [FOGLAMP] 01-11-2018 16:47:01 - INFO :: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=2f525250-8a4c-451a-a337-182a1f6ff7f4: <FogLAMP Storage, type=Storage, protocol=http, address=localhost, service port=43661, management port=46653, status=1>
Jan 11 16:47:01 nerd-034 port[20000]: Registered service 2f525250-8a4c-451a-a337-182a1f6ff7f4.
Jan 11 16:47:01 nerd-034 port[20000]: Failed to parse result of category registration:
Jan 11 16:47:06 nerd-034 [FOGLAMP] 01-11-2018 16:47:06 - INFO :: server: foglamp.services.core.server: start scheduler
Jan 11 16:47:06 nerd-034 [FOGLAMP] 01-11-2018 16:47:06 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Starting
Jan 11 16:47:06 nerd-034 [FOGLAMP] 01-11-2018 16:47:06 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Starting Scheduler: Management port received is 42921
Jan 11 16:47:06 nerd-034 [FOGLAMP] 01-11-2018 16:47:06 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 9999999 seconds
Jan 11 16:47:06 nerd-034 [FOGLAMP] 01-11-2018 16:47:06 - INFO :: server: foglamp.services.core.server: REST API Server started on http://0.0.0.0:8081
Jan 11 16:47:06 nerd-034 [FOGLAMP] 01-11-2018 16:47:06 - INFO :: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=da37e137-11f6-46ad-b59b-9995b3b5162b: <FogLAMP Core, type=Core, protocol=http, address=0.0.0.0, service port=8081, management port=42921, status=1>
Jan 11 16:47:48 nerd-034 [FOGLAMP] 01-11-2018 16:47:48 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Processing stop request
Jan 11 16:47:48 nerd-034 [FOGLAMP] 01-11-2018 16:47:48 - INFO :: scheduler: foglamp.services.core.scheduler.scheduler: Stopped
Jan 11 16:47:48 nerd-034 port[20000]: Storage service shutdown in progress.
Jan 11 16:47:48 nerd-034 [FOGLAMP] 01-11-2018 16:47:48 - INFO :: service_registry: foglamp.services.core.service_registry.service_registry: Unregistered service instance id=2f525250-8a4c-451a-a337-182a1f6ff7f4: <FogLAMP Storage, type=Storage, protocol=http, address=localhost, service port=43661, management port=46653, status=1>
Jan 11 16:47:48 nerd-034 port[20000]: Unregistered service 2f525250-8a4c-451a-a337-182a1f6ff7f4.
Jan 11 16:47:48 nerd-034 port[20000]: Storage service shut down.
```

**Note:** Failed to parse result of category registration: --- failed due to invalid format of microservice uuid4. we need to fix it from storage end
`{'category': 'STORAGE', 'service': '0xe1ebd0'}`
