### PR TITLE
FOGL-1035 unit tests for FoglampProcess class

### DIFF
--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -26,13 +26,13 @@ _logger = logger.setup(__name__)
 
 
 class ArgumentParserError(Exception):
-    """ Overwrite default exception to not terminate application """
+    """ Override default exception to not terminate application """
     pass
 
 class SilentArgParse(argparse.ArgumentParser):
 
     def error(self, message):
-        """ Overwrite default error functionality to not terminate application """
+        """ Override default error functionality to not terminate application """
         raise ArgumentParserError(message)
 
     def silent_arg_parse(self, argument_name):

--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -29,6 +29,13 @@ class ArgumentParserError(Exception):
     """ Overwrite default exception to not terminate application """
     pass
 
+class SilentArgParse(argparse.ArgumentParser):
+    def error(self, message):
+        raise ArgumentParserError(message)
+    def silent_arg_parse(self, argument_name):
+        self.add_argument(argument_name)
+        parser_result = self.parse_known_args()
+        return list(vars(parser_result[0]).values())[0]
 
 class FoglampProcess(ABC):
     """ FoglampProcess for all non-core python processes.
@@ -105,19 +112,9 @@ class FoglampProcess(ABC):
             Known Exceptions:
             ArgumentParserError
         """
-        class SilentArgParse(argparse.ArgumentParser):
-            def error(self, message):
-                raise ArgumentParserError(message)
-        
         parser = SilentArgParse()
-        parser.add_argument(argument_name)
-        try:
-            parser_result = parser.parse_known_args()
-        except ArgumentParserError:
-            raise
-        else:
-            return list(vars(parser_result[0]).values())[0]
-
+        return parser.silent_arg_parse(argument_name)
+        
     def get_services_from_core(self, name=None, _type=None):
         return self._core_microservice_management_client.get_services(name, _type)
 

--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -30,8 +30,11 @@ class ArgumentParserError(Exception):
     pass
 
 class SilentArgParse(argparse.ArgumentParser):
+
     def error(self, message):
+        """ Overwrite default error functionality to not terminate application """
         raise ArgumentParserError(message)
+
     def silent_arg_parse(self, argument_name):
         self.add_argument(argument_name)
         parser_result = self.parse_known_args()

--- a/tests/unit/python/foglamp/common/test_process.py
+++ b/tests/unit/python/foglamp/common/test_process.py
@@ -2,13 +2,9 @@
 
 import pytest
 
-from unittest.mock import MagicMock
 from unittest.mock import patch
-from unittest.mock import call
 
-from argparse import ArgumentParser
 from foglamp.common.storage_client.storage_client import ReadingsStorageClient, StorageClient
-from foglamp.common import logger
 from foglamp.common.process import FoglampProcess, SilentArgParse, ArgumentParserError
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient
 
@@ -19,12 +15,6 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 
-"""
-unit tests:
-    abstract class enforcement
-    abstract method enforcement
-
-"""
 @pytest.allure.feature("unit")
 @pytest.allure.story("common", "foglamp-process")
 class TestFoglampProcess:
@@ -37,16 +27,16 @@ class TestFoglampProcess:
                 pass
             fp = FoglampProcessImp()
 
-    @pytest.mark.parametrize('argslist', 
+    @pytest.mark.parametrize('argslist',
                              [([ArgumentParserError()]),
                               (['corehost', ArgumentParserError()]),
                               (['corehost', 0, ArgumentParserError()])
-                             ])
+                              ])
     def test_constructor_missing_args(self, argslist):
         class FoglampProcessImp(FoglampProcess):
             def run():
                 pass
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=argslist): 
+        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=argslist):
             with pytest.raises(ArgumentParserError) as excinfo:
                 fp = FoglampProcessImp()
         assert '' in str(
@@ -110,4 +100,3 @@ class TestFoglampProcess:
                             fp = FoglampProcessImp()
                             fp.unregister_service_with_core('id')
         unregister_patch.assert_called_once_with('id')
-

--- a/tests/unit/python/foglamp/common/test_process.py
+++ b/tests/unit/python/foglamp/common/test_process.py
@@ -34,7 +34,7 @@ class TestFoglampProcess:
                               ])
     def test_constructor_missing_args(self, argslist):
         class FoglampProcessImp(FoglampProcess):
-            def run():
+            def run(self):
                 pass
         with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=argslist):
             with pytest.raises(ArgumentParserError) as excinfo:
@@ -44,7 +44,7 @@ class TestFoglampProcess:
 
     def test_constructor_good(self):
         class FoglampProcessImp(FoglampProcess):
-            def run():
+            def run(self):
                 pass
         with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
@@ -64,7 +64,7 @@ class TestFoglampProcess:
 
     def test_get_services_from_core(self):
         class FoglampProcessImp(FoglampProcess):
-            def run():
+            def run(self):
                 pass
         with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
