### PR TITLE
FOGL-965 Make FogLAMP continue without avahi present

### DIFF
--- a/python/foglamp/services/common/service_announcer.py
+++ b/python/foglamp/services/common/service_announcer.py
@@ -7,6 +7,7 @@
 """Common FoglampMicroservice Class"""
 
 import foglamp.services.common.avahi as avahi
+from foglamp.common import logger
 import dbus
 
 __author__ = "Mark Riddoch"
@@ -14,6 +15,7 @@ __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
+_LOGGER = logger.setup(__name__)
 
 class ServiceAnnouncer:
     _service_name = None
@@ -23,24 +25,27 @@ class ServiceAnnouncer:
     """ The Avahi group """
 
     def __init__(self, name, service, port, txt):
-        bus = dbus.SystemBus()
-        server = dbus.Interface(bus.get_object(avahi.DBUS_NAME, avahi.DBUS_PATH_SERVER), avahi.DBUS_INTERFACE_SERVER)
-        self._group = dbus.Interface(bus.get_object(avahi.DBUS_NAME, server.EntryGroupNew()),
+        try:
+            bus = dbus.SystemBus()
+            server = dbus.Interface(bus.get_object(avahi.DBUS_NAME, avahi.DBUS_PATH_SERVER), avahi.DBUS_INTERFACE_SERVER)
+            self._group = dbus.Interface(bus.get_object(avahi.DBUS_NAME, server.EntryGroupNew()),
                                      avahi.DBUS_INTERFACE_ENTRY_GROUP)
 
-        self._service_name = name
-        index = 1
-        while True:
-            try:
-                self._group.AddService(avahi.IF_UNSPEC, avahi.PROTO_INET, 0, self._service_name, service, '', '', port,
+            self._service_name = name
+            index = 1
+            while True:
+                try:
+                    self._group.AddService(avahi.IF_UNSPEC, avahi.PROTO_INET, 0, self._service_name, service, '', '', port,
                                        avahi.string_array_to_txt_array(txt))
-            except dbus.DBusException:  # name collision -> rename
-                index += 1
-                self._service_name = '%s #%s' % (name, str(index))
-            else:
-                break
-
-        self._group.Commit()
+                except dbus.DBusException:  # name collision -> rename
+                    index += 1
+                    self._service_name = '%s #%s' % (name, str(index))
+                else:
+                    break
+            
+            self._group.Commit()
+        except Exception:
+            _LOGGER.error("Avahi not available, continuing without service discovery available")
 
     @property
     def get_service_name(self):


### PR DESCRIPTION
When Avahi is not available messages are logged in syslog...

Jan 18 10:43:08 ubuntu-test FogLAMP[5953] INFO: server: foglamp.services.core.server: Announce management API service
Jan 18 10:43:08 ubuntu-test FogLAMP[5953] ERROR: service_announcer: foglamp.services.common.service_announcer: Avahi not available, continuing without service discovery available
Jan 18 10:43:08 ubuntu-test FogLAMP[5953] INFO: server: foglamp.services.core.server: REST API Server started on http://0.0.0.0:8081
Jan 18 10:43:08 ubuntu-test FogLAMP[5953] ERROR: service_announcer: foglamp.services.common.service_announcer: Avahi not available, continuing without service discovery available
Jan 18 10:43:08 ubuntu-test FogLAMP[5953] ERROR: service_announcer: foglamp.services.common.service_announcer: Avahi not available, continuing without service discovery available