### PR TITLE
FOGL-1089 exempt storage and core unregister audit log 

### DIFF
--- a/python/foglamp/services/core/server.py
+++ b/python/foglamp/services/core/server.py
@@ -661,7 +661,8 @@ class Server:
                 raise web.HTTPNotFound(reason='Service with {} does not exist'.format(service_id))
 
             ServiceRegistry.unregister(service_id)
-            if not cls._storage_client is None:
+
+            if cls._storage_client is not None and services[0]._name not in ("FogLAMP Storage", "FogLAMP Core"):
                 try:
                     cls._audit = AuditLogger(cls._storage_client)
                     await cls._audit.information('SRVUN', { 'name' : services[0]._name })


### PR DESCRIPTION
as those are DB entries itself

And shutdown is called before unregister!

> Note: syslog entries are made by unregister core code itself hence no need to explicitly add to web endpoint def.