### PR TITLE
FOGL-976 removed skip/xfail annotation for configuration integration tests and use of conftest

### DIFF
--- a/tests/integration/foglamp/common/test_configuration_manager.py
+++ b/tests/integration/foglamp/common/test_configuration_manager.py
@@ -30,7 +30,10 @@ _configuration_tbl = sa.Table(
     sa.Column('ts', sa.types.TIMESTAMP)
 )
 
-_storage = StorageClient(core_management_host='0.0.0.0', core_management_port=43411, svc=None)
+_ADDRESS = pytest.test_env.address
+_MGT_PORT = pytest.test_env.core_mgmt_port
+
+_storage = StorageClient(core_management_host=_ADDRESS, core_management_port=_MGT_PORT, svc=None)
 cf_mgr = None
 
 
@@ -48,11 +51,7 @@ class TestConfigurationManager:
     """ configuration_manager tests
 
     The following tests need to be fixed/implemented:
-
-        - Anything that is currently under @pytest.mark.xfail; currently doesn't work due to an expected behavior change
         - FOGL-572: Verification of data type value in configuration manager (new test needs to be added)
-        - FOGL-577: Missing expected error when getting value to non-existent category
-        - 1 not yet implemented test
     """
 
     def setup_method(self):
@@ -146,9 +145,9 @@ class TestConfigurationManager:
 
         for category_name in data:
             await self.cf_mgr.create_category(category_name=category_name,
-                                  category_description=data[category_name]['category_description'],
-                                  category_value=data[category_name]['category_value'],
-                                  keep_original_items=True)
+                                              category_description=data[category_name]['category_description'],
+                                              category_value=data[category_name]['category_value'],
+                                              keep_original_items=True)
 
         sql = sa.text("SELECT * FROM foglamp.configuration WHERE key IN {}".format(_KEYS))
         async with aiopg.sa.create_engine(_CONNECTION_STRING) as engine:
@@ -182,21 +181,13 @@ class TestConfigurationManager:
             2. values in 'data' category are as expected
             3. values in 'info' category did not change
         """
+        cat_val1 = {'info': {'description': 'boolean type with default False', 'type': 'boolean', 'default': 'False'}}
         await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
-                              category_value={
-                                  'info': {
-                                      'description': 'boolean type with default False',
-                                      'type': 'boolean',
-                                      'default': 'False'}},
-                              keep_original_items=False)
+                                          category_value=cat_val1, keep_original_items=False)
 
-        await self.cf_mgr.create_category(category_name='boolean',
-                              category_description='boolean type',
-                              category_value={'data': {
-                                  'description': 'int type with default 0',
-                                  'type': 'integer',
-                                  'default': '0'}},
-                              keep_original_items=True)
+        cat_val2 = {'data': {'description': 'int type with default 0', 'type': 'integer', 'default': '0'}}
+        await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
+                                          category_value=cat_val2, keep_original_items=True)
 
         category_info = await self.cf_mgr.get_category_all_items(category_name='boolean')
         # Both category_values exist
@@ -218,19 +209,13 @@ class TestConfigurationManager:
             2. `values` dictionary only has 'data' category
             3. values in 'data' category are as expected
         """
+        cat_val1 = {'info': {'description': 'boolean type with default False', 'type': 'boolean', 'default': 'False'}}
         await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
-                              category_value={'info': {
-                                  'description': 'boolean type with default False',
-                                  'type': 'boolean',
-                                  'default': 'False'}})
+                                          category_value=cat_val1)
 
-        await self.cf_mgr.create_category(category_name='boolean',
-                              category_description='boolean type',
-                              category_value={'data': {
-                                  'description': 'int type with default 0',
-                                  'type': 'integer',
-                                  'default': '0'}},
-                              keep_original_items=False)
+        cat_val2 = {'data': {'description': 'int type with default 0', 'type': 'integer', 'default': '0'}}
+        await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
+                                          category_value=cat_val2, keep_original_items=False)
 
         category_info = await self.cf_mgr.get_category_all_items(category_name='boolean')
         # only 'data category_values exist
