### PR TITLE
FOGL-1033 storage client exceptions test

### DIFF
--- a/tests/unit/python/foglamp/common/storage_client/test_exceptions.py
+++ b/tests/unit/python/foglamp/common/storage_client/test_exceptions.py
@@ -46,7 +46,9 @@ class TestStorageClientExceptions:
             raise StorageClientException(code=11, message="foo")
         assert excinfo.type is StorageClientException
         assert issubclass(excinfo.type, Exception)
+
         # code is 11
+        # pytest raises wrapper allow only type, value and traceback info
         assert "foo" == str(excinfo.value)
 
         try:
@@ -62,10 +64,7 @@ class TestStorageClientExceptions:
             raise BadRequest()
         assert excinfo.type is BadRequest
         assert issubclass(excinfo.type, StorageClientException)
-        # code is 400
-        assert "Bad request" == str(excinfo.value)
 
-    def test_BadRequest2(self):
         try:
             raise BadRequest()
         except Exception as ex:
@@ -79,37 +78,67 @@ class TestStorageClientExceptions:
             raise StorageServiceUnavailable()
         assert excinfo.type is StorageServiceUnavailable
         assert issubclass(excinfo.type, StorageClientException)
-        # code is 503
-        assert "Storage service is unavailable" == str(excinfo.value)
+
+        try:
+            raise StorageServiceUnavailable()
+        except Exception as ex:
+            assert ex.__class__ is StorageServiceUnavailable
+            assert issubclass(ex.__class__, StorageClientException)
+            assert 503 == ex.code
+            assert "Storage service is unavailable" == ex.message
 
     def test_InvalidServiceInstance(self):
         with pytest.raises(Exception) as excinfo:
             raise InvalidServiceInstance()
         assert excinfo.type is InvalidServiceInstance
         assert issubclass(excinfo.type, StorageClientException)
-        # code is 502
-        assert "Storage client needs a valid *FogLAMP storage* micro-service instance" == str(excinfo.value)
+
+        try:
+            raise InvalidServiceInstance()
+        except Exception as ex:
+            assert ex.__class__ is InvalidServiceInstance
+            assert issubclass(ex.__class__, StorageClientException)
+            assert 502 == ex.code
+            assert "Storage client needs a valid *FogLAMP storage* micro-service instance" == ex.message
 
     def test_InvalidReadingsPurgeFlagParameters(self):
         with pytest.raises(Exception) as excinfo:
             raise InvalidReadingsPurgeFlagParameters()
         assert excinfo.type is InvalidReadingsPurgeFlagParameters
         assert issubclass(excinfo.type, BadRequest)
-        # code is 400
-        assert "Purge flag valid options are retain or purge only" == str(excinfo.value)
 
-    def test_PurgeOnlyOneOfAgeAndSize(self):
-        with pytest.raises(Exception) as excinfo:
-            raise PurgeOnlyOneOfAgeAndSize()
-        assert excinfo.type is PurgeOnlyOneOfAgeAndSize
-        assert issubclass(excinfo.type, BadRequest)
-        # code is 400
-        assert "Purge must specify only one of age or size" == str(excinfo.value)
+        try:
+            raise InvalidReadingsPurgeFlagParameters()
+        except Exception as ex:
+            assert ex.__class__ is InvalidReadingsPurgeFlagParameters
+            assert issubclass(ex.__class__, BadRequest)
+            assert 400 == ex.code
+            assert "Purge flag valid options are retain or purge only" == ex.message
 
     def test_PurgeOneOfAgeAndSize(self):
         with pytest.raises(Exception) as excinfo:
             raise PurgeOneOfAgeAndSize()
         assert excinfo.type is PurgeOneOfAgeAndSize
         assert issubclass(excinfo.type, BadRequest)
-        # code is 400
-        assert "Purge must specify one of age or size" == str(excinfo.value)
+
+        try:
+            raise PurgeOneOfAgeAndSize()
+        except Exception as ex:
+            assert ex.__class__ is PurgeOneOfAgeAndSize
+            assert issubclass(ex.__class__, BadRequest)
+            assert 400 == ex.code
+            assert "Purge must specify one of age or size" == ex.message
+
+    def test_PurgeOnlyOneOfAgeAndSize(self):
+        with pytest.raises(Exception) as excinfo:
+            raise PurgeOnlyOneOfAgeAndSize()
+        assert excinfo.type is PurgeOnlyOneOfAgeAndSize
+        assert issubclass(excinfo.type, BadRequest)
+
+        try:
+            raise PurgeOnlyOneOfAgeAndSize()
+        except Exception as ex:
+            assert ex.__class__ is PurgeOnlyOneOfAgeAndSize
+            assert issubclass(ex.__class__, BadRequest)
+            assert 400 == ex.code
+            assert "Purge must specify only one of age or size" == ex.message