@@ -77,7 +77,7 @@ class TestFoglampProcess:
 
     def test_register_service_with_core(self):
         class FoglampProcessImp(FoglampProcess):
-            def run():
+            def run(self):
                 pass
         with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
@@ -90,7 +90,7 @@ class TestFoglampProcess:
 
     def test_unregister_service_with_core(self):
         class FoglampProcessImp(FoglampProcess):
-            def run():
+            def run(self):
                 pass
         with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:

--- a/tests/unit/python/foglamp/common/test_process.py
+++ b/tests/unit/python/foglamp/common/test_process.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from unittest.mock import call
+
+from argparse import ArgumentParser
+from foglamp.common.storage_client.storage_client import ReadingsStorageClient, StorageClient
+from foglamp.common import logger
+from foglamp.common.process import FoglampProcess, SilentArgParse, ArgumentParserError
+from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient
+
+
+__author__ = "Ashwin Gopalakrishnan"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+"""
+unit tests:
+    abstract class enforcement
+    abstract method enforcement
+
+"""
+@pytest.allure.feature("unit")
+@pytest.allure.story("common", "foglamp-process")
+class TestFoglampProcess:
+
+    def test_constructor_abstract_method_run(self):
+        with pytest.raises(TypeError):
+            fp = FoglampProcess()
+        with pytest.raises(TypeError):
+            class FoglampProcessImp(FoglampProcess):
+                pass
+            fp = FoglampProcessImp()
+
+    @pytest.mark.parametrize('argslist', 
+                             [([ArgumentParserError()]),
+                              (['corehost', ArgumentParserError()]),
+                              (['corehost', 0, ArgumentParserError()])
+                             ])
+    def test_constructor_missing_args(self, argslist):
+        class FoglampProcessImp(FoglampProcess):
+            def run():
+                pass
+        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=argslist): 
+            with pytest.raises(ArgumentParserError) as excinfo:
+                fp = FoglampProcessImp()
+        assert '' in str(
+            excinfo.value)
+
+    def test_constructor_good(self):
+        class FoglampProcessImp(FoglampProcess):
+            def run():
+                pass
+        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+            with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
+                with patch.object(ReadingsStorageClient, '__init__', return_value=None) as rsc_patch:
+                    with patch.object(StorageClient, '__init__', return_value=None) as sc_patch:
+                        fp = FoglampProcessImp()
+        mmc_patch.assert_called_once_with('corehost', 0)
+        rsc_patch.assert_called_once_with('corehost', 0)
+        sc_patch.assert_called_once_with('corehost', 0)
+        assert fp._core_management_host is 'corehost'
+        assert fp._core_management_port is 0
+        assert fp._name is 'sname'
+        assert hasattr(fp, '_core_microservice_management_client')
+        assert hasattr(fp, '_readings_storage')
+        assert hasattr(fp, '_storage')
+        assert hasattr(fp, '_start_time')
+
+    def test_get_services_from_core(self):
+        class FoglampProcessImp(FoglampProcess):
+            def run():
+                pass
+        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+            with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
+                with patch.object(ReadingsStorageClient, '__init__', return_value=None) as rsc_patch:
+                    with patch.object(StorageClient, '__init__', return_value=None) as sc_patch:
+                        with patch.object(MicroserviceManagementClient, 'get_services', return_value=None) as get_patch:
+                            fp = FoglampProcessImp()
+                            fp.get_services_from_core('foo', 'bar')
+        get_patch.assert_called_once_with('foo', 'bar')
+
+    def test_register_service_with_core(self):
+        class FoglampProcessImp(FoglampProcess):
+            def run():
+                pass
+        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+            with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
+                with patch.object(ReadingsStorageClient, '__init__', return_value=None) as rsc_patch:
+                    with patch.object(StorageClient, '__init__', return_value=None) as sc_patch:
+                        with patch.object(MicroserviceManagementClient, 'register_service', return_value=None) as register_patch:
+                            fp = FoglampProcessImp()
+                            fp.register_service_with_core('payload')
+        register_patch.assert_called_once_with('payload')
+
+    def test_unregister_service_with_core(self):
+        class FoglampProcessImp(FoglampProcess):
+            def run():
+                pass
+        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+            with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
+                with patch.object(ReadingsStorageClient, '__init__', return_value=None) as rsc_patch:
+                    with patch.object(StorageClient, '__init__', return_value=None) as sc_patch:
+                        with patch.object(MicroserviceManagementClient, 'unregister_service', return_value=None) as unregister_patch:
+                            fp = FoglampProcessImp()
+                            fp.unregister_service_with_core('id')
+        unregister_patch.assert_called_once_with('id')
+


### PR DESCRIPTION
Note that register_interest and unregister_interest do not have unit tests as they are currently not implemented. I have opened issue https://scaledb.atlassian.net/browse/FOGL-1119 for this. 