@@ -240,17 +225,12 @@ class TestConfigurationManager:
         assert category_info['data']['type'] == 'integer'
         assert category_info['data']['default'] == '0'
 
-    @pytest.mark.skip(reason="FOGL-690")
     async def test_create_category_with_quoted_json_data(self):
         """ Test the behavior of create_category when quoted string in json data
         """
+        cat_val = {"data": {'description': "string type with 'default' value", 'type': 'string', 'default': 'test'}}
         await self.cf_mgr.create_category(category_name='string', category_description='boolean type',
-                              category_value={
-                                  "data": {
-                                      'description': "string type with 'default' value",
-                                      'type': 'string',
-                                      'default': 'test'}},
-                              keep_original_items=False)
+                                          category_value=cat_val, keep_original_items=False)
 
         category_info = await self.cf_mgr.get_category_all_items(category_name='string')
         assert category_info['data']['description'] == "string type with 'default' value"
@@ -268,17 +248,14 @@ class TestConfigurationManager:
             1. `default` and `value` in configuration.value are the same
             2. `value` in configuration.value gets updated, while `default` does not
         """
+        cat_val = {'info': {'description': 'boolean type with default False', 'type': 'boolean', 'default': 'False'}}
         await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
-                              category_value={
-                                  'info': {
-                                      'description': 'boolean type with default False',
-                                      'type': 'boolean',
-                                      'default': 'False'}})
+                                          category_value=cat_val)
         result = await self.cf_mgr.get_category_item_value_entry(category_name='boolean', item_name='info')
         assert result == 'False'
 
-        await self.cf_mgr.set_category_item_value_entry(category_name='boolean',
-                                            item_name='info', new_value_entry='True')
+        await self.cf_mgr.set_category_item_value_entry(category_name='boolean', item_name='info',
+                                                        new_value_entry='True')
         result = await self.cf_mgr.get_category_item_value_entry(category_name='boolean', item_name='info')
         assert result == 'True'
 
@@ -289,13 +266,9 @@ class TestConfigurationManager:
             Information in configuration.value match the category_values declared
 
         """
+        cat_val = {'info': {'description': 'boolean type with default False', 'type': 'boolean', 'default': 'False'}}
         await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
-                              category_value={
-                                  'info': {
-                                      'description': 'boolean type with default False',
-                                      'type': 'boolean',
-                                      'default': 'False'}
-                              })
+                                          category_value=cat_val)
         result = await self.cf_mgr.get_category_item(category_name='boolean', item_name='info')
         assert result['description'] == 'boolean type with default False'
         assert result['type'] == 'boolean'
@@ -310,7 +283,7 @@ class TestConfigurationManager:
         """
         with pytest.raises(TypeError) as error_exec:
             await self.cf_mgr.create_category(category_name='integer', category_description='integer type',
-                                  category_value='1')
+                                              category_value='1')
         assert "TypeError: category_val must be a dictionary" in str(error_exec)
 
     async def test_create_category_invalid_name(self):
@@ -319,12 +292,10 @@ class TestConfigurationManager:
         :assert:
             Assert that TypeError gets returned when name is not allowed other than string
         """
+        cat_val = {'info': {'description': 'invalid name with None type', 'type': 'None', 'default': 'none'}}
         with pytest.raises(TypeError) as error_exec:
             await self.cf_mgr.create_category(category_name=None, category_description='invalid name',
-                                  category_value={
-                                      'info': {
-                                          'description': 'invalid name with None type',
-                                          'type': 'None', 'default': 'none'}})
+                                              category_value=cat_val)
         assert "TypeError: category_name must be a string" in str(error_exec)
 
     async def test_create_category_invalid_type(self):
