### PR TITLE
FOG-949: force ORDER BY DESC to asset/series REST API call

### DIFF
--- a/python/foglamp/services/core/api/browser.py
+++ b/python/foglamp/services/core/api/browser.py
@@ -343,7 +343,7 @@ async def asset_averages(request):
     _limit_skip_payload = validate_limit_skip(request, d)
     d.update(_limit_skip_payload)
 
-    # FOGL-949: add ORDER BY timestamp DESC
+    # Add ORDER BY timestamp DESC
     _sort_payload = PayloadBuilder(_limit_skip_payload).ORDER_BY(["timestamp", "desc"]).chain_payload()
     d.update(_sort_payload)
 

--- a/python/foglamp/services/core/api/browser.py
+++ b/python/foglamp/services/core/api/browser.py
@@ -294,8 +294,18 @@ async def asset_averages(request):
     The amount of time covered by each returned value is set using the
     query parameter group. This may be set to seconds, minutes or hours
 
-    Return the result of the query
-    SELECT user_ts AVG((reading->>'reading')::float) FROM readings WHERE asset_code = 'asset_code' GROUP BY user_ts
+    Return the result of the query:
+
+    SELECT min((reading->>'reading')::float) AS "min",
+           max((reading->>'reading')::float) AS "max",
+           avg((reading->>'reading')::float) AS "average",
+           to_char(user_ts, 'YYYY-MM-DD HH24:MI:SS') AS "timestamp"
+    FROM foglamp.readings
+           WHERE asset_code = 'asset_code' AND
+             reading ? 'reading'
+    GROUP BY to_char(user_ts, 'YYYY-MM-DD HH24:MI:SS')
+    ORDER BY timestamp DESC;
+
     """
     asset_code = request.match_info.get('asset_code', '')
     reading = request.match_info.get('reading', '')
@@ -332,6 +342,10 @@ async def asset_averages(request):
     d['group'] = timestamp
     _limit_skip_payload = validate_limit_skip(request, d)
     d.update(_limit_skip_payload)
+
+    # FOGL-949: add ORDER BY timestamp DESC
+    _sort_payload = PayloadBuilder(_limit_skip_payload).ORDER_BY(["timestamp", "desc"]).chain_payload()
+    d.update(_sort_payload)
 
     payload = json.dumps(d)
     results = {}

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ psycopg2==2.7.1
 packaging==16.8
 
 # Common - REST interface
-aiohttp==2.3.6
+aiohttp==2.3.8
 aiohttp_cors==0.5.3
 cchardet==2.1.1
 requests==2.18.4

--- a/tests/unit-tests/C/services/storage/expected/59
+++ b/tests/unit-tests/C/services/storage/expected/59
@@ -1,1 +1,1 @@
-{"count":2,"rows":[{"min":"2","max":"96","average":"47.9523809523809","asset_code":"MyAsset","timestamp":"2017-10-11 15:10:50+00"},{"min":"1","max":"98","average":"53.7721518987342","asset_code":"MyAsset","timestamp":"2017-10-11 15:10:52+00"}]}
+{"count":2,"rows":[{"min":"1","max":"98","average":"53.7721518987342","asset_code":"MyAsset","timestamp":"2017-10-11 15:10:52+00"},{"min":"2","max":"96","average":"47.9523809523809","asset_code":"MyAsset","timestamp":"2017-10-11 15:10:50+00"}]}

--- a/tests/unit-tests/C/services/storage/expected/60
+++ b/tests/unit-tests/C/services/storage/expected/60
@@ -1,1 +1,1 @@
-{"count":2,"rows":[{"min":"2","max":"96","average":"47.9523809523809","asset_code":"MyAsset","bucket":"11-10-20177 15:10:50"},{"min":"1","max":"98","average":"53.7721518987342","asset_code":"MyAsset","bucket":"11-10-20177 15:10:52"}]}
+{"count":2,"rows":[{"min":"1","max":"98","average":"53.7721518987342","asset_code":"MyAsset","bucket":"11-10-20177 15:10:52"},{"min":"2","max":"96","average":"47.9523809523809","asset_code":"MyAsset","bucket":"11-10-20177 15:10:50"}]}

--- a/tests/unit-tests/C/services/storage/expected/88
+++ b/tests/unit-tests/C/services/storage/expected/88
@@ -1,0 +1,1 @@
+{ "entryPoint" : "limit", "message" : "Limit must be specfied as an integer", "retryable" : false}

--- a/tests/unit-tests/C/services/storage/expected/89
+++ b/tests/unit-tests/C/services/storage/expected/89
@@ -1,0 +1,1 @@
+{ "entryPoint" : "skip", "message" : "Skip must be specfied as an integer", "retryable" : false}

--- a/tests/unit-tests/C/services/storage/payloads/group_time.json
+++ b/tests/unit-tests/C/services/storage/payloads/group_time.json
@@ -30,5 +30,9 @@
     "group" : {
         "column": "user_ts",
         "format": "YYYY-MM-DD HH24:MI:SS"
+    },
+    "sort" : {
+        "column": "user_ts",
+        "direction": "asc"
     }
 }

--- a/tests/unit-tests/C/services/storage/payloads/limit_max_int.json
+++ b/tests/unit-tests/C/services/storage/payloads/limit_max_int.json
@@ -1,0 +1,7 @@
+{
+	"sort" : {
+			"column" : "id",
+			"direction" : "asc"
+		},
+	"limit" : 999999999999
+}

--- a/tests/unit-tests/C/services/storage/payloads/skip_max_int.json
+++ b/tests/unit-tests/C/services/storage/payloads/skip_max_int.json
@@ -1,0 +1,8 @@
+{
+	"sort" : {
+			"column" : "id",
+			"direction" : "asc"
+		},
+	"limit" : 1,
+	"skip" : 99999999999
+}

--- a/tests/unit-tests/C/services/storage/testCleanup.sh
+++ b/tests/unit-tests/C/services/storage/testCleanup.sh
@@ -1,4 +1,4 @@
-psql << EOF
+psql -d foglamp << EOF
 delete from foglamp.test;
 drop table foglamp.test;
 delete from foglamp.test2;

--- a/tests/unit-tests/C/services/storage/testRunner.sh
+++ b/tests/unit-tests/C/services/storage/testRunner.sh
@@ -41,9 +41,9 @@ if [ "$optional" = "" ] ; then
 			n_failed=`expr $n_failed + 1`
 			if [ "$payload" = "" ]
 			then
-				echo Test $testNum  curl -X $method $url >> failed
+				echo Test $testNum  ${name} curl -X $method $url >> failed
 			else
-				echo Test $testNum  curl -X $method $url -d@payloads/$payload  >> failed
+				echo Test $testNum  ${name} curl -X $method $url -d@payloads/$payload  >> failed
 			fi
 			(
 			unset IFS

--- a/tests/unit-tests/C/services/storage/testSetup.sh
+++ b/tests/unit-tests/C/services/storage/testSetup.sh
@@ -1,4 +1,4 @@
-psql << EOF
+psql -d foglamp << EOF
 drop table if exists foglamp.test;
 
 create table foglamp.test (

--- a/tests/unit-tests/C/services/storage/testset
+++ b/tests/unit-tests/C/services/storage/testset
@@ -85,4 +85,6 @@ Jira FOGL-690 cleanup,DELETE,http://localhost:8080/storage/table/configuration,d
 Add bad Readings,POST,http://localhost:8080/storage/reading,badreadings.json
 Query Readings Timebucket Bad,PUT,http://localhost:8080/storage/reading/query,query_readings_timebucket_bad.json
 Reading Rate Array,PUT,http://localhost:8080/storage/reading/query,reading_property_array.json
+Common Read limit max_int,PUT,http://localhost:8080/storage/table/test/query,limit_max_int.json
+Common Read skip max_int,PUT,http://localhost:8080/storage/table/test/query,skip_max_int.json
 Shutdown,POST,http://localhost:1081/foglamp/service/shutdown,,checkstate


### PR DESCRIPTION
The query related to asset/value/series now returns data order by timestamp desc:


>$ curl -s 'http://localhost:8081/foglamp/asset/fogbench%2Fpressure/pressure/series' | jq
```json
[
  {
    "min": "804",
    "average": "949.84",
    "timestamp": "2018-01-15 11:10:43",
    "max": "1086.5"
  },
  {
    "min": "821.3",
    "average": "911.63",
    "timestamp": "2018-01-15 11:10:40",
    "max": "1088.6"
  },
  {
    "min": "812",
    "average": "886.97",
    "timestamp": "2018-01-15 11:10:34",
    "max": "1021.9"
  },
  {
    "min": "823.4",
    "average": "958.06",
    "timestamp": "2018-01-15 11:10:29",
    "max": "1094.1"
  }
```