--- a/tests/unit/python/foglamp/common/storage_client/test_exceptions.py
+++ b/tests/unit/python/foglamp/common/storage_client/test_exceptions.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Test foglamp/common/storage_client/exceptions.py """
+
+import pytest
+
+from foglamp.common.storage_client.exceptions import StorageClientException
+from foglamp.common.storage_client.exceptions import *
+
+__copyright__ = "Copyright (c) 2018 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("common", "storage_client")
+class TestStorageClientExceptions:
+
+    def test_init_StorageClientException(self):
+
+        with pytest.raises(Exception) as excinfo:
+            raise StorageClientException()
+        assert excinfo.type is TypeError
+        assert "__init__() missing 1 required positional argument: 'code'" == str(excinfo.value)
+
+    def test_default_init_StorageClientException(self):
+        with pytest.raises(Exception) as excinfo:
+            raise StorageClientException(40)
+        assert excinfo.type is StorageClientException
+        assert issubclass(excinfo.type, Exception)
+
+        try:
+            raise StorageClientException(40)
+        except Exception as ex:
+            assert ex.__class__ is StorageClientException
+            assert issubclass(ex.__class__, Exception)
+            assert 40 == ex.code
+            assert ex.message is None
+
+    def test_init_args_StorageClientException(self):
+        with pytest.raises(Exception) as excinfo:
+            raise StorageClientException(code=11, message="foo")
+        assert excinfo.type is StorageClientException
+        assert issubclass(excinfo.type, Exception)
+        # code is 11
+        assert "foo" == str(excinfo.value)
+
+        try:
+            raise StorageClientException(code=11, message="foo")
+        except Exception as ex:
+            assert ex.__class__ is StorageClientException
+            assert issubclass(ex.__class__, Exception)
+            assert 11 == ex.code
+            assert "foo" == ex.message
+
+    def test_BadRequest(self):
+        with pytest.raises(Exception) as excinfo:
+            raise BadRequest()
+        assert excinfo.type is BadRequest
+        assert issubclass(excinfo.type, StorageClientException)
+        # code is 400
+        assert "Bad request" == str(excinfo.value)
+
+    def test_BadRequest2(self):
+        try:
+            raise BadRequest()
+        except Exception as ex:
+            assert ex.__class__ is BadRequest
+            assert issubclass(ex.__class__, StorageClientException)
+            assert 400 == ex.code
+            assert "Bad request" == ex.message
+
+    def test_StorageServiceUnavailable(self):
+        with pytest.raises(Exception) as excinfo:
+            raise StorageServiceUnavailable()
+        assert excinfo.type is StorageServiceUnavailable
+        assert issubclass(excinfo.type, StorageClientException)
+        # code is 503
+        assert "Storage service is unavailable" == str(excinfo.value)
+
+    def test_InvalidServiceInstance(self):
+        with pytest.raises(Exception) as excinfo:
+            raise InvalidServiceInstance()
+        assert excinfo.type is InvalidServiceInstance
+        assert issubclass(excinfo.type, StorageClientException)
+        # code is 502
+        assert "Storage client needs a valid *FogLAMP storage* micro-service instance" == str(excinfo.value)
+
+    def test_InvalidReadingsPurgeFlagParameters(self):
+        with pytest.raises(Exception) as excinfo:
+            raise InvalidReadingsPurgeFlagParameters()
+        assert excinfo.type is InvalidReadingsPurgeFlagParameters
+        assert issubclass(excinfo.type, BadRequest)
+        # code is 400
+        assert "Purge flag valid options are retain or purge only" == str(excinfo.value)
+
+    def test_PurgeOnlyOneOfAgeAndSize(self):
+        with pytest.raises(Exception) as excinfo:
+            raise PurgeOnlyOneOfAgeAndSize()
+        assert excinfo.type is PurgeOnlyOneOfAgeAndSize
+        assert issubclass(excinfo.type, BadRequest)
+        # code is 400
+        assert "Purge must specify only one of age or size" == str(excinfo.value)
+
+    def test_PurgeOneOfAgeAndSize(self):
+        with pytest.raises(Exception) as excinfo:
+            raise PurgeOneOfAgeAndSize()
+        assert excinfo.type is PurgeOneOfAgeAndSize
+        assert issubclass(excinfo.type, BadRequest)
+        # code is 400
+        assert "Purge must specify one of age or size" == str(excinfo.value)


### PR DESCRIPTION
> $ pytest tests/unit/python/foglamp/common/storage_client/test_exceptions.py 

```
======================================================= test session starts ========================================================
platform linux -- Python 3.5.2, pytest-3.4.0, py-1.5.2, pluggy-0.6.0
rootdir: /home/foglamp/foglamp/FogLAMP, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 9 items                                                                                                                  

tests/unit/python/foglamp/common/storage_client/test_exceptions.py .........                                                 [100%]

===================================================== 9 passed in 0.02 seconds =====================================================

```

> [FOGL-1033] $ pytest tests/unit/python/

```
============================================== 147 passed, 1 skipped in 1.22 seconds ===============================================
```