### PR TITLE
FOGL-1006

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,6 @@ docs/.cache/
 # Compiled Object files
 *.pyc
 
-# Allure
-allure/
-allure-report/
-
 # build specific
 /C/plugins/storage/build
 /C/services/storage/build

--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -1,13 +1,13 @@
-pylint==1.7.1
-pytest==3.1.1
-pytest-allure-adaptor==1.7.7
-pytest-asyncio==0.6.0
+pylint==1.8.2
+pytest==3.4.0
+pytest-allure-adaptor==1.7.10
+pytest-asyncio==0.8.0
 pytest-mock==1.6.0
 pytest-cov==2.5.1
+pytest-aiohttp==0.3.0
 
 # postgreSQL
 aiopg==0.13.0
 SQLAlchemy==1.1.10
 psycopg2==2.7.1
 asyncpg==0.12.0
-

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,10 @@
+# Cache
+.pytest_cache
+
+# Coverage
+.coverage
+htmlcov/
+
+# Allure
+allure/
+allure-report/

--- a/tests/unit/python/foglamp/services/core/api/test_audit.py
+++ b/tests/unit/python/foglamp/services/core/api/test_audit.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+
+import json
+from unittest.mock import MagicMock, patch
+from aiohttp import web
+import pytest
+from foglamp.services.core import routes
+from foglamp.services.core import connect
+from foglamp.common.storage_client.storage_client import StorageClient
+
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("api", "audit")
+class TestAudit:
+
+    @pytest.fixture
+    def client(self, loop, test_client):
+        app = web.Application(loop=loop)
+        # fill the routes table
+        routes.setup(app)
+        return loop.run_until_complete(test_client(app))
+
+    async def test_get_severity(self, client):
+        resp = await client.get('/foglamp/audit/severity')
+        assert 200 == resp.status
+        result = await resp.text()
+        json_response = json.loads(result)
+        log_severity = json_response['logSeverity']
+
+        # verify the severity count
+        assert 4 == len(log_severity)
+
+        # verify the name and value of severity
+        for i in range(len(log_severity)):
+            if log_severity[i]['index'] == 1:
+                assert 'FATAL' == log_severity[i]['name']
+            elif log_severity[i]['index'] == 2:
+                assert 'ERROR' == log_severity[i]['name']
+            elif log_severity[i]['index'] == 3:
+                assert 'WARNING' == log_severity[i]['name']
+            elif log_severity[i]['index'] == 4:
+                assert 'INFORMATION' == log_severity[i]['name']
+
+    async def test_audit_log_codes(self, client):
+        storage_client_mock = MagicMock(StorageClient)
+        response = {"rows": [{"code": "PURGE", "description": "Data Purging Process"},
+                             {"code": "LOGGN", "description": "Logging Process"},
+                             {"code": "STRMN", "description": "Streaming Process"},
+                             {"code": "SYPRG", "description": "System Purge"}
+                             ]}
+
+        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+            with patch.object(storage_client_mock, 'query_tbl', return_value=response):
+                resp = await client.get('/foglamp/audit/logcode')
+                assert 200 == resp.status
+                result = await resp.text()
+                json_response = json.loads(result)
+                log_codes = [key['code'] for key in json_response['logCode']]
+
+                # verify the default log_codes with their values which are defined in init.sql
+                assert 4 == len(log_codes)
+                assert 'PURGE' in log_codes
+                assert 'LOGGN' in log_codes
+                assert 'STRMN' in log_codes
+                assert 'SYPRG' in log_codes
+
+    # TODO: source request params as it needs validation, a bit tricky to mock with existing code
+    # '?source=PURGE','?source=PURGE&severity=error')
+    @pytest.mark.parametrize("request_params", [
+        '',
+        '?skip=1',
+        '?severity=error',
+        '?severity=ERROR&limit=1',
+        '?severity=INFORMATION&limit=1&skip=1',
+        '?source=&severity=&limit=&skip='
+    ])
+    async def test_get_audit_with_params(self, client, request_params):
+        storage_client_mock = MagicMock(StorageClient)
+        response = {"rows": [{"log": {"end_time": "2018-01-30 18:39:48.1517317788", "rowsRemaining": 0,
+                                  "start_time": "2018-01-30 18:39:48.1517317788", "rowsRemoved": 0,
+                                  "unsentRowsRemoved": 0, "rowsRetained": 0},
+                          "code": "PURGE", "level": "4", "id": 2,
+                          "ts": "2018-01-30 18:39:48.796263+05:30", 'count': 1}]}
+        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+            with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=response):
+                    resp = await client.get('/foglamp/audit{}'.format(request_params))
+                    assert 200 == resp.status
+                    result = await resp.text()
+                    json_response = json.loads(result)
+                    assert 1 == json_response['totalCount']
+                    assert 1 == len(json_response['audit'])
+
+    # TODO: add source request param with invalid data, a bit tricky to mock with existing code
+    @pytest.mark.parametrize("request_params, response_code, response_message", [
+        ('?limit=invalid', 400, "Limit must be a positive integer"),
+        ('?limit=-1', 400, "Limit must be a positive integer"),
+        ('?skip=invalid', 400, "Skip/Offset must be a positive integer"),
+        ('?skip=-1', 400, "Skip/Offset must be a positive integer"),
+        ('?severity=BLA', 400, "'BLA' is not a valid severity")
+    ])
+    async def test_params_with_bad_data(self, client, request_params, response_code, response_message):
+        resp = await client.get('/foglamp/audit{}'.format(request_params))
+        assert response_code == resp.status
+        assert response_message == resp.reason


