### PR TITLE
FOGL-889 

### DIFF
--- a/C/plugins/storage/postgres/plugin.cpp
+++ b/C/plugins/storage/postgres/plugin.cpp
@@ -165,15 +165,17 @@ std::string results;
 /**
  * Purge readings from the buffer
  */
-char *plugin_reading_purge(PLUGIN_HANDLE handle, unsigned long age, unsigned int flags, unsigned long sent)
+char *plugin_reading_purge(PLUGIN_HANDLE handle, unsigned long param, unsigned int flags, unsigned long sent)
 {
 ConnectionManager *manager = (ConnectionManager *)handle;
 Connection        *connection = manager->allocate();
 std::string 	  results;
+unsigned long	  age, size;
 
 	// TODO put flags in common header file
 	if (flags & 0x0002)	// Purge by size
 	{
+		size = param;
 		unsigned long deletedRows = 0;
 		unsigned long unsentPurged = 0;
 		unsigned long unsentRetained = 0;
@@ -183,7 +185,7 @@ std::string 	  results;
 		 * the required size or we no longer remove readings
 		 */
 		long tableSize = connection->tableSize(std::string("readings"));
-		while (tableSize > age)
+		while (tableSize > size)
 		{
 			(void)connection->purgeReadings(0, flags, sent, results);
 
@@ -203,7 +205,7 @@ std::string 	  results;
 			{
 				// We didn't remove any readings, so stop here
 				Logger::getLogger()->error("Failed to reach target readings size %ld during purge operation",
-					age);
+					size);
 				break;
 			}
 			tableSize = newTableSize;
@@ -221,6 +223,7 @@ std::string 	  results;
 	}
 	else
 	{
+		age = param;
 		(void)connection->purgeReadings(age, flags, sent, results);
 	}
 	manager->release(connection);

--- a/python/foglamp/common/storage_client/storage_client.py
+++ b/python/foglamp/common/storage_client/storage_client.py
@@ -475,13 +475,14 @@ class ReadingsStorageClient(StorageClient):
 
         :param age: the maximum age of data to retain, expressed in hours
         :param sent_id: the id of the last reading to be sent out of FogLAMP
+        :param size: the maximum size of data to retain, expressed in Kbytes
         :param flag: define what to do about unsent readings. Valid options are retain or purge
         :return: a JSON with the number of readings removed, the number of unsent readings removed
             and the number of readings that remain
         :Example:
-            curl -X PUT http://0.0.0.0:8080/storage/reading/purge?age=24&sent=2&flags=PURGE
-            curl -X PUT <base url>?/storage/reading/purge?age=<age>&sent=<reading id>&flags=<flags>
-
+            curl -X PUT "http://0.0.0.0:<storage_service_port>/storage/reading/purge?age=<age>&sent=<reading id>&flags=<flags>"
+            curl -X PUT "http://0.0.0.0:<storage_service_port>/storage/reading/purge?age=24&sent=2&flags=PURGE"
+            curl -X PUT "http://0.0.0.0:<storage_service_port>/storage/reading/purge?size=1024&sent=0&flags=PURGE"
         """
         # TODO: flagS should be flag?
 

--- a/python/foglamp/tasks/purge/purge.py
+++ b/python/foglamp/tasks/purge/purge.py
@@ -50,7 +50,7 @@ class Purge(FoglampProcess):
         },
         "size": {
             "description": "Maximum size of data to be retained, the oldest data will be removed to keep below this "
-                           "size, unless retained. (in Bytes)",
+                           "size, unless retained. (in Kbytes)",
             "type": "integer",
             "default": "1000000"
         },


### PR DESCRIPTION
Below items which we need to fix as per [FOGL-889](https://scaledb.atlassian.net/browse/FOGL-889)

- [x] Add unit tests by purge size in test_purge.py -- Unit tests has already covered in [FOGL-1014](https://scaledb.atlassian.net/browse/FOGL-1014)
- [x] Fix description for size key in purge.py
- [x] Add CURL example with size in storage_client.py
- [x] Add size param docstring in storage_client.py
- [x] Add purge endpoint test in test_storage_client.py as well -- No focus on integration tests as of now 
- [x] fix logger error message with size in plugin.cpp **--** Fixed by @MarkRiddoch in this PR
Logger::getLogger()->error("Failed to reach target readings size %ld during purge operation",age);