@@ -333,13 +304,10 @@ class TestConfigurationManager:
         :assert:
             Assert that TypeError gets returned when type is not allowed e.g. float
         """
+        cat_val = {'info': {'description': 'float type with default 1.1', 'type': 'float', 'default': '1.1'}}
         with pytest.raises(ValueError) as error_exec:
             await self.cf_mgr.create_category(category_name='float', category_description='float type',
-                                  category_value={
-                                      'info': {
-                                          'description': 'float type with default 1.1',
-                                          'type': 'float',
-                                          'default': '1.1'}})
+                                              category_value=cat_val)
         assert ('ValueError: Invalid entry_val for entry_name "type" for item_name info. valid: ' +
                 "['boolean', 'integer', 'string', 'IPv4', " +
                 "'IPv6', 'X509 certificate', 'password', 'JSON']") in str(error_exec)
@@ -352,14 +320,10 @@ class TestConfigurationManager:
         """
         # TODO: should be case insensitive? EVEN for this SCREAMING_SNAKE_CASE makes more sense!
         # e.g. X509_CERTIFICATE, IPV4 etc.
-
+        cat_val = {'info': {'description': 'INTEGER type with default 1', 'type': 'INTEGER', 'default': '1'}}
         with pytest.raises(ValueError) as error_exec:
             await self.cf_mgr.create_category(category_name='INTEGER', category_description='INTEGER type',
-                                  category_value={
-                                      'info': {
-                                          'description': 'INTEGER type with default 1',
-                                          'type': 'INTEGER',
-                                          'default': '1'}})
+                                              category_value=cat_val)
         assert ('ValueError: Invalid entry_val for entry_name "type" for item_name info. valid: ' +
                 "['boolean', 'integer', 'string', 'IPv4', " +
                 "'IPv6', 'X509 certificate', 'password', 'JSON']") in str(error_exec)
@@ -370,13 +334,10 @@ class TestConfigurationManager:
         :assert:
             Assert TypeError when type is set to bool rather than 'boolean'
         """
+        cat_val = {'info': {'description': 'boolean type with default False', 'type': bool, 'default': 'False'}}
         with pytest.raises(TypeError) as error_exec:
             await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
-                                  category_value={'info': {
-                                      'description': 'boolean type with default False',
-                                      'type': bool,
-                                      'default': 'False'
-                                  }})
+                                              category_value=cat_val)
         assert ("TypeError: entry_val must be a string for item_name " +
                 "info and entry_name type") in str(error_exec)
 
@@ -386,14 +347,11 @@ class TestConfigurationManager:
         :assert:
             Assert TypeError when default is set to False rather than 'False'
         """
+
+        cat_val = {'info': {'description': 'boolean type with default False', 'type': 'boolean', 'default': False}}
         with pytest.raises(TypeError) as error_exec:
-            await self.cf_mgr.create_category(category_name='boolean',
-                                  category_description='boolean type',
-                                  category_value={'info': {
-                                      'description': 'boolean type with default False',
-                                      'type': 'boolean',
-                                      'default': False
-                                  }})
+            await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
+                                              category_value=cat_val)
         assert ("TypeError: entry_val must be a string for item_name "
                 "info and entry_name default") in str(error_exec)
 
@@ -404,14 +362,10 @@ class TestConfigurationManager:
             Assert TypeError when description is set to None rather than  string
             note: Empty string is allowed for description
         """
+        cat_val = {'info': {'description': None, 'type': 'boolean', 'default': 'False'}}
         with pytest.raises(TypeError) as error_exec:
-            await self.cf_mgr.create_category(category_name='boolean',
-                                  category_description='boolean type',
-                                  category_value={'info': {
-                                      'description': None,
-                                      'type': 'boolean',
-                                      'default': 'False'
-                                  }})
+            await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
+                                              category_value=cat_val)
         assert ("TypeError: entry_val must be a string for item_name " +
                 "info and entry_name description") in str(error_exec)
 
@@ -421,12 +375,11 @@ class TestConfigurationManager:
         :assert:
             Assert ValueError when type is missing
         """
+        cat_val = {'info': {'description': 'boolean type with default False', 'default': 'False'}}
+
         with pytest.raises(ValueError) as error_exec:
             await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
-                                  category_value={
-                                      'info': {
-                                          'description': 'boolean type with default False',
-                                          'default': 'False'}})
+                                              category_value=cat_val)
         assert "ValueError: Missing entry_name type for item_name info" in str(error_exec)
 
     async def test_create_category_missing_entry_for_description(self):
