### PR TITLE
FOGL-1043 service registry package exceptions test

### DIFF
--- a/python/foglamp/services/core/service_registry/exceptions.py
+++ b/python/foglamp/services/core/service_registry/exceptions.py
@@ -15,14 +15,18 @@ __version__ = "${VERSION}"
 class DoesNotExist(Exception):
     pass
 
+
 class AlreadyExistsWithTheSameName(Exception):
     pass
+
 
 class AlreadyExistsWithTheSameAddressAndPort(Exception):
     pass
 
+
 class AlreadyExistsWithTheSameAddressAndManagementPort(Exception):
     pass
+
 
 class NonNumericPortError(TypeError):
     pass

--- a/tests/unit/python/foglamp/services/core/service_registry/test_exceptions.py
+++ b/tests/unit/python/foglamp/services/core/service_registry/test_exceptions.py
@@ -47,8 +47,9 @@ class TestServiceRegistryExceptions:
         assert issubclass(excinfo.type, Exception)
         assert "" == str(excinfo.value)
 
-    with pytest.raises(Exception) as excinfo:
-        raise NonNumericPortError()
-    assert excinfo.type is NonNumericPortError
-    assert issubclass(excinfo.type, TypeError)
-    assert "" == str(excinfo.value)
+    def test_NonNumericPortError(self):
+        with pytest.raises(Exception) as excinfo:
+            raise NonNumericPortError()
+        assert excinfo.type is NonNumericPortError
+        assert issubclass(excinfo.type, TypeError)
+        assert "" == str(excinfo.value)

--- a/tests/unit/python/foglamp/services/core/service_registry/test_exceptions.py
+++ b/tests/unit/python/foglamp/services/core/service_registry/test_exceptions.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Test foglamp/services/core/service_registry/exceptions.py """
+
+import pytest
+
+from foglamp.services.core.service_registry.exceptions import *
+
+__copyright__ = "Copyright (c) 2018 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("services", "core", "service_registry")
+class TestServiceRegistryExceptions:
+
+    def test_DoesNotExist(self):
+        with pytest.raises(Exception) as excinfo:
+            raise DoesNotExist()
+        assert excinfo.type is DoesNotExist
+        assert issubclass(excinfo.type, Exception)
+        assert "" == str(excinfo.value)
+
+    def test_AlreadyExistsWithTheSameName(self):
+        with pytest.raises(Exception) as excinfo:
+            raise AlreadyExistsWithTheSameName()
+        assert excinfo.type is AlreadyExistsWithTheSameName
+        assert issubclass(excinfo.type, Exception)
+        assert "" == str(excinfo.value)
+
+    def test_AlreadyExistsWithTheSameAddressAndPort(self):
+        with pytest.raises(Exception) as excinfo:
+            raise AlreadyExistsWithTheSameAddressAndPort()
+        assert excinfo.type is AlreadyExistsWithTheSameAddressAndPort
+        assert issubclass(excinfo.type, Exception)
+        assert "" == str(excinfo.value)
+
+    def test_AlreadyExistsWithTheSameAddressAndManagementPort(self):
+        with pytest.raises(Exception) as excinfo:
+            raise AlreadyExistsWithTheSameAddressAndManagementPort()
+        assert excinfo.type is AlreadyExistsWithTheSameAddressAndManagementPort
+        assert issubclass(excinfo.type, Exception)
+        assert "" == str(excinfo.value)
+
+    with pytest.raises(Exception) as excinfo:
+        raise NonNumericPortError()
+    assert excinfo.type is NonNumericPortError
+    assert issubclass(excinfo.type, TypeError)
+    assert "" == str(excinfo.value)


### PR DESCRIPTION
> [FOGL-1043] $ pytest tests/unit/python/foglamp/services/core/service_registry/test_exceptions.py 

```
======================================================= test session starts ========================================================
platform linux -- Python 3.5.2, pytest-3.4.0, py-1.5.2, pluggy-0.6.0
rootdir: /home/foglamp/foglamp/FogLAMP, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 5 items                                                                                                                  

tests/unit/python/foglamp/services/core/service_registry/test_exceptions.py ....                                             [100%]

===================================================== 5 passed in 0.02 seconds =====================================================
```
> [FOGL-1043] $ pytest tests/unit/python

`
============================================== 143 passed, 1 skipped in 1.21 seconds ===============================================`