### PR TITLE
FOGL-1054 - unit tests for services/south/server.py

### DIFF
--- a/python/foglamp/services/south/server.py
+++ b/python/foglamp/services/south/server.py
@@ -20,6 +20,7 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 _LOGGER = logger.setup(__name__)
+_MAX_RETRY_POLL = 3
 
 
 class Server(FoglampMicroservice):
@@ -139,14 +140,15 @@ class Server(FoglampMicroservice):
     async def _exec_plugin_async(self) -> None:
         """Executes async type plugin
         """
+        _LOGGER.info('Started South Plugin: {}'.format(self._name))
         self._plugin.plugin_start(self._plugin_handle)
 
     async def _exec_plugin_poll(self) -> None:
         """Executes poll type plugin
         """
-        max_retry = 3
+        _LOGGER.info('Started South Plugin: {}'.format(self._name))
         try_count = 1
-        while self._plugin and try_count <= max_retry:
+        while self._plugin and try_count <= _MAX_RETRY_POLL:
             try:
                 data = self._plugin.plugin_poll(self._plugin_handle)
                 if len(data) > 0:
@@ -172,6 +174,7 @@ class Server(FoglampMicroservice):
                 try_count += 1
                 _LOGGER.exception('Failed to poll for plugin {}, retry count: {}'.format(self._name, try_count))
                 await asyncio.sleep(2)