### PR DESCRIPTION
**Fixed items:**
- [x] gitignore added for tests/
- [x] test deps updated to their latest release version
- [x] unit test added for  services->core->api->test_audit.py
- [ ] conftest
- [ ] Readme.rst
- [x] Allure report 

## O/p -- All Passed
```
foglamp@nerd-034:~/Development/FogLAMP/tests/unit/python/foglamp/services/core/api$ pytest -s -v test_audit.py
============================================================= test session starts =============================================================
platform linux -- Python 3.5.2, pytest-3.4.0, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/foglamp/Development/FogLAMP/tests/unit/python/foglamp/services/core/api, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 13 items                                                                                                                            

test_audit.py::TestAudit::test_get_severity[pyloop] PASSED
test_audit.py::TestAudit::test_audit_log_codes[pyloop] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[pyloop] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[pyloop-?skip=1] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[pyloop-?severity=error] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[pyloop-?severity=ERROR&limit=1] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[pyloop-?severity=INFORMATION&limit=1&skip=1] PASSED
test_audit.py::TestAudit::test_get_audit_with_params[pyloop-?source=&severity=&limit=&skip=] PASSED
test_audit.py::TestAudit::test_params_with_bad_data[pyloop-?limit=invalid-400-Limit must be a positive integer] PASSED
test_audit.py::TestAudit::test_params_with_bad_data[pyloop-?limit=-1-400-Limit must be a positive integer] PASSED
test_audit.py::TestAudit::test_params_with_bad_data[pyloop-?skip=invalid-400-Skip/Offset must be a positive integer] PASSED
test_audit.py::TestAudit::test_params_with_bad_data[pyloop-?skip=-1-400-Skip/Offset must be a positive integer] PASSED
test_audit.py::TestAudit::test_params_with_bad_data[pyloop-?severity=BLA-400-'BLA' is not a valid severity] PASSED

======== 13 passed in 0.56 seconds ====

```
## Test coverage -- **87%** check htmlcov->index.html on browser

