### PR TITLE
[#no-ticket] Fix for Unit test foglamp.plugins.south.http_south.http_south.HttpSouthIngest

### DIFF
--- a/tests/unit/python/foglamp/plugins/south/test_http_south.py
+++ b/tests/unit/python/foglamp/plugins/south/test_http_south.py
@@ -4,9 +4,9 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-"""Unit test for foglamp.south.http_south"""
+"""Unit test for foglamp.plugins.south.http_south.http_south"""
+
 import json
-import asyncpg
 import pytest
 import asyncio
 from unittest import mock
@@ -14,6 +14,7 @@ from unittest.mock import patch
 from aiohttp.test_utils import make_mocked_request
 from aiohttp.streams import StreamReader
 from multidict import CIMultiDict
+
 from foglamp.plugins.south.http_south.http_south import HttpSouthIngest
 from foglamp.plugins.south.coap_listen.coap_listen import Ingest
 
@@ -26,11 +27,7 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 
-loop = asyncio.get_event_loop()
-__DB_NAME = "foglamp"
-
-
-def mock_request(data):
+def mock_request(data, loop):
     payload = StreamReader(loop=loop)
     payload.feed_data(data.encode())
     payload.feed_eof()
@@ -44,13 +41,13 @@ def mock_request(data):
 
 
 @pytest.allure.feature("unit")
-@pytest.allure.story("south")
-class TestHttpSouthDeviceUnit(object):
-    """Unit tests for foglamp.south.coap.IngestReadings
+@pytest.allure.story("plugin", "south", "http")
+class TestHttpSouthIngest(object):
+    """Unit tests foglamp.plugins.south.http_south.http_south.HttpSouthIngest
     """
 
-    async def test_post_sensor_reading_ok(self):
-        data =  """{
+    async def test_post_sensor_reading_ok(self, event_loop):
+        data = """{
             "timestamp": "2017-01-02T01:02:03.23232Z-05:00",
             "asset": "sensor1",
             "key": "80a43623-ebe5-40d6-8d80-3f892da9b3b4",
@@ -62,17 +59,17 @@ class TestHttpSouthDeviceUnit(object):
                 }
             }
         }"""
-        with patch.object(Ingest, 'add_readings', return_value=asyncio.ensure_future(asyncio.sleep(0.1))) as mock_method1:
-            with patch.object(Ingest, 'is_available', return_value=True) as mock_method2:
-                request = mock_request(data)
+        with patch.object(Ingest, 'add_readings', return_value=asyncio.ensure_future(asyncio.sleep(0.1))):
+            with patch.object(Ingest, 'is_available', return_value=True):
+                request = mock_request(data, event_loop)
                 r = await HttpSouthIngest.render_post(request)
                 retval = json.loads(r.body.decode())
                 # Assert the POST request response
                 assert 200 == retval['status']
                 assert 'success' == retval['result']
 
-    async def test_post_sensor_reading_missing_demiliter(self):
-        data =  """{
+    async def test_post_sensor_reading_missing_delimiter(self, event_loop):
+        data = """{
             "timestamp": "2017-01-02T01:02:03.23232Z-05:00",
             "asset": "sensor1",
             "key": "80a43623-ebe5-40d6-8d80-3f892da9b3b4",
@@ -83,27 +80,26 @@ class TestHttpSouthDeviceUnit(object):
                     "unit": "kelvin"
                 }
         }"""
-        with patch.object(Ingest, 'add_readings', return_value=asyncio.ensure_future(asyncio.sleep(0.1))) as mock_method1:
-            with patch.object(Ingest, 'is_available', return_value=True) as mock_method2:
-                request = mock_request(data)
-                r = await HttpSouthIngest.render_post(request)
-                retval = json.loads(r.body.decode())
-                # Assert the POST request response
-                assert 400 == retval['status']
-                assert retval['error'].startswith("Expecting ',' delimiter:")
+        with patch.object(Ingest, 'is_available', return_value=True):
+            request = mock_request(data, event_loop)
+            r = await HttpSouthIngest.render_post(request)
+            retval = json.loads(r.body.decode())
+            # Assert the POST request response
+            assert 400 == retval['status']
+            assert retval['error'].startswith("Expecting ',' delimiter:")
 
-    async def test_post_sensor_reading_not_dict(self):
-        data =  """{
+    async def test_post_sensor_reading_not_dict(self, event_loop):
+        data = """{
             "timestamp": "2017-01-02T01:02:03.23232Z-05:00",
             "asset": "sensor2",
             "key": "80a43623-ebe5-40d6-8d80-3f892da9b3b4",
             "readings": "500"
         }"""
-        with patch.object(Ingest, 'add_readings', return_value=asyncio.ensure_future(asyncio.sleep(0.1))) as mock_method1:
-            with patch.object(Ingest, 'is_available', return_value=True) as mock_method2:
-                request = mock_request(data)
-                r = await HttpSouthIngest.render_post(request)
-                retval = json.loads(r.body.decode())
-                # Assert the POST request response
-                assert 400 == retval['status']
-                assert "readings must be a dictionary" == retval['error']
+
+        with patch.object(Ingest, 'is_available', return_value=True):
+            request = mock_request(data, event_loop)
+            r = await HttpSouthIngest.render_post(request)
+            retval = json.loads(r.body.decode())
+            # Assert the POST request response
+            assert 400 == retval['status']
+            assert "readings must be a dictionary" == retval['error']


### PR DESCRIPTION
1. fixed test and patching as add readings was never called (and, was throwing logs for task destroyed etc.) with bad request tests; 
2. using  pytest asyncio event loop fixture
3. 

```
pytest -s tests/unit/python
77 passed, 1 skipped in 0.45 seconds
```