### PR TITLE
FOGL-846 browser time series test fixes

### DIFF
--- a/python/foglamp/services/core/api/browser.py
+++ b/python/foglamp/services/core/api/browser.py
@@ -52,7 +52,6 @@ __version__ = "${VERSION}"
 __DEFAULT_LIMIT = 20
 __DEFAULT_OFFSET = 0
 __TIMESTAMP_FMT = 'YYYY-MM-DD HH24:MI:SS.MS'
-_NO_RECORDS_FOUND = {"message": "No Records found"}
 
 
 def setup(app):
@@ -64,7 +63,7 @@ def setup(app):
     app.router.add_route('GET', '/foglamp/asset/{asset_code}/{reading}/series', asset_averages)
 
 
-def validate_limit_skip(request, _dict):
+def prepare_limit_skip_payload(request, _dict):
     """ limit skip clause validation
 
     Args:
@@ -102,8 +101,11 @@ async def asset_counts(request):
     """ Browse all the assets for which we have recorded readings and
     return a readings count.
 
-    Return the result of the query
-    SELECT asset_code, count(*) FROM readings GROUP BY asset_code;
+    Returns:
+           json result on basis of SELECT asset_code, count(*) FROM readings GROUP BY asset_code;
+
+    :Example:
+            curl -X GET http://localhost:8081/foglamp/asset
     """
 
     # TODO: FOGL-643 - Aggregate with alias support needed to use payload builder
@@ -133,8 +135,13 @@ async def asset(request):
     return is defaulted to a small number (20), this may be changed by supplying
     the query parameter ?limit=xx&skip=xx
 
-    Return the result of the query
-    SELECT TO_CHAR(user_ts, '__TIMESTAMP_FMT') as "timestamp", (reading)::jsonFROM readings WHERE asset_code = 'asset_code' ORDER BY user_ts DESC LIMIT 20 OFFSET 0
+    Returns:
+          json result on basis of SELECT TO_CHAR(user_ts, '__TIMESTAMP_FMT') as "timestamp", (reading)::jsonFROM readings WHERE asset_code = 'asset_code' ORDER BY user_ts DESC LIMIT 20 OFFSET 0;
+
+    :Example:
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity?limit=1
+            curl -X GET "http://localhost:8081/foglamp/asset/fogbench%2Fhumidity?limit=1&skip=1"
     """
     asset_code = request.match_info.get('asset_code', '')
 
@@ -147,11 +154,9 @@ async def asset(request):
     d.update(_and_where)
 
     # Add the order by and limit, offset clause
-    _limit_skip_payload = validate_limit_skip(request, d)
-    _sort_payload = PayloadBuilder(_limit_skip_payload).ORDER_BY(["user_ts", "desc"]).chain_payload()
-    d.update(_sort_payload)
-
-    payload = json.dumps(d)
+    _limit_skip_payload = prepare_limit_skip_payload(request, d)
+    payload = PayloadBuilder(_limit_skip_payload).ORDER_BY(["timestamp", "desc"]).payload()
+    
     results = {}
     try:
         _storage = connect.get_storage()
@@ -185,8 +190,14 @@ async def asset_reading(request):
 
     Only one of hour, minutes or seconds should be supplied
 
