### PR TITLE
FOGL-1016 create category end point added

### DIFF
--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -145,8 +145,12 @@ class ConfigurationManager(ConfigurationManagerSingleton):
         return category_val_copy
 
     async def _create_new_category(self, category_name, category_val, category_description):
-        payload = PayloadBuilder().INSERT(key=category_name, description=category_description, value=category_val).payload()
-        self._storage.insert_into_tbl("configuration", payload)
+        try:
+            payload = PayloadBuilder().INSERT(key=category_name, description=category_description, value=category_val).payload()
+            result = self._storage.insert_into_tbl("configuration", payload)
+            response = result['response']
+        except KeyError:
+                raise ValueError(result['message'])
 
     async def _read_all_category_names(self):
         # SELECT configuration.key, configuration.description, configuration.value, configuration.ts FROM configuration
@@ -216,9 +220,13 @@ class ConfigurationManager(ConfigurationManagerSingleton):
         self._storage.update_tbl("configuration", payload)
 
     async def _update_category(self, category_name, category_val, category_description):
-        payload = PayloadBuilder().SET(value=category_val, description=category_description).\
-            WHERE(["key", "=", category_name]).payload()
-        self._storage.update_tbl("configuration", payload)
+        try:
+            payload = PayloadBuilder().SET(value=category_val, description=category_description).\
+                WHERE(["key", "=", category_name]).payload()
+            result = self._storage.update_tbl("configuration", payload)
+            response = result['response']
+        except KeyError:
+            raise ValueError(result['message'])
 
     async def get_all_category_names(self):
         """Get all category names in the FogLAMP system

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -15,7 +15,7 @@ __version__ = "${VERSION}"
 
 _help = """
     -------------------------------------------------------------------------------
-    | GET             | /foglamp/category                                         |
+    | GET POST        | /foglamp/category                                         |
     | GET             | /foglamp/category/{category_name}                         |
     | GET PUT         | /foglamp/category/{category_name}/{config_item}           |
     | DELETE          | /foglamp/category/{category_name}/{config_item}/value     |
@@ -70,6 +70,51 @@ async def get_category(request):
         raise web.HTTPNotFound(reason="No such Category found for {}".format(category_name))
 
     return web.json_response(category)
+
+
+async def create_category(request):
+    """
+
+    Args:
+         request: A JSON object that defines the category
+
+    Returns:
+            category info
+
+    :Example:
+            curl -d '{"key": "category_name", "description": "description", "value": {dict}}' -X POST http://localhost:8081/foglamp/category
+    """
+    try:
+        cf_mgr = ConfigurationManager(connect.get_storage())
+        data = await request.json()
+        if not isinstance(data, dict):
+            raise ValueError('Data payload must be a dictionary')
+
+        valid_keys = ['key', 'description', 'value']
+        for k in valid_keys:
+            if k not in list(data.keys()):
+                raise KeyError("'{}' key not found".format(k))
+
+        category_name = data.get('key')
+        category_desc = data.get('description')
+        category_value = data.get('value')
+        if not isinstance(category_value, dict):
+            raise ValueError('Category value must be a dictionary')
+
+        await cf_mgr.create_category(category_name=category_name, category_description=category_desc,
+                                     category_value=category_value, keep_original_items=False)
+
+        category_info = await cf_mgr.get_category_all_items(category_name=category_name)
+        if category_info is None:
+            raise web.HTTPNotFound(reason="No such {} found".format(category_info))
+
+    except (KeyError, ValueError, TypeError) as ex:
+        raise web.HTTPBadRequest(reason=str(ex))
+
+    except Exception as ex:
+        raise web.HTTPException(reason=str(ex))
+
+    return web.json_response({"key": category_name, "description": category_desc, "value": category_info})
 
 
 async def get_category_item(request):

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -82,7 +82,7 @@ async def create_category(request):
             category info
 
     :Example:
