### PR TITLE
more stop improvements and better logging for exception in scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ data/etc/certs/*
 /etc/storage.json
 /etc/certs/*
 
+*.cert
+*.key
+*.csr
+
 # Docs
 docs/_build
 docs/__pycache__/

--- a/python/foglamp/plugins/south/cc2650async/cc2650async.py
+++ b/python/foglamp/plugins/south/cc2650async/cc2650async.py
@@ -360,12 +360,6 @@ def plugin_shutdown(handle):
     Returns:
     Raises:
     """
-    # Find all running tasks:
-    pending_tasks = asyncio.Task.all_tasks()
-
-    # Wait until tasks done:
-    asyncio.ensure_future(asyncio.wait(*pending_tasks, timeout=handle['shutdownThreshold']['value']))
-
     if 'tag' in handle:
         bluetooth_adr = handle['bluetoothAddress']['value']
         tag = handle['tag']
@@ -383,3 +377,9 @@ def plugin_shutdown(handle):
 
         tag.disconnect()
         _LOGGER.info('SensorTagCC2650 {} Disconnected.'.format(bluetooth_adr))
+
+    # Find all pending tasks and cancel
+    pending = asyncio.Task.all_tasks()
+    for p in pending:
+        p.cancel()
+    _LOGGER.info('CC2650 async plugin shut down.')

--- a/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
+++ b/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
@@ -278,14 +278,16 @@ def plugin_shutdown(handle):
     Returns:
     Raises:
     """
-    # Find all running tasks:
-    pending_tasks = asyncio.Task.all_tasks()
-
-    # Wait until tasks done:
-    asyncio.ensure_future(asyncio.wait(*pending_tasks, timeout=handle['shutdownThreshold']['value']))
 
     if 'tag' in handle:
         bluetooth_adr = handle['bluetoothAddress']['value']
         tag = handle['tag']
         tag.disconnect()
         _LOGGER.info('SensorTagCC2650 {} Disconnected.'.format(bluetooth_adr))
+
+    # Find all pending tasks and cancel
+    pending = asyncio.Task.all_tasks()
+    for p in pending:
+        p.cancel()
+    _LOGGER.info('CC2650 poll plugin shut down.')
+

--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -816,16 +816,16 @@ class Scheduler(object):
             if self._purge_tasks_task is not None:
                 try:
                     await self._purge_tasks_task
-                except Exception:
-                    self._logger.exception('An exception was raised by Scheduler._purge_tasks')
+                except Exception as ex:
+                    self._logger.exception('An exception was raised by Scheduler._purge_tasks %s', str(ex))
 
             self._resume_check_schedules()
 
             # Stop the main loop
             try:
                 await self._scheduler_loop_task
-            except Exception:
-                self._logger.exception('An exception was raised by Scheduler._scheduler_loop')
+            except Exception as ex:
+                self._logger.exception('An exception was raised by Scheduler._scheduler_loop %s', str(ex))
             self._scheduler_loop_task = None
 
         # Can not iterate over _task_processes - it can change mid-iteration
@@ -860,7 +860,7 @@ class Scheduler(object):
             await asyncio.sleep(1)
 
         if self._task_processes:
-            raise TimeoutError()
+            raise TimeoutError("Timeout Error: Could not stop scheduler")
 
         self._schedule_executions = None
         self._task_processes = None
@@ -872,14 +872,9 @@ class Scheduler(object):
         self._start_time = None
 
         self._logger.info("Stopped")
-
         return True
 
-
-
-
-
-    # -------------------------------------------- CRUD methods for scheduled_processes, schedules, tasks
+    # CRUD methods for scheduled_processes, schedules, tasks
 
     async def get_scheduled_processes(self) -> List[ScheduledProcess]:
         """Retrieves all rows from the scheduled_processes table

--- a/python/foglamp/services/core/server.py
+++ b/python/foglamp/services/core/server.py
@@ -569,7 +569,7 @@ class Server:
             cls.scheduler = None
         except TimeoutError as e:
             _logger.exception('Unable to stop the scheduler')
-            raise
+            raise e
 
     @classmethod
     async def ping(cls, request):

--- a/python/foglamp/services/south/server.py
+++ b/python/foglamp/services/south/server.py
@@ -199,15 +199,18 @@ class Server(FoglampMicroservice):
 
         try:
             await Ingest.stop()
-        except Exception:
-            _LOGGER.exception('Unable to stop the Ingest server')
+        except Exception as ex:
+            _LOGGER.exception('Unable to stop the Ingest server. %s', str(ex))
             return
 
         # Finish all pending asyncio tasks
         pending = asyncio.Task.all_tasks()
-        asyncio.gather(*pending)
+        for p in pending:
+            p.cancel()
 
-        # This deactivates event loop and helps aiohttp microservice server instance in graceful shutdown
+        # This deactivates event loop and
+        # helps aiohttp microservice server instance in graceful shutdown
+        _LOGGER.info('Stopping South Services Event Loop')
         loop.stop()
 
     async def shutdown(self, request):


### PR DESCRIPTION
This PR is on top of FOGL-653, though these fixes are really imp for develop branch itself (even if applied without FOGL-653)

* needs a test for http south plugin shutdown

**more improvements (may be separate JIRA)**

* needs a fix north task/ plugin shutdown/cleanup
* then check why scheduler still get timeout error (if it does even then)
* shutdown microservices (with their aiohttp instance loop) before  Or after scheduler stop