+        _LOGGER.exception('Max retries exhausted in starting South plugin: {}'.format(self._name))
 
     def run(self):
         """Starts the South Microservice
@@ -243,6 +246,7 @@ class Server(FoglampMicroservice):
             new_handle = self._plugin.plugin_reconfigure(self._plugin_handle, new_config)
             self._plugin_handle = new_handle
 
+            _LOGGER.info('Reconfiguration done for South plugin {}'.format(self._name))
             if new_handle['restart'] == 'yes':
                 self._task_main.cancel()
                 # Executes the requested plugin type with new config

--- a/tests/unit/python/foglamp/services/south/test_services_south_server.py
+++ b/tests/unit/python/foglamp/services/south/test_services_south_server.py
@@ -1,0 +1,485 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+import asyncio
+import copy
+import pytest
+import sys
+from unittest import mock
+from unittest.mock import MagicMock, Mock, call
+from foglamp.services.south import server as South
+from foglamp.services.south.server import Server
+from foglamp.common.storage_client.storage_client import StorageClient
+from foglamp.services.common.microservice import FoglampMicroservice
+from foglamp.common.configuration_manager import ConfigurationManager
+from foglamp.services.south.ingest import Ingest
+from foglamp.services.south import exceptions
+
+__author__ = "Amarendra K Sinha"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+_TEST_CONFIG = {
+    'plugin': {
+        'description': 'Python module name of the plugin to load',
+        'type': 'string',
+        'default': 'test'
+    }
+}
+plugin_attrs = {
+    'plugin_info.return_value': {
+        'name': 'CoAP Server',
+        'version': '1.0',
+        'mode': 'async',
+        'type': 'south',
+        'interface': '1.0',
+        'config': {
+            'plugin': {
+                'description': 'Python module name of the plugin to load',
+                'type': 'string',
+                'default': 'test',
+                'value': 'test',
+            },
+            'port': {
+                'description': 'Port to listen on',
+                'type': 'integer',
+                'default': '5683',
+                'value': '5683',
+            },
+            'uri': {
+                'description': 'URI to accept data on',
+                'type': 'string',
+                'default': 'sensor-values',
+                'value': 'sensor-values',
+            }
+        }
+    },
+    'plugin_init.return_value': {
+        'config': {
+            'plugin': {
+                'description': 'Python module name of the plugin to load',
+                'type': 'string',
+                'default': 'test',
+                'value': 'test',
+            },
+            'port': {
+                'description': 'Port to listen on',
+                'type': 'integer',
+                'default': '5683',
+                'value': '5683',
+            },
+            'uri': {
+                'description': 'URI to accept data on',
+                'type': 'string',
+                'default': 'sensor-values',
+                'value': 'sensor-values',
+            }
+        }
+    },
+    'plugin_start.return_value': "",
+    # We are forcing RuntimeError as poll plugin runs an infinite loop and as such this will tested indirectly
+    'plugin_poll.side_effect': RuntimeError,
+    'plugin_shutdown.return_value': "",
+    'plugin_reconfigure.return_value': {"restart": "yes"}
+}
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("south")
+class TestServicesSouthServer:
+    def south_fixture(self, mocker):
+        async def cat_get():
+            config = _TEST_CONFIG
+            config['plugin']['value'] = config['plugin']['default']
+            return config
+
+        mocker.patch.object(FoglampMicroservice, "__init__", return_value=None)
+
+        south_server = Server()
+        south_server._storage = MagicMock(spec=StorageClient)
+        mocker.patch.object(south_server, '_core_microservice_management_client')
+        mocker.patch.object(south_server, '_name', 'test')
+
+        cfg_mgr_create_cat = mocker.patch.object(ConfigurationManager, "create_category",
+                                                 return_value=asyncio.sleep(.1))
+        cfg_mgr_get_cat_all = mocker.patch.object(ConfigurationManager, "get_category_all_items",
+                                                  return_value=asyncio.ensure_future(cat_get()))
+        ingest_start = mocker.patch.object(Ingest, 'start', return_value=asyncio.sleep(.1))
+        log_exception = mocker.patch.object(South._LOGGER, "exception")
+        log_info = mocker.patch.object(South._LOGGER, "info")
+
+        return cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info
+
+    @pytest.mark.asyncio
+    async def test__start_async_plugin(self, mocker, loop):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        mock_plugin = MagicMock()
+        attrs = copy.deepcopy(plugin_attrs)
+        attrs['plugin_info.return_value']['mode'] = 'async'
+        mock_plugin.configure_mock(**attrs)
+        sys.modules['foglamp.plugins.south.test.test'] = mock_plugin
+
+        # WHEN
+        await south_server._start(loop)
+        await asyncio.sleep(1)
+
+        # THEN
+        assert 2 == cfg_mgr_create_cat.call_count
+        calls = [
+            call(south_server._name, _TEST_CONFIG,
+                 '{} Device'.format(south_server._name), True),
+            call(south_server._name, plugin_attrs['plugin_init.return_value']['config'],
+                  '{} Device'.format(south_server._name))
+        ]
+        # cfg_mgr_create_cat.assert_has_calls(calls, any_order=True) TODO
+        cfg_mgr_create_cat.assert_called_with(south_server._name, plugin_attrs['plugin_init.return_value']['config'],
+                                                  '{} Device'.format(south_server._name))
+        assert 2 == cfg_mgr_get_cat_all.call_count
+        cfg_mgr_get_cat_all.assert_has_calls([call(south_server._name), call(south_server._name)])
+        assert 1 == ingest_start.call_count
+        ingest_start_params = None, None
+        ingest_start.assert_called_with(*ingest_start_params)
+        assert 1 == log_info.call_count
+        assert 0 == log_exception.call_count
+        assert south_server._task_main.done() is True
+
+    @pytest.mark.asyncio
+    async def test__start_async_plugin_bad_plugin_value(self, mocker, loop):
+        # GIVEN
+        async def cat_get():
+            config = _TEST_CONFIG
+            config['plugin']['value'] = None
+            return config
+
+        mocker.patch.object(FoglampMicroservice, "__init__", return_value=None)
+
+        south_server = Server()
+        south_server._storage = MagicMock(spec=StorageClient)
+        mocker.patch.object(south_server, '_core_microservice_management_client')
+        mocker.patch.object(south_server, '_name', 'test')
+        mocker.patch.object(south_server, '_stop', return_value=asyncio.sleep(.1))
+
+        cfg_mgr_create_cat = mocker.patch.object(ConfigurationManager, "create_category",
+                                                 return_value=asyncio.sleep(.1))
+        cfg_mgr_get_cat_all = mocker.patch.object(ConfigurationManager, "get_category_all_items",
+                                                  return_value=asyncio.ensure_future(cat_get()))
+        log_exception = mocker.patch.object(South._LOGGER, "exception")
+
+        # WHEN
+        await south_server._start(loop)
+        await asyncio.sleep(1)
+
+        # THEN
+        assert 1 == cfg_mgr_create_cat.call_count
+        assert 1 == cfg_mgr_get_cat_all.call_count
+        assert 1 == log_exception.call_count
+        log_exception.assert_called_with('Failed to initialize plugin {}'.format(south_server._name))
+
+    @pytest.mark.asyncio
+    async def test__start_async_plugin_bad_plugin_name(self, mocker, loop):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        mocker.patch.object(south_server, '_stop', return_value=asyncio.sleep(.1))
+        sys.modules['foglamp.plugins.south.test.test'] = None
+
+        # WHEN
+        await south_server._start(loop)
+        await asyncio.sleep(1)
+
+        # THEN
+        assert 1 == cfg_mgr_create_cat.call_count
+        assert 1 == cfg_mgr_get_cat_all.call_count
+        assert 1 == log_exception.call_count
+        log_exception.assert_called_with('Failed to initialize plugin {}'.format(south_server._name))
+
+    @pytest.mark.asyncio
+    async def test__start_async_plugin_bad_plugin_type(self, mocker, loop):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        mocker.patch.object(south_server, '_stop', return_value=asyncio.sleep(.1))
+        mock_plugin = MagicMock()
+        attrs = copy.deepcopy(plugin_attrs)
+        attrs['plugin_info.return_value']['mode'] = 'async'
+        attrs['plugin_info.return_value']['type'] = 'bad'
+        mock_plugin.configure_mock(**attrs)
+        sys.modules['foglamp.plugins.south.test.test'] = mock_plugin
+
+        # WHEN
+        await south_server._start(loop)
+        await asyncio.sleep(1)
+
+        # THEN
+        assert 2 == cfg_mgr_create_cat.call_count
+        assert 2 == cfg_mgr_get_cat_all.call_count
+        assert 1 == log_exception.call_count
+        log_exception.assert_called_with('Failed to initialize plugin {}'.format(south_server._name))
+
+    @pytest.mark.asyncio
+    async def test__start_poll_plugin(self, loop, mocker):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        # Mocking _stop() required as we are testing poll_plugin indirectly
+        mocker.patch.object(south_server, '_stop', return_value=asyncio.sleep(.1))
+        mock_plugin = MagicMock()
+        attrs = copy.deepcopy(plugin_attrs)
+        attrs['plugin_info.return_value']['mode'] = 'poll'
+        mock_plugin.configure_mock(**attrs)
+        sys.modules['foglamp.plugins.south.test.test'] = mock_plugin
+
+        # WHEN
+        South._MAX_RETRY_POLL = 1
+        await south_server._start(loop)
+        await asyncio.sleep(1)
+
+        # THEN
+        assert 2 == cfg_mgr_create_cat.call_count
+        calls = [
+            call(south_server._name, _TEST_CONFIG,
+                 '{} Device'.format(south_server._name), True),
+            call(south_server._name, plugin_attrs['plugin_init.return_value']['config'],
+                  '{} Device'.format(south_server._name))
+        ]
+        # cfg_mgr_create_cat.assert_has_calls(calls, any_order=True) TODO
+        cfg_mgr_create_cat.assert_called_with(south_server._name, plugin_attrs['plugin_init.return_value']['config'],
+                                                  '{} Device'.format(south_server._name))
+        assert 2 == cfg_mgr_get_cat_all.call_count
+        cfg_mgr_get_cat_all.assert_has_calls([call(south_server._name), call(south_server._name)])
+        assert 1 == ingest_start.call_count
+        ingest_start_params = None, None
+        ingest_start.assert_called_with(*ingest_start_params)
+        assert 1 == log_info.call_count
+        assert 1 == log_exception.call_count
+        assert south_server._task_main.done() is False  # because of exception occurred
+
+    @pytest.mark.asyncio
+    async def test__exec_plugin_async(self, loop, mocker):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        mock_plugin = MagicMock()
+        attrs = copy.deepcopy(plugin_attrs)
+        attrs['plugin_info.return_value']['mode'] = 'async'
+        mock_plugin.configure_mock(**attrs)
+        sys.modules['foglamp.plugins.south.test.test'] = mock_plugin
+
+        # WHEN
+        # We need to run _start() in order to initialize self._plugin
+        await south_server._start(loop)
+        await asyncio.sleep(1)
+
+        # This line is redundant as it has already been executed above
+        await south_server._exec_plugin_async()
+
+        # THEN
+        assert 2 == log_info.call_count
+        log_info.assert_called_with('Started South Plugin: {}'.format(south_server._name))
+
+    @pytest.mark.asyncio
+    async def test__exec_plugin_poll(self, loop, mocker):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        # Mocking _stop() required as we are testing poll_plugin indirectly
+        mocker.patch.object(south_server, '_stop', return_value=asyncio.sleep(.1))
+        mock_plugin = MagicMock()
+        attrs = copy.deepcopy(plugin_attrs)
+        attrs['plugin_info.return_value']['mode'] = 'poll'
+        mock_plugin.configure_mock(**attrs)
+        sys.modules['foglamp.plugins.south.test.test'] = mock_plugin
+
+        # WHEN
+        # We need to run _start() in order to initialize self._plugin
+        South._MAX_RETRY_POLL = 1
+        await south_server._start(loop)
+        await asyncio.sleep(1)
+
+        # This line is redundant as it has already been executed above
+        await south_server._exec_plugin_poll()
+
+        # THEN
+        assert 2 == log_info.call_count
+        log_info.assert_called_with('Started South Plugin: {}'.format(south_server._name))
+
+    @pytest.mark.asyncio
+    async def test__exec_plugin_poll_exceed_retries(self, loop, mocker):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        mocker.patch.object(south_server, '_stop', return_value=asyncio.sleep(.1))
+        mock_plugin = MagicMock()
+        attrs = copy.deepcopy(plugin_attrs)
+        attrs['plugin_info.return_value']['mode'] = 'poll'
+        mock_plugin.configure_mock(**attrs)
+        sys.modules['foglamp.plugins.south.test.test'] = mock_plugin
+
+        # WHEN
+        # We need to run _start() in order to initialize self._plugin
+        South._MAX_RETRY_POLL = 1
+        await south_server._start(loop)
+        await asyncio.sleep(1)
+        await south_server._exec_plugin_poll()
+
+        # THEN
+        # Count is 2 and 4 because above method is executed twice
+        assert 2 == log_info.call_count
+        assert 4 == log_exception.call_count
+        calls = [call('Max retries exhausted in starting South plugin: test'), call('Failed to poll for plugin test, retry count: 2'),
+                 call('Max retries exhausted in starting South plugin: test'), call('Failed to poll for plugin test, retry count: 2')]
+        log_exception.assert_has_calls(calls, any_order=True)
+
+    @pytest.mark.asyncio
+    async def test_run(self, mocker):
+        """Not fit for Unit test"""
+        pass
+
+    @pytest.mark.asyncio
+    async def test__stop(self, loop, mocker):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        ingest_stop = mocker.patch.object(Ingest, 'stop', return_value=asyncio.sleep(.1))
+        mock_plugin = MagicMock()
+        attrs = copy.deepcopy(plugin_attrs)
+        attrs['plugin_info.return_value']['mode'] = 'async'
+        mock_plugin.configure_mock(**attrs)
+        sys.modules['foglamp.plugins.south.test.test'] = mock_plugin
+
+        # WHEN
+        # We need to initialize and start plugin in order to stop it
+        await south_server._start(loop)
+        await asyncio.sleep(1)
+        await south_server._stop(loop)
+        await asyncio.sleep(1)
+
+        # THEN
+        assert 3 == log_info.call_count
+        calls = [call('Started South Plugin: {}'.format(south_server._name)),
+                 call('Stopped the Ingest server.'),
+                 call('Stopping South service event loop, for plugin test.')]
+        log_info.assert_has_calls(calls, any_order=True)
+        assert 0 == log_exception.call_count
+
+    @pytest.mark.asyncio
+    async def test__stop_plugin_stop_error(self, loop, mocker):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        ingest_stop = mocker.patch.object(Ingest, 'stop', return_value=asyncio.sleep(.1))
+        mock_plugin = MagicMock()
+        attrs = copy.deepcopy(plugin_attrs)
+        attrs['plugin_info.return_value']['mode'] = 'async'
+        attrs['plugin_shutdown.side_effect'] = RuntimeError
+        mock_plugin.configure_mock(**attrs)
+        sys.modules['foglamp.plugins.south.test.test'] = mock_plugin
+
+        # WHEN
+        # We need to initialize and start plugin in order to stop it
+        await south_server._start(loop)
+        await asyncio.sleep(1)
+        await south_server._stop(loop)
+        await asyncio.sleep(1)
+
+        # THEN
+        assert 3 == log_info.call_count
+        calls = [call('Started South Plugin: {}'.format(south_server._name)),
+                 call('Stopped the Ingest server.'),
+                 call('Stopping South service event loop, for plugin test.')]
+        log_info.assert_has_calls(calls, any_order=True)
+        assert 1 == log_exception.call_count
+
+    @pytest.mark.asyncio
+    async def test_shutdown(self, loop, mocker):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        server_stop = mocker.patch.object(south_server, '_stop', return_value=asyncio.sleep(.1))
+        unregister = mocker.patch.object(south_server, 'unregister_service_with_core', return_value=True)
+
+        # WHEN
+        await south_server.shutdown(request=None)
+
+        # THEN
+        assert 1 == log_info.call_count
+        log_info.assert_called_with('Stopping South Service plugin {}'.format(south_server._name))
+
+    @pytest.mark.asyncio
+    async def test_shutdown_error(self, loop, mocker):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        server_stop = mocker.patch.object(south_server, '_stop', return_value=asyncio.sleep(.1), side_effect=RuntimeError)
+        unregister = mocker.patch.object(south_server, 'unregister_service_with_core', return_value=True)
+
+        # WHEN
+        from aiohttp.web_exceptions import HTTPInternalServerError
+        with pytest.raises(HTTPInternalServerError):
+            await south_server.shutdown(request=None)
+
+        # THEN
+        assert 1 == log_info.call_count
+        log_info.assert_called_with('Stopping South Service plugin {}'.format(south_server._name))
+        assert 1 == log_exception.call_count
+        log_exception.assert_called_with('Error in stopping South Service plugin {}, '.format(south_server._name))
+
+    @pytest.mark.asyncio
+    async def test_change(self, loop, mocker):
+        # GIVEN
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        mock_plugin = MagicMock()
+        attrs = copy.deepcopy(plugin_attrs)
+        attrs['plugin_info.return_value']['mode'] = 'async'
+        mock_plugin.configure_mock(**attrs)
+        sys.modules['foglamp.plugins.south.test.test'] = mock_plugin
+
+        # WHEN
+        await south_server._start(loop)
+        await asyncio.sleep(1)
+        await south_server.change(request=None)
+
+        # THEN
+        assert 4 == log_info.call_count
+        calls = [call('Started South Plugin: test'),
+                 call('Configuration has changed for South plugin test'),
+                 call('Reconfiguration done for South plugin test'),
+                 call('Started South Plugin: test')]
+        log_info.assert_has_calls(calls, any_order=True)
+
+    @pytest.mark.asyncio
+    async def test_change_error(self, loop, mocker):
+        # GIVEN
+        from foglamp.services.south import exceptions
+        cat_get, south_server, cfg_mgr_create_cat, cfg_mgr_get_cat_all, ingest_start, log_exception, log_info = \
+                self.south_fixture(mocker)
+        mock_plugin = MagicMock()
+        attrs = copy.deepcopy(plugin_attrs)
+        attrs['plugin_info.return_value']['mode'] = 'async'
+        attrs['plugin_reconfigure.side_effect'] = exceptions.DataRetrievalError
+        mock_plugin.configure_mock(**attrs)
+        sys.modules['foglamp.plugins.south.test.test'] = mock_plugin
+
+        # WHEN
+        with pytest.raises(TypeError):
+            await south_server._start(loop)
+            await asyncio.sleep(1)
+            await south_server.change(request=None)
+
+        # THEN
+        assert 2 == log_info.call_count
+        calls = [call('Started South Plugin: test'),
+                 call('Configuration has changed for South plugin test')]
+        log_info.assert_has_calls(calls, any_order=True)
+
+        assert 1 == log_exception.call_count
+        calls = [call('Data retreival error in plugin test during reconfigure')]
+        log_exception.assert_has_calls(calls, any_order=True)
+

--- a/tests/unit/python/foglamp/services/south/test_services_south_server.py
+++ b/tests/unit/python/foglamp/services/south/test_services_south_server.py
@@ -8,7 +8,6 @@ import asyncio
 import copy
 import pytest
 import sys
-from unittest import mock
 from unittest.mock import MagicMock, Mock, call
 from foglamp.services.south import server as South
 from foglamp.services.south.server import Server
@@ -16,7 +15,6 @@ from foglamp.common.storage_client.storage_client import StorageClient
 from foglamp.services.common.microservice import FoglampMicroservice
 from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.services.south.ingest import Ingest
-from foglamp.services.south import exceptions
 
 __author__ = "Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"


### PR DESCRIPTION
Test Result:
```
FogLAMP (FOGL-1054 *%) $ pytest -s -vv  tests/unit/python/foglamp/services/south/test_services_south_server.py 
======================================================= test session starts ========================================================
platform linux -- Python 3.5.2, pytest-3.4.0, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python3.5
cachedir: .pytest_cache
rootdir: /home/asinha/Development/FogLAMP, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 15 items                                                                                                                 

tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test__start_async_plugin[pyloop] PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test__start_async_plugin_bad_plugin_value[pyloop] Failed to initialize plugin test No module named 'foglamp.plugins.south.None'
PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test__start_async_plugin_bad_plugin_name[pyloop] Failed to initialize plugin test import of 'foglamp.plugins.south.test.test' halted; None in sys.modules
PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test__start_async_plugin_bad_plugin_type[pyloop] Failed to initialize plugin test 
PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test__start_poll_plugin[pyloop] PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test__exec_plugin_async[pyloop] PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test__exec_plugin_poll[pyloop] PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test__exec_plugin_poll_exceed_retries[pyloop] PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test_run PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test__stop[pyloop] PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test__stop_plugin_stop_error[pyloop] PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test_shutdown[pyloop] PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test_shutdown_error[pyloop] PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test_change[pyloop] PASSED
tests/unit/python/foglamp/services/south/test_services_south_server.py::TestServicesSouthServer::test_change_error[pyloop] PASSED

==================================================== 15 passed in 8.36 seconds =====================================================

```

Code Coverage:

```
Coverage for python/foglamp/services/south/server.py : 84% Show keyboard shortcuts
157 statements   132 run 25 missing 0 excluded

```