### PR TITLE
fix aiohttp dependency

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,6 +12,7 @@ aiohttp==2.3.6
 aiohttp_cors==0.5.3
 cchardet==2.1.1
 requests==2.18.4
+yarl==0.18.0
 
 # CoAP South Microservice Plugin
 aiocoap==0.3


### PR DESCRIPTION
until https://github.com/aio-libs/aiohttp/issues/2662 is fixed.

We need this in 1.1 and master too