### PR TITLE
FOGL-1048 test added for Service Record

### DIFF
--- a/tests/unit/python/foglamp/common/test_service_record.py
+++ b/tests/unit/python/foglamp/common/test_service_record.py
@@ -23,22 +23,22 @@ class TestServiceRecord:
     @pytest.mark.parametrize("s_port", [None, 12, "34"])
     def test_init(self, s_port):
         obj = ServiceRecord("some id", "aName", "Storage", "http", "127.0.0.1", s_port, 1234)
-        assert obj._id == "some id"
-        assert obj._name == "aName"
-        assert obj._type == "Storage"
+        assert "some id" == obj._id
+        assert "aName" == obj._name
+        assert "Storage" == obj._type
         if s_port:
-            assert obj._port == int(s_port)
+            assert int(s_port) == obj._port
         else:
             assert obj._port is None
-        assert obj._management_port == 1234
-        assert obj._status == 1
+        assert 1234 == obj._management_port
+        assert 1 == obj._status
 
     @pytest.mark.parametrize("s_type", ["Storage", "Core", "Southbound"])
     def test_init_with_valid_type(self, s_type):
         obj = ServiceRecord("some id", "aName", s_type, "http", "127.0.0.1", None, 1234)
-        assert obj._id == "some id"
-        assert obj._name == "aName"
-        assert obj._type == s_type
+        assert "some id" == obj._id
+        assert "aName" == obj._name
+        assert s_type == obj._type
 
     def test_init_with_invalid_type(self):
         with pytest.raises(Exception) as excinfo:

--- a/tests/unit/python/foglamp/common/test_service_record.py
+++ b/tests/unit/python/foglamp/common/test_service_record.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+
+""" Test foglamp/common/service_record.py """
+
+import pytest
+
+from foglamp.common.service_record import ServiceRecord
+
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("common", "service-record")
+class TestServiceRecord:
+
+    @pytest.mark.parametrize("s_port", [None, 12, "34"])
+    def test_init(self, s_port):
+        obj = ServiceRecord("some id", "aName", "Storage", "http", "127.0.0.1", s_port, 1234)
+        assert obj._id == "some id"
+        assert obj._name == "aName"
+        assert obj._type == "Storage"
+        if s_port:
+            assert obj._port == int(s_port)
+        else:
+            assert obj._port is None
+        assert obj._management_port == 1234
+        assert obj._status == 1
+
+    @pytest.mark.parametrize("s_type", ["Storage", "Core", "Southbound"])
+    def test_init_with_valid_type(self, s_type):
+        obj = ServiceRecord("some id", "aName", s_type, "http", "127.0.0.1", None, 1234)
+        assert obj._id == "some id"
+        assert obj._name == "aName"
+        assert obj._type == s_type
+
+    def test_init_with_invalid_type(self):
+        with pytest.raises(Exception) as excinfo:
+            obj = ServiceRecord("some id", "aName", "BLAH", "http", "127.0.0.1", None, 1234)
+        assert excinfo.type is ServiceRecord.InvalidServiceType


### PR DESCRIPTION
```
collected 7 items                                                                                                                         

tests/unit/python/foglamp/common/test_service_record.py::TestServiceRecord::test_init[None] PASSED
tests/unit/python/foglamp/common/test_service_record.py::TestServiceRecord::test_init[12] PASSED
tests/unit/python/foglamp/common/test_service_record.py::TestServiceRecord::test_init[34] PASSED
tests/unit/python/foglamp/common/test_service_record.py::TestServiceRecord::test_init_with_valid_type[Storage] PASSED
tests/unit/python/foglamp/common/test_service_record.py::TestServiceRecord::test_init_with_valid_type[Core] PASSED
tests/unit/python/foglamp/common/test_service_record.py::TestServiceRecord::test_init_with_valid_type[Southbound] PASSED
tests/unit/python/foglamp/common/test_service_record.py::TestServiceRecord::test_init_with_invalid_type PASSED

----------- coverage: platform linux, python 3.5.2-final-0 -----------
Name                                                                                Stmts   Miss  Cover
-------------------------------------------------------------------------------------------------------

tests/unit/python/foglamp/common/test_service_record.py                                27      0   100%
```