-    Return the result of the query
-    SELECT TO_CHAR(user_ts, '__TIMESTAMP_FMT') as "timestamp", reading->>'reading' FROM readings WHERE asset_code = 'asset_code' ORDER BY user_ts DESC LIMIT 20 OFFSET 0
+    Returns:
+           json result on basis of SELECT TO_CHAR(user_ts, '__TIMESTAMP_FMT') as "timestamp", reading->>'reading' FROM readings WHERE asset_code = 'asset_code' ORDER BY user_ts DESC LIMIT 20 OFFSET 0;
+
+    :Example:
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature?limit=1
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature?skip=10
+            curl -X GET "http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature?limit=1&skip=10"
     """
     asset_code = request.match_info.get('asset_code', '')
     reading = request.match_info.get('reading', '')
@@ -204,11 +215,9 @@ async def asset_reading(request):
     d.update(_and_where)
 
     # Add the order by and limit, offset clause
-    _limit_skip_payload = validate_limit_skip(request, d)
-    _sort_payload = PayloadBuilder(_limit_skip_payload).ORDER_BY(["user_ts", "desc"]).chain_payload()
-    d.update(_sort_payload)
+    _limit_skip_payload = prepare_limit_skip_payload(request, d)
+    payload = PayloadBuilder(_limit_skip_payload).ORDER_BY(["timestamp", "desc"]).payload()
 
-    payload = json.dumps(d)
     results = {}
     try:
         _storage = connect.get_storage()
@@ -241,8 +250,11 @@ async def asset_summary(request):
 
     Only one of hour, minutes or seconds should be supplied
 
-    Return the result of the query
-    SELECT MIN(reading->>'reading'), MAX(reading->>'reading'), AVG((reading->>'reading')::float) FROM readings WHERE asset_code = 'asset_code'
+    Returns:
+           json result on basis of SELECT MIN(reading->>'reading'), MAX(reading->>'reading'), AVG((reading->>'reading')::float) FROM readings WHERE asset_code = 'asset_code';
+
+    :Example:
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature/summary
     """
     asset_code = request.match_info.get('asset_code', '')
     reading = request.match_info.get('reading', '')
@@ -295,18 +307,27 @@ async def asset_averages(request):
     The amount of time covered by each returned value is set using the
     query parameter group. This may be set to seconds, minutes or hours
 
-    Return the result of the query:
+    Returns:
+            on the basis of
+            SELECT min((reading->>'reading')::float) AS "min",
+                   max((reading->>'reading')::float) AS "max",
+                   avg((reading->>'reading')::float) AS "average",
+                   to_char(user_ts, 'YYYY-MM-DD HH24:MI:SS') AS "timestamp"
+            FROM foglamp.readings
+                   WHERE asset_code = 'asset_code' AND
+                     reading ? 'reading'
+            GROUP BY to_char(user_ts, 'YYYY-MM-DD HH24:MI:SS')
+            ORDER BY timestamp DESC;
 
-    SELECT min((reading->>'reading')::float) AS "min",
-           max((reading->>'reading')::float) AS "max",
-           avg((reading->>'reading')::float) AS "average",
-           to_char(user_ts, 'YYYY-MM-DD HH24:MI:SS') AS "timestamp"
-    FROM foglamp.readings
-           WHERE asset_code = 'asset_code' AND
-             reading ? 'reading'
-    GROUP BY to_char(user_ts, 'YYYY-MM-DD HH24:MI:SS')
-    ORDER BY timestamp DESC;
-
+    :Example:
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature/series
+            curl -X GET "http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature/series?limit=1&skip=1"
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature/series?hours=1
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature/series?minutes=60
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature/series?seconds=3600
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature/series?group=seconds
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature/series?group=minutes
+            curl -X GET http://localhost:8081/foglamp/asset/fogbench%2Fhumidity/temperature/series?group=hours
     """
     asset_code = request.match_info.get('asset_code', '')
     reading = request.match_info.get('reading', '')
@@ -339,16 +360,13 @@ async def asset_averages(request):
     _and_where = where_clause(request, _where)
     d.update(_and_where)
 
-    # Add the group by and limit, offset clause
+    # Add the GROUP BY
     d['group'] = timestamp
-    _limit_skip_payload = validate_limit_skip(request, d)
-    d.update(_limit_skip_payload)
 
-    # Add ORDER BY timestamp DESC
-    _sort_payload = PayloadBuilder(_limit_skip_payload).ORDER_BY(["timestamp", "desc"]).chain_payload()
-    d.update(_sort_payload)
+    # Add LIMIT, OFFSET, ORDER BY timestamp DESC
+    _limit_skip_payload = prepare_limit_skip_payload(request, d)
+    payload = PayloadBuilder(_limit_skip_payload).ORDER_BY(["timestamp", "desc"]).payload()
 
-    payload = json.dumps(d)
     results = {}
     try:
         _storage = connect.get_storage()

--- a/tests/integration/foglamp/services/core/api/test_browser_assets.py
+++ b/tests/integration/foglamp/services/core/api/test_browser_assets.py
@@ -131,6 +131,8 @@ class TestBrowseAssets:
     async def test_get_all_assets(self):
         """
         Verify that Asset contains the test data and readings count is equal to the number of readings inserted
