### PR TITLE
FOGL-1063: Unit test for purge main entry point

### DIFF
--- a/python/foglamp/tasks/purge/purge.py
+++ b/python/foglamp/tasks/purge/purge.py
@@ -67,10 +67,7 @@ class Purge(FoglampProcess):
         super().__init__()
         self._logger = logger.setup("Data Purge")
         self._audit = AuditLogger(self._storage)
-        if loop is None:
-            self.loop = asyncio.get_event_loop()
-        else:
-            self.loop = loop
+        self.loop = asyncio.get_event_loop() if loop is None else loop
 
     def write_statistics(self, total_purged, unsent_purged):
         stats = Statistics(self._storage)

--- a/tests/unit/python/foglamp/plugins/common/test_plugins_common_utils.py
+++ b/tests/unit/python/foglamp/plugins/common/test_plugins_common_utils.py
@@ -13,7 +13,7 @@ from collections import Counter
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("plugins", "common")
-class TestUtils():
+class TestUtils:
     @pytest.mark.parametrize("test_input_old, test_input_new, expected", [
         ({'a': 1, 'b': 2, 'c': 3}, {'a': 11, 'b': 22, 'c': 33}, ['a', 'b', 'c']),
         ({'a': 1, 'b': 2, 'c': 3}, {'a': 11, 'b': 22, 'd': 44}, ['a', 'b', 'd']),

--- a/tests/unit/python/foglamp/tasks/purge/test_purge_main.py
+++ b/tests/unit/python/foglamp/tasks/purge/test_purge_main.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Test tasks/purge/__main__.py entry point
+
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from foglamp.tasks import purge
+
+from foglamp.common import logger
+from foglamp.common.storage_client.storage_client import StorageClient
+from foglamp.tasks.purge.purge import Purge
+from foglamp.common.process import FoglampProcess
+from foglamp.common.audit_logger import AuditLogger
+
+__author__ = "Vaibhav Singhal"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.fixture
+async def _purge_instance():
+    mockStorageClient = MagicMock(spec=StorageClient)
+    mockAuditLogger = AuditLogger(mockStorageClient)
+    with patch.object(FoglampProcess, "__init__"):
+        with patch.object(logger, "setup"):
+            with patch.object(mockAuditLogger, "__init__", return_value=None):
+                p = Purge()
+    return p
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("tasks", "purge")
+def test_main(_purge_instance):
+    with patch.object(purge, "__name__", "__main__"):
+        purge.purge_process = _purge_instance
+        with patch.object(Purge, 'run', return_value=None):
+            purge.purge_process.run()
+            purge.purge_process.run.assert_called_once_with()

--- a/tests/unit/python/foglamp/tasks/purge/test_purge_main.py
+++ b/tests/unit/python/foglamp/tasks/purge/test_purge_main.py
@@ -26,13 +26,13 @@ __version__ = "${VERSION}"
 
 
 @pytest.fixture
-async def _purge_instance():
+async def _purge_instance(event_loop):
     mockStorageClient = MagicMock(spec=StorageClient)
     mockAuditLogger = AuditLogger(mockStorageClient)
     with patch.object(FoglampProcess, "__init__"):
         with patch.object(logger, "setup"):
             with patch.object(mockAuditLogger, "__init__", return_value=None):
-                p = Purge()
+                p = Purge(loop=event_loop)
     return p
 
 


### PR DESCRIPTION
- [X] Unit test of purge main entry point (Note: This does not increases the code coverage of purge/__main__.py)

- [X] Minor code refactor in in purge.py 

- [X] Minor code refactor in common/test_plugins_common_utils.py to get rid of a PEP8 warning