### PR TITLE
FOGL-939, FOGL-940: Add JQ filter configuration on north plugins and update sending process

### DIFF
--- a/python/foglamp/common/jqfilter.py
+++ b/python/foglamp/common/jqfilter.py
@@ -28,11 +28,9 @@ class JQFilter:
         super().__init__()
         self._logger = logger.setup("JQFilter")
 
-    def transform(self, apply_filter, reading_block, filter_string):
+    def transform(self, reading_block, filter_string):
         """
         Args:
-            apply_filter: Flag to tell whether to apply filter or not,
-                if flag is false then reading_block is returned as is.
             reading_block: Formatted JSON on which filter needs to be applied.
             filter_string: filter to apply. Filter should be in JQ format.
         Returns: transformed JSON (if apply_filter is true)
@@ -45,8 +43,6 @@ class JQFilter:
                 and usage with plugins using defined configurations.
 
         """
-        if apply_filter.upper() == "FALSE":
-            return reading_block
         try:
             return pyjq.all(filter_string, reading_block)
         except TypeError as ex:

--- a/python/foglamp/plugins/north/omf/omf.py
+++ b/python/foglamp/plugins/north/omf/omf.py
@@ -95,6 +95,16 @@ _CONFIG_DEFAULT_OMF = {
                 "Company": "Dianomic"
             }
         )
+    },
+    "applyFilter": {
+        "description": "Whether to apply filter before processing the data",
+        "type": "boolean",
+        "default": "False"
+    },
+    "filterRule": {
+        "description": "JQ formatted filter to apply (applicable if applyFilter is True)",
+        "type": "string",
+        "default": ".[]"
     }
 }
 

--- a/python/foglamp/tasks/north/sending_process.py
+++ b/python/foglamp/tasks/north/sending_process.py
@@ -29,6 +29,7 @@ from foglamp.common import logger
 from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.common.storage_client import payload_builder
 from foglamp.common.statistics import Statistics
+from foglamp.common.jqfilter import JQFilter
 
 
 __author__ = "Stefano Simonelli"
@@ -597,6 +598,9 @@ class SendingProcess:
             last_object_id = self._last_object_id_read(stream_id)
             data_to_send = self._load_data_into_memory(last_object_id)
             if data_to_send:
+                if self._config_from_manager['applyFilter']["value"].upper() == "TRUE":
+                    jqfilter = JQFilter()
+                    data_to_send = jqfilter.transform(data_to_send, self._config_from_manager['filterRule']["value"])
                 data_sent, new_last_object_id, num_sent = self._plugin.plugin_send(self._plugin_handle, data_to_send, stream_id)
                 if data_sent:
                     # Updates reached position, statistics and logs the operation within the Storage Layer


### PR DESCRIPTION
~~Looked from http receiving side:~~
~~Earlier response (where we are manipulating each read tuple in code):~~
```
[{'asset_code': 'fogbench/pressure', 'readings': [{'reading': {'pressure': 901.3}, 'user_ts': '2018-01-11 14:13:18.157493+05:30', 'read_key': 'c452a4e1-c9ed-4023-92ee-ca37d0c354dc'}]}, {'asset_code': 'fogbench/humidity', 'readings': [{'reading': {'temperature': 20, 'humidity': 14}, 'user_ts': '2018-01-11 14:13:18.157535+05:30', 'read_key': 'd0f364e4-f43b-45cd-8553-01d0715c8a27'}]}]
```

~~Using JQ Filter:~~
```
[{'asset_code': 'fogbench/pressure', 'readings': [{'reading': {'pressure': 901.3}, 'user_ts': '2018-01-11 14:13:18.157493+05:30', 'read_key': 'c452a4e1-c9ed-4023-92ee-ca37d0c354dc'}]}, {'asset_code': 'fogbench/humidity', 'readings': [{'reading': {'temperature': 20, 'humidity': 14}, 'user_ts': '2018-01-11 14:13:18.157535+05:30', 'read_key': 'd0f364e4-f43b-45cd-8553-01d0715c8a27'}]}]
```

~~No change in output~~


As per the latest discussion, the scope of using jq filter is manipulating in data only. Plugins assume that they get the right set of keys and payloads keys are not altered. Default jq configuration will be False