@@ -435,12 +388,10 @@ class TestConfigurationManager:
         :assert:
             Assert ValueError when description is missing
         """
+        cat_val = {'info': {'type': 'boolean', 'default': 'False'}}
         with pytest.raises(ValueError) as error_exec:
             await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
-                                  category_value={
-                                      'info': {
-                                          'type': 'boolean',
-                                          'default': 'False'}})
+                                              category_value=cat_val)
         assert "ValueError: Missing entry_name description for item_name info" in str(error_exec)
 
     async def test_create_category_missing_value_for_default(self):
@@ -450,12 +401,11 @@ class TestConfigurationManager:
         :assert:
             Assert ValueError when default is missing
         """
+        cat_val = {'info': {'description': 'integer type with value False', 'type': 'integer'}}
+
         with pytest.raises(ValueError) as error_exec:
             await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
-                                  category_value={
-                                      'info': {
-                                          'type': 'integer',
-                                          'description': 'integer type with value False'}})
+                                              category_value=cat_val)
         assert "ValueError: Missing entry_name default for item_name info" in str(error_exec)
 
     async def test_create_category_invalid_description(self):
@@ -464,18 +414,11 @@ class TestConfigurationManager:
         :assert:
             Assert that TypeError gets returned when description is not allowed other than string
         """
+        cat_val = {'info': {'description': 'boolean type with default False', 'type': 'boolean', 'default': 'False'}}
         with pytest.raises(TypeError) as error_exec:
             await self.cf_mgr.create_category(category_name="boolean", category_description=None,
-                                  category_value={
-                                      'info': {
-                                          'description': 'boolean type with default False',
-                                          'type': 'boolean', 'default': 'False'}})
+                                              category_value=cat_val)
         assert "TypeError: category_description must be a string" in str(error_exec)
-
-    @pytest.mark.xfail(reason="not yet implemented")
-    async def test_get_all_category_names_error(self):
-        await self.cf_mgr.get_all_category_names()
-        # TODO: assert empty list?
 
     async def test_set_category_item_value_error(self):
         """ Test update of configuration.value when category_name or item_name does not exist
@@ -484,13 +427,12 @@ class TestConfigurationManager:
              Assert that ValueError gets returned on either category_name nor item_name does not exist
         """
         with pytest.raises(ValueError) as error_exec:
-            await self.cf_mgr.set_category_item_value_entry(category_name='boolean',
-                                                item_name='info', new_value_entry='True')
+            await self.cf_mgr.set_category_item_value_entry(category_name='boolean', item_name='info',
+                                                            new_value_entry='True')
 
         assert "ValueError: No detail found for the category_name: boolean and item_name: info"\
                in str(error_exec)
 
-    @pytest.mark.xfail(reason="FOGL-577")
     async def test_get_category_item_value_entry_dne(self):
         """ Test that None gets returned when either category_name and/or item_name don't exist
 