```
foglamp@nerd-034:~/Development/FogLAMP/tests/unit/python/foglamp/services/core/api$ pytest test_audit.py --cov ../../../../../../../python/foglamp/services/core/api/. --cov-report=html
collected 13 items                                                                                                                            
test_audit.py .............                                                                                                             [100%]

----------- coverage: platform linux, python 3.5.2-final-0 -----------
Coverage HTML written to dir htmlcov

==== 13 passed in 0.75 seconds ==
Coverage for /home/foglamp/Development/FogLAMP/python/foglamp/services/core/api/audit.py : 87% Show keyboard shortcuts
94 statements   82 run 12 missing 0 excluded
```
## Pylint  (3.33/10) -- No worries FOGL-622 and FOGL-173
```
foglamp@nerd-034:~/Development/FogLAMP/tests/unit/python/foglamp/services/core/api$ pylint test_audit.py No config file found, using default configuration
************* Module test_audit
W: 82, 0: TODO: source request params as it needs validation, a bit tricky to mock with existing code (fixme)
W:108, 0: TODO: add source request param with invalid data, a bit tricky to mock with existing code (fixme)
C: 65, 0: Wrong continued indentation (remove 1 space).
                    ]
                   |^ (bad-continuation)
W:101, 0: Bad indentation. Found 20 spaces, expected 16 (bad-indentation)
W:102, 0: Bad indentation. Found 20 spaces, expected 16 (bad-indentation)
W:103, 0: Bad indentation. Found 20 spaces, expected 16 (bad-indentation)
W:104, 0: Bad indentation. Found 20 spaces, expected 16 (bad-indentation)
W:105, 0: Bad indentation. Found 20 spaces, expected 16 (bad-indentation)
W:106, 0: Bad indentation. Found 20 spaces, expected 16 (bad-indentation)
C:116, 0: Line too long (103/100) (line-too-long)
C:  1, 0: Missing module docstring (missing-docstring)
C: 23, 0: Missing class docstring (missing-docstring)
E: 23, 1: Module 'pytest' has no 'allure' member (no-member)
E: 24, 1: Module 'pytest' has no 'allure' member (no-member)
C: 28, 4: Missing method docstring (missing-docstring)
R: 28, 4: Method could be a function (no-self-use)
C: 34,10: Missing method docstring (missing-docstring)
C: 36,15: Comparison should be resp.status == 200 (misplaced-comparison-constant)
C: 42,15: Comparison should be len(log_severity) == 4 (misplaced-comparison-constant)
C: 45, 8: Consider using enumerate instead of iterating with range and len (consider-using-enumerate)
C: 47,23: Comparison should be log_severity[i]['index'] == 1 (misplaced-comparison-constant)
C: 48,23: Comparison should be log_severity[i]['name'] == 'FATAL' (misplaced-comparison-constant)
C: 50,23: Comparison should be log_severity[i]['index'] == 2 (misplaced-comparison-constant)
C: 51,23: Comparison should be log_severity[i]['name'] == 'ERROR' (misplaced-comparison-constant)
C: 53,23: Comparison should be log_severity[i]['index'] == 3 (misplaced-comparison-constant)
C: 54,23: Comparison should be log_severity[i]['name'] == 'WARNING' (misplaced-comparison-constant)
C: 56,23: Comparison should be log_severity[i]['index'] == 4 (misplaced-comparison-constant)
C: 57,23: Comparison should be log_severity[i]['name'] == 'INFORMATION' (misplaced-comparison-constant)
C: 59,10: Missing method docstring (missing-docstring)
C: 70,23: Comparison should be resp.status == 200 (misplaced-comparison-constant)
C: 76,23: Comparison should be len(log_codes) == 4 (misplaced-comparison-constant)
C: 91, 4: Missing method docstring (missing-docstring)
C:102,27: Comparison should be resp.status == 200 (misplaced-comparison-constant)
C:105,27: Comparison should be json_response['totalCount'] == 1 (misplaced-comparison-constant)
C:106,27: Comparison should be len(json_response['audit']) == 1 (misplaced-comparison-constant)
C:115, 4: Missing method docstring (missing-docstring)

------------------------------------------------------------------
Your code has been rated at 3.33/10 (previous run: 3.33/10, +0.00)

```

## Allure report
```
pytest tests/unit/python/foglamp/services/core/api/ --alluredir tests/allure-report
allure generate tests/allure-report/
allure  open
```
![allure_report](https://user-images.githubusercontent.com/27723735/35621019-f96ff026-06a8-11e8-9c0b-ca0656ddc958.jpg)
![allure_behavior](https://user-images.githubusercontent.com/27723735/35622262-2f2d99a8-06ad-11e8-8aac-e1d2dbc86fd5.jpg)