+
+        http://localhost:8081/foglamp/asset
         """
         conn = http.client.HTTPConnection(BASE_URL)
         conn.request("GET", '/foglamp/asset')
@@ -148,6 +150,7 @@ class TestBrowseAssets:
     async def test_get_asset_readings(self):
         """
         Verify that if more than 20 readings, only 20 are returned as the default limit for asset_code
+
         http://localhost:8081/foglamp/asset/TESTAPI
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -162,6 +165,7 @@ class TestBrowseAssets:
     async def test_get_asset_readings_q_limit(self):
         """
         Verify that if more than 20 readings, limited readings are returned for asset_code when querying with limit
+
         http://localhost:8081/foglamp/asset/TESTAPI?limit=1
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -182,6 +186,7 @@ class TestBrowseAssets:
         """
         Verify that if more than 20 readings, only last n sec readings are returned
         when seconds is passed as query parameter
+
         http://localhost:8081/foglamp/asset/TESTAPI?seconds=15
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -202,6 +207,7 @@ class TestBrowseAssets:
         """
         Verify that if more than 20 readings, only last n min readings are returned
         when minutes is passed as query parameter
+
         http://localhost:8081/foglamp/asset/TESTAPI?minutes=15
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -225,6 +231,7 @@ class TestBrowseAssets:
         """
         Verify that if more than 20 readings, only last n hrs readings are returned
         when hours is passed as query parameter
+
         http://localhost:8081/foglamp/asset/TESTAPI?hours=2
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -250,6 +257,7 @@ class TestBrowseAssets:
     async def test_get_asset_readings_q_time_complex(self):
         """
         Verify that if a combination of hrs, min, sec is used, shortest period will apply
+
         http://localhost:8081/foglamp/asset/TESTAPI?hours=20&minutes=20&seconds=20&limit=20
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -271,6 +279,7 @@ class TestBrowseAssets:
     async def test_get_asset_sensor_readings(self):
         """
         Verify that if more than 20 readings for an assets sensor value, only 20 are returned as the default limit
+
         http://localhost:8081/foglamp/asset/TESTAPI/x
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -285,6 +294,7 @@ class TestBrowseAssets:
     async def test_get_asset_sensor_readings_with_empty_params(self):
         """
         Verify that if more than 20 readings for an assets sensor value, only 20 are returned as the default limit
+
         http://localhost:8081/foglamp/asset/TESTAPI/x
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -300,6 +310,7 @@ class TestBrowseAssets:
     async def test_get_asset_sensor_readings_q_limit(self):
         """
         Verify that if more than 20 readings, limited readings for a sensor value are returned when querying with limit
+
         http://localhost:8081/foglamp/asset/TESTAPI/x?limit=1
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -317,6 +328,7 @@ class TestBrowseAssets:
         """
         Verify that if more than 20 readings, only last n sec readings for a sensor value are returned when
         seconds is passed as query parameter
+
         http://localhost:8081/foglamp/asset/TESTAPI/x?seconds=120
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -334,6 +346,7 @@ class TestBrowseAssets:
         """
         Verify that if more than 20 readings, only last n min readings for a sensor value are returned when
         minutes is passed as query parameter
