### PR TITLE
FOGL-1094: purge by size is now a not implemented feaure for Postgres

### DIFF
--- a/C/services/common/include/plugin_exception.h
+++ b/C/services/common/include/plugin_exception.h
@@ -1,0 +1,31 @@
+/*
+ * FogLAMP services common.
+ *
+ * Copyright (c) 2018 OSisoft, LLC
+ *
+ * Released under the Apache 2.0 Licence
+ *
+ * Author: Massimiliano Pinto
+ */
+
+/**
+ * Implementation of PluginNotImplementedException.
+ * This exception should be thrown when a feature is not implemented yet.
+ */
+class PluginNotImplementedException : public std::exception {
+public:
+	// Construct with a default error message:
+	PluginNotImplementedException(const char * error = "Functionality not implemented yet!")
+	{
+		errorMessage = error;
+	}
+
+	// Compatibility with std::exception.
+	const char * what() const noexcept
+	{
+		return errorMessage.c_str();
+	}
+
+private:
+        std::string errorMessage;
+};

--- a/C/services/storage/storage_api.cpp
+++ b/C/services/storage/storage_api.cpp
@@ -1,11 +1,11 @@
 /*
  * FogLAMP storage service.
  *
- * Copyright (c) 2017 OSisoft, LLC
+ * Copyright (c) 2017-2018 OSisoft, LLC
  *
  * Released under the Apache 2.0 Licence
  *
- * Author: Mark Riddoch
+ * Author: Mark Riddoch, Massimiliano Pinto
  */
 #include "client_http.hpp"
 #include "server_http.hpp"
@@ -13,6 +13,7 @@
 #include "storage_stats.h"
 #include "management_api.h"
 #include "logger.h"
+#include "plugin_exception.h"
 
 
 // Added for the default_resource example
@@ -635,8 +636,20 @@ string        flags;
 		}
 		string responsePayload = purged;
 		respond(response, responsePayload);
-	} catch (exception ex) {
+	}
+	/** Handle PluginNotImplementedException exception here */
+	catch (PluginNotImplementedException& ex) {
+		string payload = "{ \"error\" : \"";
+		payload += ex.what();
+		payload += "\" }";
+		/** Return HTTP code 400 with message from storage plugin */
+		respond(response, SimpleWeb::StatusCode::client_error_bad_request, payload);
+		return;
+	}
+	/** Handle general exception */
+	catch (exception ex) {
 		internalError(response, ex);
+		return;
 	}
 }
 


### PR DESCRIPTION
FOGL-1094: purge by size is now a not implemented feaure for Postgres
And exception is raised when purge by size is called for Postgres srorage plugin.

This has been added because the tablesize calculation is not updated after deleting records

`# curl` -v -X PUT "http://127.0.0.1:34653/storage/reading/purge?size=1&sent=0&flags=PURGE"


```
HTTP/1.1 400 Bad Request

{
  "error": "Purge by size is not supported by 'Postgres' storage engine."
}
```