-            curl -d '{"key": "category_name", "description": "description", "value": {dict}}' -X POST http://localhost:8081/foglamp/category
+            curl -d '{"key": "TEST", "description": "description", "value": {"info": {"description": "Test", "type": "boolean", "default": "true"}}}' -X POST http://localhost:8081/foglamp/category
     """
     try:
         cf_mgr = ConfigurationManager(connect.get_storage())
@@ -90,16 +90,14 @@ async def create_category(request):
         if not isinstance(data, dict):
             raise ValueError('Data payload must be a dictionary')
 
-        valid_keys = ['key', 'description', 'value']
-        for k in valid_keys:
+        valid_post_keys = ['key', 'description', 'value']
+        for k in valid_post_keys:
             if k not in list(data.keys()):
-                raise KeyError("'{}' key not found".format(k))
+                raise KeyError("'{}' param required to create a category".format(k))
 
         category_name = data.get('key')
         category_desc = data.get('description')
         category_value = data.get('value')
-        if not isinstance(category_value, dict):
-            raise ValueError('Category value must be a dictionary')
 
         await cf_mgr.create_category(category_name=category_name, category_description=category_desc,
                                      category_value=category_value, keep_original_items=False)

--- a/python/foglamp/services/core/routes.py
+++ b/python/foglamp/services/core/routes.py
@@ -23,6 +23,7 @@ def setup(app):
 
     # Configuration
     app.router.add_route('GET', '/foglamp/category', api_configuration.get_categories)
+    app.router.add_route('POST', '/foglamp/category', api_configuration.create_category)
     app.router.add_route('GET', '/foglamp/category/{category_name}', api_configuration.get_category)
     app.router.add_route('GET', '/foglamp/category/{category_name}/{config_item}', api_configuration.get_category_item)
     app.router.add_route('PUT', '/foglamp/category/{category_name}/{config_item}', api_configuration.set_configuration_item)


### PR DESCRIPTION

**curl -d '{"key":"test_cat", "description":"Test desc", "value": {"info": {"description": "Test", "type": "boolean", "default": "False"}}}' -X POST http://localhost:8081/foglamp/category**

**Response**

```
{
 "key": "test_cat",
 "value": {
   "info": {
     "value": "False",
     "type": "boolean",
     "description": "Test",
     "default": "False"
   }
 },
 "description": "Test desc"
}
```

**NOTE**
1) No unit tests added yet, should cover when [FOGL-1009](https://scaledb.atlassian.net/browse/FOGL-1009)
2) See Response format (not matched with DOC, as per only category name needs, but I think better to return all info)
3) create_category should not expect any return value from storage, so used *get_category_all_items* to fetch all info to make sure category has been created



**Integration tests O/p** - just to confirm, no regression with new changes
```
pytest -s -v test_configuration_manager.py 
============================================================= test session starts =============================================================
platform linux -- Python 3.5.2, pytest-3.4.0, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/foglamp/Development/FogLAMP/tests/integration/foglamp/common, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 29 items                                                                                                                            

test_configuration_manager.py::TestConfigurationManager::test_accepted_data_types PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_keep_original_items_true PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_keep_original_items_false PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_with_quoted_json_data PASSED
test_configuration_manager.py::TestConfigurationManager::test_set_category_item_value_entry PASSED
test_configuration_manager.py::TestConfigurationManager::test_get_category_item PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_dict PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_name PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_type PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_case_sensitive_type PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_entry_value_for_type PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_entry_value_for_default PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_entry_none_for_description PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_missing_entry_for_type PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_missing_entry_for_description PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_missing_value_for_default PASSED
test_configuration_manager.py::TestConfigurationManager::test_create_category_invalid_description PASSED
test_configuration_manager.py::TestConfigurationManager::test_set_category_item_value_error PASSED
test_configuration_manager.py::TestConfigurationManager::test_get_category_item_value_entry_dne PASSED
test_configuration_manager.py::TestConfigurationManager::test_get_category_item_empty PASSED
test_configuration_manager.py::TestConfigurationManager::test_get_category_all_items_done PASSED
test_configuration_manager.py::TestConfigurationManager::test_register_interest PASSED
test_configuration_manager.py::TestConfigurationManager::test_register_interest_category_name_none_error PASSED
test_configuration_manager.py::TestConfigurationManager::test_register_interest_callback_none_error PASSED
test_configuration_manager.py::TestConfigurationManager::test_unregister_interest_0_callback PASSED
test_configuration_manager.py::TestConfigurationManager::test_unregister_interest_1_callback PASSED
test_configuration_manager.py::TestConfigurationManager::test_unregister_interest_2_callback PASSED
test_configuration_manager.py::TestConfigurationManager::test_unregister_interest_category_name_none_error PASSED
test_configuration_manager.py::TestConfigurationManager::test_unregister_interest_callback_none_error PASSED
==== 29 passed in 1.40 seconds ====
```
