### PR TITLE
FOGL-1133 - Circular import disallows many unit tests from running

### DIFF
--- a/python/foglamp/services/core/service_registry/service_registry.py
+++ b/python/foglamp/services/core/service_registry/service_registry.py
@@ -12,7 +12,6 @@ import time
 from foglamp.common import logger
 from foglamp.common.service_record import ServiceRecord
 from foglamp.services.core.service_registry import exceptions as service_registry_exceptions
-from foglamp.services.core import server
 
 __author__ = "Praveen Garg, Amarendra Kumar Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -85,6 +84,12 @@ class ServiceRegistry:
         :return:
         """
         if service_name in ("FogLAMP Storage", "FogLAMP Core"):
+            return
+
+        # Require a local import in order to avoid circular import references
+        from foglamp.services.core import server
+
+        if server.Server.scheduler is None:
             return
 
         future = asyncio.ensure_future(server.Server.scheduler.remove_service_from_task_processes(service_name))


### PR DESCRIPTION
Test suite result:
```
a@a ~/Development/FogLAMP/tests/unit/python/foglamp (FOGL-1133) $ pytest
======================================================= test session starts ========================================================
platform linux -- Python 3.6.3, pytest-3.4.0, py-1.5.2, pluggy-0.6.0
rootdir: /home/a/Development/FogLAMP/tests/unit/python/foglamp, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 466 items                                                                                                                

common/test_audit_logger.py ..........                                                                                       [  2%]
common/test_configuration_manager.py ........................................................................                [ 17%]
common/test_jqfilter.py ....                                                                                                 [ 18%]
common/test_logger.py .....                                                                                                  [ 19%]
common/test_process.py ........                                                                                              [ 21%]
common/test_service_record.py .......                                                                                        [ 22%]
common/test_statistics.py ................                                                                                   [ 26%]
common/microservice_management_client/test_microservice_management_client.py .......................                         [ 31%]
common/storage_client/test_payload_builder.py ...................................................s...........                [ 44%]
common/storage_client/test_sc_exceptions.py ..........                                                                       [ 46%]
common/storage_client/test_storage_client.py ...............                                                                 [ 50%]
common/storage_client/test_utils.py ..................                                                                       [ 53%]
plugins/common/test_plugins_common_utils.py ....                                                                             [ 54%]
plugins/north/common/test_common.py .                                                                                        [ 54%]
plugins/south/test_http_south.py ...                                                                                         [ 55%]
services/common/test_avahi.py ......                                                                                         [ 56%]
services/common/test_services_common_utils.py ....                                                                           [ 57%]
services/common/microservice_management/test_instance.py ..........                                                          [ 59%]
services/core/test_connect.py ...                                                                                            [ 60%]
services/core/test_main.py .                                                                                                 [ 60%]
services/core/api/test_audit.py .................                                                                            [ 64%]
services/core/api/test_backup_restore.py ...................................                                                 [ 71%]
services/core/api/test_browser_assets.py ..........................................                                          [ 80%]
services/core/api/test_common_ping.py ...                                                                                    [ 81%]
services/core/api/test_statistics_api.py ........                                                                            [ 83%]
services/core/interest_registry/test_interest_registry.py ........                                                           [ 84%]
services/core/scheduler/test_scheduler_entities.py .........                                                                 [ 86%]
services/core/scheduler/test_scheduler_exceptions.py .....                                                                   [ 87%]
services/core/service_registry/test_exceptions.py .....                                                                      [ 89%]
services/core/service_registry/test_monitor.py ..                                                                            [ 89%]
services/core/service_registry/test_service_registry.py .........                                                            [ 91%]
services/south/test_services_south_main.py .                                                                                 [ 91%]
services/south/test_services_south_server.py ...............                                                                 [ 94%]
tasks/purge/test_purge.py ................                                                                                   [ 98%]
tasks/purge/test_purge_main.py .                                                                                             [ 98%]
tasks/statistics/test_statistics_history.py ......                                                                           [ 99%]
tasks/statistics/test_statistics_main.py .                                                                                   [100%]

============================================== 465 passed, 1 skipped in 36.55 seconds ==============================================

```