@@ -498,53 +440,39 @@ class TestConfigurationManager:
             1. Assert None is returned when item_name does not exist
             2. Assert None is returned when category_name does not exist
         """
+        cat_val = {'info': {'description': 'boolean type with default False', 'type': 'boolean', 'default': 'False'}}
         await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
-                              category_value={
-                                  'info': {
-                                      'description': 'boolean type with default False',
-                                      'type': 'boolean',
-                                      'default': 'False'}
-                              })
+                                          category_value=cat_val)
         result = await self.cf_mgr.get_category_item_value_entry(category_name='boolean', item_name='data')
         assert result is None
 
         result = await self.cf_mgr.get_category_item_value_entry(category_name='integer', item_name='info')
         assert result is None
 
-    @pytest.mark.xfail(reason="FOGL-577")
     async def test_get_category_item_empty(self):
         """ Test that get_category_item when either category_name or item_name do not exist
 
         :assert:
             Assert result is None when category_name or item_name do not exist in configuration
         """
+        cat_val = {'info': {'description': 'boolean type with default False', 'type': 'boolean', 'default': 'False'}}
         await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
-                              category_value={
-                                  'info': {
-                                      'description': 'boolean type with default False',
-                                      'type': 'boolean',
-                                      'default': 'False'}
-                              })
+                                          category_value=cat_val)
         result = await self.cf_mgr.get_category_item(category_name='integer', item_name='info')
         assert result is None
 
         result = await self.cf_mgr.get_category_item(category_name='boolean', item_name='data')
         assert result is None
 
-    @pytest.mark.xfail(reason="FOGL-577")
-    async def test_get_category_all_items_dne(self):
+    async def test_get_category_all_items_done(self):
         """ Test get_category_all_items doesn't return anything if category_name doesn't exist
 
         :assert:
             Assert None gets returned when category_name does not exist
         """
+        cat_val = {'info': {'description': 'boolean type with default False', 'type': 'boolean', 'default': 'False'}}
         await self.cf_mgr.create_category(category_name='boolean', category_description='boolean type',
-                              category_value={
-                                  'info': {
-                                      'description': 'boolean type with default False',
-                                      'type': 'boolean',
-                                      'default': 'False'}
-                              })
+                                          category_value=cat_val)
 
         result = await self.cf_mgr.get_category_all_items(category_name='integer')
         assert result is None
@@ -619,7 +547,6 @@ class TestConfigurationManager:
         assert list(self.cf_mgr._registered_interests.keys())[0] == 'boolean'
         assert self.cf_mgr._registered_interests['boolean'] == {'tests.callback2'}
 
-
     async def test_unregister_interest_category_name_none_error(self):
         """ Test that error gets returned when category_name is None
 
@@ -641,4 +568,3 @@ class TestConfigurationManager:
             self.cf_mgr.unregister_interest(category_name='integer', callback=None)
         assert "ValueError: Failed to unregister interest. callback cannot be None" in (
             str(error_exec))
-


### PR DESCRIPTION
As [FOGL-577](https://scaledb.atlassian.net/browse/FOGL-577), [FOGl-690](https://scaledb.atlassian.net/browse/FOGL-690) stories are fixed and out of date as of current

**Fixed items**

- [x] fixed configuration integration tests which were skipped/xfailed with above.
- [x] address and mgt port values from conftest now
- [x] Fixed indentation and PEP8 errors/warnings
- [x] **No regression** :white_check_mark: 

**Tests O/p**

```
collected 29 items 

test_configuration_manager.py::TestConfigurationManager::test_accepted_data_types PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_keep_original_items_true PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_keep_original_items_false PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_with_quoted_json_data PASSED
test_configuration_manager.py::TestConfigurationManager::test_set_category_item_value_entry PASSED
test_configuration_manager.py::TestConfigurationManager::test_get_category_item PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_dict PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_name PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_type PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_case_sensitive_type PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_entry_value_for_type PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_entry_value_for_default PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_entry_none_for_description PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_missing_entry_for_type PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_missing_entry_for_description PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_missing_value_for_default PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_description PASSED
test_configuration_manager.py::TestConfigurationManager::test_set_category_item_value_error PASSED
test_configuration_manager.py::TestConfigurationManager::test_get_category_item_value_entry_dne PASSED
test_configuration_manager.py::TestConfigurationManager::test_get_category_item_empty PASSED
test_configuration_manager.py::TestConfigurationManager::test_get_category_all_items_done PASSED
test_configuration_manager.py::TestConfigurationManager::test_register_interest PASSED
test_configuration_manager.py::TestConfigurationManager::test_register_interest_category_name_none_error PASSED
test_configuration_manager.py::TestConfigurationManager::test_register_interest_callback_none_error PASSED
test_configuration_manager.py::TestConfigurationManager::test_unregister_interest_0_callback PASSED
test_configuration_manager.py::TestConfigurationManager::test_unregister_interest_1_callback PASSED
test_configuration_manager.py::TestConfigurationManager::test_unregister_interest_2_callback PASSED
test_configuration_manager.py::TestConfigurationManager::test_unregister_interest_category_name_none_error PASSED
test_configuration_manager.py::TestConfigurationManager::test_unregister_interest_callback_none_error PASSED

== 29 passed in 1.13 seconds ==
```