### PR TITLE
FOGL-1132 GET end point added for cert store along with unit tests

### DIFF
--- a/python/foglamp/services/core/routes.py
+++ b/python/foglamp/services/core/routes.py
@@ -84,6 +84,7 @@ def setup(app):
     app.router.add_route('PUT', '/foglamp/update', update.update_package)
 
     # certs store
+    app.router.add_route('GET', '/foglamp/certificate', certificate_store.get_certs)
     app.router.add_route('POST', '/foglamp/certificate', certificate_store.upload)
     app.router.add_route('DELETE', '/foglamp/certificate/{name}', certificate_store.delete_certificate)
 

--- a/tests/unit/python/foglamp/services/core/api/test_certificate_store.py
+++ b/tests/unit/python/foglamp/services/core/api/test_certificate_store.py
@@ -40,8 +40,8 @@ class TestCertificateStore:
         return pathlib.Path(__file__).parent
 
     async def test_get_certs(self, client, certs_path):
-        actual_response = {"certificates": [{"key": "foglamp.key", "cert": "foglamp.cert"},
-                                            {"key": '', "cert": "server.cert"}]}
+        response_content = [{"cert": "foglamp.cert", "key": "foglamp.key"},
+                            {"cert": "server.cert", "key": ""}]
         with patch.object(certificate_store, '_get_certs_dir', return_value=certs_path / 'certs'):
             with patch('os.walk') as mockwalk:
                 mockwalk.return_value = [
@@ -49,8 +49,13 @@ class TestCertificateStore:
                 ]
                 resp = await client.get('/foglamp/certificate')
                 assert 200 == resp.status
-                result = await resp.text()
-                assert actual_response == json.loads(result)
+                res = await resp.text()
+                jdict = json.loads(res)
+                result = jdict["certificates"]
+                assert 2 == len(result)
+                assert response_content[0] in result
+                assert response_content[1] in result
+            mockwalk.assert_called_once_with(certs_path / 'certs')
 
     async def test_get_certs_if_dir_is_empty(self, client, certs_path):
         with patch.object(certificate_store, '_get_certs_dir', return_value=certs_path / 'certs'):
@@ -60,7 +65,9 @@ class TestCertificateStore:
                 assert 200 == resp.status
                 result = await resp.text()
                 json_response = json.loads(result)
+                assert 0 == len(json_response['certificates'])
                 assert {'certificates': []} == json_response
+            mockwalk.assert_called_once_with(certs_path / 'certs')
 
     async def test_get_certs_if_bad_extension(self, client, certs_path):
         with patch.object(certificate_store, '_get_certs_dir', return_value=certs_path / 'certs'):
@@ -70,7 +77,9 @@ class TestCertificateStore:
                 assert 200 == resp.status
                 result = await resp.text()
                 json_response = json.loads(result)
+                assert 0 == len(json_response['certificates'])
                 assert {'certificates': []} == json_response
+            mockwalk.assert_called_once_with(certs_path / 'certs')
 
     async def test_get_certs_if_pair_is_missing(self, client, certs_path):
         actual_response = {'certificates': [{'key': '', 'cert': 'server.cert'}]}
@@ -81,7 +90,9 @@ class TestCertificateStore:
                 assert 200 == resp.status
                 result = await resp.text()
                 json_response = json.loads(result)
+                assert 1 == len(json_response['certificates'])
                 assert actual_response == json_response
+            mockwalk.assert_called_once_with(certs_path / 'certs')
 
     async def test_upload(self, client, certs_path):
         files = {'key': open(str(certs_path / 'certs/foglamp.key'), 'rb'),


### PR DESCRIPTION
Fixed items:
- [x] GET end point to list certs
- [x] unit tests

**Coverage 99%**
```
102 statements   | 101 run | 1 missing | 0 excluded
```
**Total tests**
```
collected 623 items

== 618 passed, 5 skipped in 32.95 seconds ==
```

**Tests O/P**

```
collected 18 items                                                                                                                            

services/core/api/test_certificate_store.py::TestCertificateStore::test_get_certs[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_get_certs_if_dir_is_empty[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_get_certs_if_bad_extension[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_get_certs_if_pair_is_missing[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_upload[pyloop] PASSED
services/=======================================================core/api/test_certificate_store.py::TestCertificateStore::test_file_upload_with_overwrite[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_file_upload_with_different_names[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_bad_key_file_upload[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_bad_cert_file_upload[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_bad_extension_file_upload[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_bad_overwrite_file_upload[pyloop-blah] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_bad_overwrite_file_upload[pyloop-2] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_upload_with_existing_and_no_overwrite[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_exception[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_bad_delete_cert[pyloop--404-Not Found] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_bad_delete_cert[pyloop-blah-404-Certificate with name blah does not exist] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_bad_delete_cert_if_in_use[pyloop] PASSED
services/core/api/test_certificate_store.py::TestCertificateStore::test_delete_cert[pyloop] PASSED

----------- coverage: platform linux, python 3.5.2-final-0 -----------
Coverage HTML written to dir htmlcov


=== 18 passed in 1.23 seconds ====
```