+
         http://localhost:8081/foglamp/asset/TESTAPI/x?minutes=20
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -353,6 +366,7 @@ class TestBrowseAssets:
         """
         Verify that if more than 20 readings, only last n hr readings for a sensor value are returned when
         hours is passed as query parameter
+
         http://localhost:8081/foglamp/asset/TESTAPI/x?hours=2
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -373,6 +387,7 @@ class TestBrowseAssets:
     async def test_get_asset_sensor_readings_q_time_complex(self):
         """
         Verify that if a combination of hrs, min, sec is used, shortest period will apply for sensor reading
+
         http://localhost:8081/foglamp/asset/TESTAPI/x?hours=20&minutes=20&seconds=120&limit=20
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -415,6 +430,7 @@ class TestBrowseAssets:
         """
         Verify min, max, avg summary values of only last n sec readings for a sensor value are returned when
         seconds is passed as query parameter
+
         http://localhost:8081/foglamp/asset/TESTAPI/x/summary?seconds=180
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -508,10 +524,10 @@ class TestBrowseAssets:
     """
     Tests for time averaged sensor values
     """
-    @pytest.mark.xfail(reason="FOGL-547")
     async def test_get_asset_sensor_readings_time_avg(self):
         """
         Verify that series data is grouped by default on seconds
+
         http://localhost:8081/foglamp/asset/TESTAPI/x/series
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -524,13 +540,14 @@ class TestBrowseAssets:
 
         # Find unique set of times grouped by seconds from test data
         grouped_ts_sec = self.group_date_time(unit="second")
+        sensor_code_1_list = self.test_data_x_val_list[-1]
 
         # Verify the length of groups and value of last element. Test data has only 1 record for last second's group
         assert len(retval) == len(grouped_ts_sec)
