### PR TITLE
FOGL-1007 Unit test for api/backup_restore.py

### DIFF
--- a/python/foglamp/plugins/storage/postgres/backup_restore/backup_postgres.py
+++ b/python/foglamp/plugins/storage/postgres/backup_restore/backup_postgres.py
@@ -394,8 +394,8 @@ class BackupProcess(FoglampProcess):
         if status != lib.BackupStatus.COMPLETED:
 
             self._logger.error(self._MESSAGES_LIST["e000007"])
-            raise exceptions.BackupFailed
             loop.run_until_complete(audit.information('BKEXC', {'status': 'failed'}))
+            raise exceptions.BackupFailed
         else:
             loop.run_until_complete(audit.information('BKEXC', {'status': 'completed'}))
 

--- a/python/foglamp/services/core/api/backup_restore.py
+++ b/python/foglamp/services/core/api/backup_restore.py
@@ -118,8 +118,6 @@ async def get_backup_details(request):
     :Example: curl -X GET http://localhost:8081/foglamp/backup/1
     """
     backup_id = request.match_info.get('backup_id', None)
-    if not backup_id:
-        raise web.HTTPBadRequest(reason='Backup id is required')
     try:
         backup_id = int(backup_id)
         backup = Backup(connect.get_storage())

--- a/python/foglamp/services/core/api/backup_restore.py
+++ b/python/foglamp/services/core/api/backup_restore.py
@@ -131,7 +131,7 @@ async def get_backup_details(request):
     except ValueError:
         raise web.HTTPBadRequest(reason='Invalid backup id')
     except exceptions.DoesNotExist:
-        raise web.HTTPNotFound(reason='Backup with {} does not exist'.format(backup_id))
+        raise web.HTTPNotFound(reason='Backup id {} does not exist'.format(backup_id))
     except Exception as ex:
         raise web.HTTPException(reason=(str(ex)))
 
@@ -144,8 +144,6 @@ async def delete_backup(request):
     :Example: curl -X DELETE http://localhost:8081/foglamp/backup/1
     """
     backup_id = request.match_info.get('backup_id', None)
-    if not backup_id:
-        raise web.HTTPBadRequest(reason='Backup id is required')
     try:
         backup_id = int(backup_id)
         backup = Backup(connect.get_storage())

--- a/tests/unit/python/foglamp/services/core/api/test_backup_restore.py
+++ b/tests/unit/python/foglamp/services/core/api/test_backup_restore.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+
+import json
+from unittest.mock import MagicMock, patch
+from aiohttp import web
+import pytest
+from collections import Counter
+from foglamp.services.core import routes
+from foglamp.services.core import connect
+from foglamp.plugins.storage.postgres.backup_restore.backup_postgres import Backup
+from foglamp.services.core.api import backup_restore
+from foglamp.common.storage_client.storage_client import StorageClient
+
+
+__author__ = "Vaibhav Singhal"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("api", "core")
+class TestBackupRestore:
+
+    @pytest.fixture
+    def client(self, loop, test_client):
+        app = web.Application(loop=loop)
+        # fill the routes table
+        routes.setup(app)
+        return loop.run_until_complete(test_client(app))
+
+    @pytest.mark.parametrize("input_data, expected", [
+        (1, "RUNNING"),
+        (2, "COMPLETED"),
+        (3, "CANCELED"),
+        (4, "INTERRUPTED"),
+        (5, "FAILED"),
+        (6, "RESTORED"),
+        (7, "UNKNOWN")
+    ])
+    def test_get_status(self, input_data, expected):
+        assert expected == backup_restore._get_status(input_data)
+
+    @pytest.mark.parametrize("request_params", [
+        '',
+        '?limit=1',
+        '?skip=1',
+        '?status=completed',
+        '?status=failed',
+        '?status=restored&skip=10',
+        '?status=running&limit=1',
+        '?status=canceled&limit=10&skip=0',
+        '?status=interrupted&limit=&skip=',
+        '?status=&limit=&skip='
+    ])
+    async def test_get_backups(self, client, request_params):
+        storage_client_mock = MagicMock(StorageClient)
+        response = [{'file_name': '1.dump',
+                     'id': 1, 'type': '1', 'status': '2',
+                     'ts': '2018-02-15 15:18:41.821978+05:30',
+                     'exit_code': '0'}]
+        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+            with patch.object(Backup, 'get_all_backups', return_value=response):
+                    resp = await client.get('/foglamp/backup{}'.format(request_params))
+                    assert 200 == resp.status
+                    result = await resp.text()
+                    json_response = json.loads(result)
+                    assert 1 == len(json_response['backups'])
+                    assert Counter({"id", "date", "status"}) == Counter(json_response['backups'][0].keys())
+
+    @pytest.mark.parametrize("request_params, response_code, response_message", [
+        ('?limit=invalid', 400, "Limit must be a positive integer"),
+        ('?limit=-1', 400, "Limit must be a positive integer"),
+        ('?skip=invalid', 400, "Skip/Offset must be a positive integer"),
+        ('?skip=-1', 400, "Skip/Offset must be a positive integer"),
+        ('?status=BLA', 400, "'BLA' is not a valid status"),
+        ('', 500, "Internal Server Error")
+    ])
+    async def test_get_backups_bad_data(self, client, request_params, response_code, response_message):
+        resp = await client.get('/foglamp/backup{}'.format(request_params))
+        assert response_code == resp.status
+        assert response_message == resp.reason


### PR DESCRIPTION
- [X] Unit test added

- Test Results:

 `35 passed in 2.37 seconds`

- Code coverage:

```
Coverage for FogLAMP/python/foglamp/services/core/api/backup_restore.py : 100%
103 statements   103 run 0 missing 0 excluded
```

- [X] Fixed FOGL-1102