### PR TITLE
Fogl 924 - cc2650poll plugin fails with error

### DIFF
--- a/python/foglamp/plugins/south/common/sensortag_cc2650.py
+++ b/python/foglamp/plugins/south/common/sensortag_cc2650.py
@@ -136,24 +136,30 @@ class SensorTagCC2650(object):
     is_connected = False
 
     def __init__(self, bluetooth_adr, timeout):
-        try:
-            self.bluetooth_adr = bluetooth_adr
+        attempt_count = 1
+        while attempt_count <= 5:
+            try:
+                self.bluetooth_adr = bluetooth_adr
 
-            self.con = pexpect.spawn('gatttool -b ' + bluetooth_adr + ' --interactive')
-            self.con.expect('\[LE\]>', timeout=int(timeout))
+                self.con = pexpect.spawn('gatttool -b ' + bluetooth_adr + ' --interactive')
+                self.con.expect('\[LE\]>', timeout=int(timeout))
 
-            msg_debug = 'SensorTagCC2650 {} Connecting... If nothing happens, please press the power button.'.\
-                        format(self.bluetooth_adr)
-            print(msg_debug)
-            _LOGGER.debug(msg_debug)
+                msg_debug = 'SensorTagCC2650 {} Connecting... If nothing happens, please press the power button.'.\
+                            format(self.bluetooth_adr)
+                print(msg_debug)
+                _LOGGER.debug(msg_debug)
 
-            self.con.sendline('connect')
-            self.con.expect('.*Connection successful.*\[LE\]>', timeout=int(timeout))
-            self.is_connected = True
-            msg_success = 'SensorTagCC2650 {} connected successfully'.format(self.bluetooth_adr)
-            print(msg_success)
-            _LOGGER.debug(msg_success)
-        except (ExceptionPexpect, EOF, TIMEOUT, Exception) as ex:
+                self.con.sendline('connect')
+                self.con.expect('.*Connection successful.*\[LE\]>', timeout=int(timeout))
+                self.is_connected = True
+                msg_success = 'SensorTagCC2650 {} connected successfully'.format(self.bluetooth_adr)
+                print(msg_success)
+                _LOGGER.debug(msg_success)
+            except (ExceptionPexpect, EOF, TIMEOUT, Exception) as ex:
+                attempt_count += 1
+                time.sleep(0.33)
+
+        if attempt_count > 5:
             self.is_connected = False
             self.con.sendline('quit')
             # TODO: Investigate why SensorTag goes to sleep often and find a suitable software solution to awake it.

--- a/python/foglamp/plugins/south/common/sensortag_cc2650.py
+++ b/python/foglamp/plugins/south/common/sensortag_cc2650.py
@@ -155,6 +155,7 @@ class SensorTagCC2650(object):
                 msg_success = 'SensorTagCC2650 {} connected successfully'.format(self.bluetooth_adr)
                 print(msg_success)
                 _LOGGER.debug(msg_success)
+                break
             except (ExceptionPexpect, EOF, TIMEOUT, Exception) as ex:
                 attempt_count += 1
                 time.sleep(0.33)


### PR DESCRIPTION
This PR replaces [PR#457](https://github.com/foglamp/FogLAMP/pull/457).

As required by @ashwinscale, this PR provides solution for retries, with plugin restart, in case CC POLL plugin hangs in middle or develops some trouble midway or needs a hard keypress restart midway. To test this PR,
- Start server with CC2650POLL plugin enabled but sensortag NOT switched on.
- Observe syslog, after 1-2 startup retries, switch on the sensortag.
- Observe readings table. You will see readings coming in.
- Switch off sensortag.
- Observe syslog and readings table. Readings will stop coming.
- Now Switch on sensortag again.
- Watch syslog and readings table. Data will start coming again.