-        assert retval[-1]["average"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["max"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["min"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["time"] == grouped_ts_sec[-1]
+        assert retval[0]["max"] == str(sensor_code_1_list)
+        assert retval[0]["min"] == str(sensor_code_1_list)
+        assert retval[0]["timestamp"] == str(grouped_ts_sec[-1])
+        assert retval[0]["average"] == str(sensor_code_1_list)
 
     async def test_get_asset_sensor_readings_invalid_group(self):
         conn = http.client.HTTPConnection(BASE_URL)
@@ -540,10 +557,10 @@ class TestBrowseAssets:
         assert r.status == 400
         assert r.reason == "blah is not a valid group"
 
-    @pytest.mark.xfail(reason="FOGL-547")
     async def test_get_asset_sensor_readings_time_avg_q_group_sec(self):
         """
         Verify that series data is grouped by seconds
+
         http://localhost:8081/foglamp/asset/TESTAPI/x/series?group=seconds
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -556,18 +573,19 @@ class TestBrowseAssets:
 
         # Find unique set of times grouped by seconds from test data
         grouped_ts_sec = self.group_date_time(unit="second")
+        sensor_code_1_list = self.test_data_x_val_list[-1]
 
         # Grouped by 'YYY-MM-DD hh:mm:ss' returns 4 data points, verify the last data point with last value of test data
         assert len(retval) == len(grouped_ts_sec)
-        assert retval[-1]["average"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["max"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["min"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["time"] == grouped_ts_sec[-1]
+        assert retval[0]["max"] == str(sensor_code_1_list)
+        assert retval[0]["min"] == str(sensor_code_1_list)
+        assert retval[0]["timestamp"] == str(grouped_ts_sec[-1])
+        assert retval[0]["average"] == str(sensor_code_1_list)
 
-    @pytest.mark.xfail(reason="FOGL-547")
     async def test_get_asset_sensor_readings_time_avg_q_group_min(self):
         """
         Verify that series data is grouped by minutes
+
         http://localhost:8081/foglamp/asset/TESTAPI/x/series?group=minutes
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -579,18 +597,19 @@ class TestBrowseAssets:
         retval = json.loads(r)
         # Find unique set of times grouped by minutes from test data
         grouped_ts_min = self.group_date_time(unit="minute")
+        sensor_code_1_list = self.test_data_x_val_list[-1]
 
         # Grouped by 'YYY-MM-DD hh:mm' returns 4 data points, verify the last data point with last value of test data
         assert len(retval) == len(grouped_ts_min)
-        assert retval[-1]["average"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["max"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["min"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["time"] == grouped_ts_min[-1]
+        assert retval[0]["max"] == str(sensor_code_1_list)
+        assert retval[0]["min"] == str(sensor_code_1_list)
+        assert retval[0]["timestamp"] == str(grouped_ts_min[-1])
+        assert retval[0]["average"] == str(sensor_code_1_list)
 
-    @pytest.mark.xfail(reason="FOGL-547")
     async def test_get_asset_sensor_readings_time_avg_q_group_hrs(self):
         """
         Verify that series data is grouped by hours
+
         http://localhost:8081/foglamp/asset/TESTAPI/x/series?group=hours
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -602,18 +621,21 @@ class TestBrowseAssets:
         retval = json.loads(r)
         # Find unique set of times grouped by hours from test data
         grouped_ts_hrs = self.group_date_time(unit="hour")
+        sensor_code_1_list = self.test_data_x_val_list[-2:]
+        avg = sum(sensor_code_1_list) / len(sensor_code_1_list)
 
         # Verify the values of a group, We know last 2 records of test data were created within the same hour
         assert len(retval) == len(grouped_ts_hrs)
-        assert retval[-1]["average"] == sum(self.test_data_x_val_list[-2:]) / len(self.test_data_x_val_list[-2:])
-        assert retval[-1]["max"] == max(self.test_data_x_val_list[-2:])
-        assert retval[-1]["min"] == min(self.test_data_x_val_list[-2:])
-        assert retval[-1]["time"] == grouped_ts_hrs[-1]
+        assert retval[0]["max"] == str(max(sensor_code_1_list))
+        assert retval[0]["min"] == str(min(sensor_code_1_list))
+        assert retval[0]["timestamp"] == str(grouped_ts_hrs[-1])
+        assert pytest.approx(retval[0]["average"], str(avg))
 
-    @pytest.mark.xfail(reason="FOGL-547")
+    @pytest.mark.xfail(reason="FOGl-510 - need proper test environment")
     async def test_get_asset_sensor_readings_time_avg_q_limit_group_hrs(self):
         """
         Verify that series data is grouped by hours and limits are working
+
         http://localhost:8081/foglamp/asset/TESTAPI/x/series?group=hours&limit=1
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -630,15 +652,15 @@ class TestBrowseAssets:
 
         # Verify the values of a group, We know first 19 records of test data were created within the same hour
         assert len(retval) == 1
-        assert retval[-1]["average"] == sum(self.test_data_x_val_list[:19]) / len(self.test_data_x_val_list[:19])
-        assert retval[-1]["max"] == max(self.test_data_x_val_list[:19])
-        assert retval[-1]["min"] == min(self.test_data_x_val_list[:19])
-        assert retval[-1]["time"] == grouped_ts_hrs[0]
+        assert retval[0]["average"] == str(sum(self.test_data_x_val_list[:19]) / len(self.test_data_x_val_list[:19]))
+        assert retval[0]["max"] == str(max(self.test_data_x_val_list[:19]))
+        assert retval[0]["min"] == str(min(self.test_data_x_val_list[:19]))
+        assert retval[0]["timestamp"] == str(grouped_ts_hrs[0])
 
-    @pytest.mark.xfail(reason="FOGL-547")
     async def test_get_asset_sensor_readings_time_avg_q_time(self):
         """
         Verify that series data is grouped by seconds (default) and time range (last n minutes) is working
+
         http://localhost:8081/foglamp/asset/TESTAPI/x/series?minutes=20
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -651,24 +673,26 @@ class TestBrowseAssets:
 
         # Find unique set of times grouped by seconds (default grouping) from test data
         grouped_ts = self.group_date_time()
+        sensor_code_1_list1 = str(self.test_data_x_val_list[-1])
+        sensor_code_1_list2 = str(self.test_data_x_val_list[-2])
 
         # Verify the values of a group (default by sec), has 2 records only when querying for last 20 min
         # For last n min, grouped by 'YYY-MM-DD hh:mm:ss' verify with last and second last test data
         assert len(retval) == 2
-        assert retval[-1]["average"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["max"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["min"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["time"] == grouped_ts[-1]
+        assert retval[0]["max"] == sensor_code_1_list1
+        assert retval[0]["min"] == sensor_code_1_list1
+        assert retval[0]["timestamp"] == str(grouped_ts[-1])
+        assert retval[0]["average"] == sensor_code_1_list1
 
-        assert retval[-2]["average"] == self.test_data_x_val_list[-2]
-        assert retval[-2]["max"] == self.test_data_x_val_list[-2]
-        assert retval[-2]["min"] == self.test_data_x_val_list[-2]
-        assert retval[-2]["time"] == grouped_ts[-2]
+        assert retval[1]["max"] == sensor_code_1_list2
+        assert retval[1]["min"] == sensor_code_1_list2
+        assert retval[1]["timestamp"] == str(grouped_ts[-2])
+        assert retval[1]["average"] == sensor_code_1_list2
 
-    @pytest.mark.xfail(reason="FOGL-547")
     async def test_get_asset_sensor_readings_time_avg_q_group_time_limit(self):
         """
         Verify that if a combination of hrs, min, sec is used, shortest period will apply with specified grouping
+
         http://localhost:8081/foglamp/asset/TESTAPI/x/series?hours=20&minutes=20&seconds=180&limit=20&group=hours
         """
         conn = http.client.HTTPConnection(BASE_URL)
@@ -682,14 +706,15 @@ class TestBrowseAssets:
 
         # Find unique set of times grouped by hours from test data
         grouped_ts = self.group_date_time(unit="hour")
+        sensor_code_1_list = str(self.test_data_x_val_list[-1])
 
         # Verify the values of a group, has 1 record only (shortest time) and hourly grouping
         # For example in last 180 sec, grouped by 'YYY-MM-DD hh' is equal to last record of test data
         assert len(retval) == 1
-        assert retval[-1]["average"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["max"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["min"] == self.test_data_x_val_list[-1]
-        assert retval[-1]["time"] == grouped_ts[-1]
+        assert retval[0]["max"] == sensor_code_1_list
+        assert retval[0]["min"] == sensor_code_1_list
+        assert retval[0]["timestamp"] == grouped_ts[-1]
+        assert retval[0]["average"] == sensor_code_1_list
 
     @pytest.mark.parametrize("request_params, response_code, response_message", [
         ('?limit=invalid', 400, "Limit must be a positive integer"),


### PR DESCRIPTION
**FOGL-547** removed from browser tests and curl examples added for asset browser end-points.

**Tests O/p**: All passed except one (xfail with reason=FOGL-510)

```
collected 38 items 

test_browser_assets.py::TestBrowseAssets::test_get_all_assets PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_limit PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_sec PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_min PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_hrs PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_readings_q_time_complex PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_with_empty_params PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_limit PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_sec PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_min PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_hrs PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_q_time_complex PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_sec PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_min PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_hrs PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_stats_q_time_complex PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_invalid_group PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_sec PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_min PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_hrs PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_limit_group_hrs xfail
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_time PASSED
test_browser_assets.py::TestBrowseAssets::test_get_asset_sensor_readings_time_avg_q_group_time_limit PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?limit=invalid-400-Limit must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?limit=-1-400-Limit must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?skip=invalid-400-Skip/Offset must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?skip=-1-400-Skip/Offset must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?minutes=-1-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?minutes=blah-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?seconds=-1-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?seconds=blah-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?hours=-1-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_params_with_bad_data[?hours=blah-400-Time must be a positive integer] PASSED
test_browser_assets.py::TestBrowseAssets::test_error_when_no_rows_key_available PASSED

== 37 passed, 1 xfailed in 1.62 seconds ==
```