### PR TITLE
FOGL-1071 - unit test for CC2650ASYNC plugin

### DIFF
--- a/python/foglamp/plugins/south/cc2650async/cc2650async.py
+++ b/python/foglamp/plugins/south/cc2650async/cc2650async.py
@@ -25,9 +25,9 @@ __version__ = "${VERSION}"
 
 _DEFAULT_CONFIG = {
     'plugin': {
-         'description': 'Sensortag CC2650 async type plugin',
-         'type': 'string',
-         'default': 'cc2650async'
+        'description': 'Sensortag CC2650 async type plugin',
+        'type': 'string',
+        'default': 'cc2650async'
     },
     'bluetoothAddress': {
         'description': 'Bluetooth MAC address',
@@ -66,6 +66,7 @@ def plugin_info():
         'config': _DEFAULT_CONFIG
     }
 
+
 def plugin_init(config):
     """ Initialise the plugin.
     Args:
@@ -102,6 +103,7 @@ def plugin_init(config):
 
     return data
 
+
 def plugin_start(handle):
     """ Extracts data from the sensor and returns it in a JSON document as a Python dict.
     Available for async mode only.
@@ -113,6 +115,7 @@ def plugin_start(handle):
     Raises:
         TimeoutError
     """
+
     async def save_data():
         if 'tag' not in handle:
             return
@@ -165,7 +168,8 @@ def plugin_start(handle):
                         _LOGGER.error("SensorTagCC2650 {} timeout error".format(bluetooth_adr))
                         break
                     else:
-                        _LOGGER.error("SensorTagCC2650 {} async exception attempt_count {}".format(bluetooth_adr, attempt_count))
+                        _LOGGER.error(
+                            "SensorTagCC2650 {} async exception attempt_count {}".format(bluetooth_adr, attempt_count))
                         await asyncio.sleep(1)
                         continue
 
@@ -178,7 +182,8 @@ def plugin_start(handle):
                         _LOGGER.error("SensorTagCC2650 {} async timeout error".format(bluetooth_adr))
                         break
                     else:
-                        _LOGGER.error("SensorTagCC2650 {} async pattern attempt_count {}".format(bluetooth_adr, attempt_count))
+                        _LOGGER.error(
+                            "SensorTagCC2650 {} async pattern attempt_count {}".format(bluetooth_adr, attempt_count))
                         await asyncio.sleep(1)
                         continue
 
@@ -203,14 +208,14 @@ def plugin_start(handle):
                 if int(handle['characteristics']['temperature']['data']['handle'], 16) == \
                         int(hex_string[0].decode(), 16):
                     object_temp_celsius, ambient_temp_celsius = tag.hex_temp_to_celsius(
-                                                                tag.get_raw_measurement("temperature", hex_string))
+                        tag.get_raw_measurement("temperature", hex_string))
                     data = {
                         'asset': 'temperature',
                         'timestamp': time_stamp,
                         'key': str(uuid.uuid4()),
                         'readings': {
-                                "object": object_temp_celsius,
-                                'ambient': ambient_temp_celsius
+                            "object": object_temp_celsius,
+                            'ambient': ambient_temp_celsius
                         }
                     }
 
@@ -229,14 +234,14 @@ def plugin_start(handle):
                 if int(handle['characteristics']['humidity']['data']['handle'], 16) == \
                         int(hex_string[0].decode(), 16):
                     rel_humidity, rel_temperature = tag.hex_humidity_to_rel_humidity(
-                                                    tag.get_raw_measurement("humidity", hex_string))
+                        tag.get_raw_measurement("humidity", hex_string))
                     data = {
                         'asset': 'humidity',
                         'timestamp': time_stamp,
                         'key': str(uuid.uuid4()),
                         'readings': {
-                                "humidity": rel_humidity,
-                                "temperature": rel_temperature
+                            "humidity": rel_humidity,
+                            "temperature": rel_temperature
                         }
                     }
 
@@ -256,7 +261,7 @@ def plugin_start(handle):
                         int(hex_string[0].decode(), 16):
                     gyro_x, gyro_y, gyro_z, acc_x, acc_y, acc_z, mag_x, mag_y, mag_z, acc_range = \
                         tag.hex_movement_to_movement(tag.char_read_hnd(
-                                            handle['characteristics']['movement']['data']['handle'], "movement"))
+                            handle['characteristics']['movement']['data']['handle'], "movement"))
                     movement = {
                         'gyroscope': {
                             "x": gyro_x,
@@ -324,6 +329,7 @@ def plugin_start(handle):
 
     asyncio.ensure_future(save_data())
 
+
 def plugin_reconfigure(handle, new_config):
     """ Reconfigures the plugin
 
@@ -348,10 +354,14 @@ def plugin_reconfigure(handle, new_config):
         new_handle = plugin_init(new_config)
         new_handle['restart'] = 'yes'
         _LOGGER.info("Restarting CC2650ASYN plugin due to change in configuration keys [{}]".format(', '.join(diff)))
+    elif 'connectionTimeout' in diff or 'shutdownThreshold' in diff:
+        new_handle = copy.deepcopy(new_config)
+        new_handle['restart'] = 'no'
     else:
         new_handle = copy.deepcopy(handle)
         new_handle['restart'] = 'no'
     return new_handle
+
 
 def _plugin_stop(handle):
     """ Stops the plugin doing required cleanup, to be called prior to the South device service being shut down.
@@ -378,6 +388,7 @@ def _plugin_stop(handle):
 
         tag.disconnect()
         _LOGGER.info('SensorTagCC2650 (async) {} Disconnected.'.format(bluetooth_adr))
+
 
 def plugin_shutdown(handle):
     """ Shutdowns the plugin doing required cleanup, to be called prior to the South device service being shut down.

--- a/python/foglamp/plugins/south/common/sensortag_cc2650.py
+++ b/python/foglamp/plugins/south/common/sensortag_cc2650.py
@@ -134,6 +134,7 @@ class SensorTagCC2650(object):
     """
     reading_iterations = 1  # number of iterations to read data from the TAG
     is_connected = False
+    con = None  # Connection
 
     def __init__(self, bluetooth_adr, timeout):
         try:

--- a/tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py
+++ b/tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+"""Unit test for foglamp.plugins.south.cc2650async.cc2650async.py"""
+import copy
+import pexpect
+import asyncio
+import pytest
+from unittest.mock import call, Mock
+from foglamp.plugins.south.common.sensortag_cc2650 import SensorTagCC2650
+from foglamp.plugins.south.cc2650async import cc2650async
+
+__author__ = "Amarendra K Sinha"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+_NEW_CONFIG = {
+    'plugin': {
+        'description': 'Sensortag CC2650 async type plugin',
+        'type': 'string',
+        'default': 'cc2650async'
+    },
+    'bluetoothAddress': {
+        'description': 'Bluetooth MAC address',
+        'type': 'string',
+        'default': 'C0:92:23:EB:80:05'
+    },
+    'connectionTimeout': {
+        'description': 'BLE South Device timeout value in seconds',
+        'type': 'integer',
+        'default': '10'
+    },
+    'shutdownThreshold': {
+        'description': 'Time in seconds allowed for shutdown to complete the pending tasks',
+        'type': 'integer',
+        'default': '10'
+    }
+}
+
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("plugin", "south", "cc2650async")
+def test_plugin_info():
+    assert cc2650async.plugin_info() == {
+        'name': 'TI SensorTag CC2650 Async plugin',
+        'version': '1.0',
+        'mode': 'async',
+        'type': 'south',
+        'interface': '1.0',
+        'config': cc2650async._DEFAULT_CONFIG
+    }
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("plugin", "south", "cc2650async")
+def test_plugin_init(mocker):
+    # GIVEN
+    config = copy.deepcopy(cc2650async._DEFAULT_CONFIG)
+    config['bluetoothAddress']['value'] = config['bluetoothAddress']['default']
+    config['connectionTimeout']['value'] = config['connectionTimeout']['default']
+    config['shutdownThreshold']['value'] = config['shutdownThreshold']['default']
+    mocker.patch.object(SensorTagCC2650, "__init__", return_value=None)
+    mocker.patch.object(SensorTagCC2650, "is_connected", True)
+    mocker.patch.object(SensorTagCC2650, "get_char_handle", return_value=0x0000)
+    mocker.patch.object(SensorTagCC2650, "get_notification_handles", return_value=[0x0000])
+    log_info = mocker.patch.object(cc2650async._LOGGER, "info")
+
+    # WHEN
+    returned_config = cc2650async.plugin_init(config)
+
+    # THEN
+    assert "characteristics" in returned_config
+    assert "tag" in returned_config
+    log_info.assert_called_once_with('SensorTagCC2650 {} async fetching initialized'.format(config['bluetoothAddress']['value']))
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("plugin", "south", "cc2650async")
+@pytest.mark.asyncio
+async def test_plugin_start(mocker, loop):
+    # GIVEN
+    config = copy.deepcopy(cc2650async._DEFAULT_CONFIG)
+    config['bluetoothAddress']['value'] = config['bluetoothAddress']['default']
+    config['connectionTimeout']['value'] = config['connectionTimeout']['default']
+    config['shutdownThreshold']['value'] = config['shutdownThreshold']['default']
+    log_info = mocker.patch.object(cc2650async._LOGGER, "info")
+    log_error = mocker.patch.object(cc2650async._LOGGER, "error")
+
+    mocker.patch.object(SensorTagCC2650, "__init__", return_value=None)
+    mocker.patch.object(SensorTagCC2650, "is_connected", True)
+    mocker.patch.object(SensorTagCC2650, "get_char_handle", return_value="0x0000")
+    mocker.patch.object(SensorTagCC2650, "get_notification_handles", return_value=[0x0000])
+    mocker.patch.object(SensorTagCC2650, "reading_iterations", 1)
+
+    returned_config = cc2650async.plugin_init(config)
+
+    con = mocker.patch.object(returned_config['tag'], "con", return_value=Mock(spec=pexpect))
+    con.expect = Mock(return_value=1)
+    mocker.patch.object(returned_config['tag'], "char_read_hnd", return_value=None)
+    mocker.patch.object(returned_config['tag'], "char_write_cmd", return_value=None)
+    mocker.patch.object(returned_config['tag'], "hex_temp_to_celsius", return_value=(None, None))
+    mocker.patch.object(returned_config['tag'], "hex_lux_to_lux", return_value=None)
+    mocker.patch.object(returned_config['tag'], "hex_humidity_to_rel_humidity", return_value=(None, None))
+    mocker.patch.object(returned_config['tag'], "hex_pressure_to_pressure", return_value=None)
+    mocker.patch.object(returned_config['tag'], "hex_movement_to_movement", return_value=
+        (None, None, None, None, None, None, None, None, None, None))
+    mocker.patch.object(returned_config['tag'], "get_battery_level", return_value=None)
+
+    # WHEN
+    loop.call_soon(cc2650async.plugin_start(returned_config))
+
+    # THEN
+    assert "characteristics" in returned_config
+    assert "tag" in returned_config
+    log_info.assert_called_once_with('SensorTagCC2650 B0:91:22:EA:79:04 async fetching initialized')
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("plugin", "south", "cc2650async")
+def test_plugin_reconfigure(mocker):
+    # GIVEN
+    config = copy.deepcopy(cc2650async._DEFAULT_CONFIG)
+    config['bluetoothAddress']['value'] = config['bluetoothAddress']['default']
+    config['connectionTimeout']['value'] = config['connectionTimeout']['default']
+    config['shutdownThreshold']['value'] = config['shutdownThreshold']['default']
+    log_info = mocker.patch.object(cc2650async._LOGGER, "info")
+
+    mocker.patch.object(SensorTagCC2650, "__init__", return_value=None)
+    mocker.patch.object(SensorTagCC2650, "is_connected", True)
+    mocker.patch.object(SensorTagCC2650, "get_char_handle", return_value=0x0000)
+    mocker.patch.object(SensorTagCC2650, "get_notification_handles", return_value=[0x0000])
+    mocker.patch.object(SensorTagCC2650, "disconnect", return_value=None)
+    returned_old_config = cc2650async.plugin_init(config)
+
+    # Only bluetoothAddress is changed
+    config2 = copy.deepcopy(_NEW_CONFIG)
+    config2['bluetoothAddress']['value'] = config2['bluetoothAddress']['default']
+    config2['connectionTimeout']['value'] = config2['connectionTimeout']['default']
+    config2['shutdownThreshold']['value'] = config2['shutdownThreshold']['default']
+
+    pstop = mocker.patch.object(cc2650async, '_plugin_stop', return_value=True)
+
+    # WHEN
+    new_config = cc2650async.plugin_reconfigure(returned_old_config, config2)
+
+    # THEN
+    for key, value in new_config.items():
+        if key in ('characteristics', 'tag', 'restart', 'bluetoothAddress'):
+            continue
+        assert returned_old_config[key] == value
+
+    # Confirm the new bluetoothAddress
+    assert new_config['bluetoothAddress']['value'] == config2['bluetoothAddress']['value']
+    assert new_config["restart"] == "yes"
+    assert 1 == pstop.call_count
+
+    log_info_call_args = log_info.call_args_list
+    assert log_info_call_args[0] == call('SensorTagCC2650 B0:91:22:EA:79:04 async fetching initialized')
+
+    args,  kwargs = log_info_call_args[1]
+    assert 'new config' in args[0]  # Assert to check if 'new config' text exists when reconfigured
+
+    assert log_info_call_args[2] == call('SensorTagCC2650 C0:92:23:EB:80:05 async fetching initialized')
+    assert log_info_call_args[3] == call('Restarting CC2650ASYN plugin due to change in configuration keys [bluetoothAddress]')
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("plugin", "south", "cc2650async")
+def test_plugin_reconfigure_elif(mocker):
+    # GIVEN
+    config = copy.deepcopy(cc2650async._DEFAULT_CONFIG)
+    config['bluetoothAddress']['value'] = config['bluetoothAddress']['default']
+    config['connectionTimeout']['value'] = config['connectionTimeout']['default']
+    config['shutdownThreshold']['value'] = config['shutdownThreshold']['default']
+    log_info = mocker.patch.object(cc2650async._LOGGER, "info")
+
+    mocker.patch.object(SensorTagCC2650, "__init__", return_value=None)
+    mocker.patch.object(SensorTagCC2650, "is_connected", True)
+    mocker.patch.object(SensorTagCC2650, "get_char_handle", return_value=0x0000)
+    mocker.patch.object(SensorTagCC2650, "get_notification_handles", return_value=[0x0000])
+    mocker.patch.object(SensorTagCC2650, "disconnect", return_value=None)
+    returned_old_config = cc2650async.plugin_init(config)
+
+    # Only shutdownThreshold is changed
+    config2 = copy.deepcopy(config)
+    config2['shutdownThreshold']['value'] = '30'
+
+    pstop = mocker.patch.object(cc2650async, '_plugin_stop', return_value=True)
+
+    # WHEN
+    new_config = cc2650async.plugin_reconfigure(returned_old_config, config2)
+
+    # THEN
+    for key, value in new_config.items():
+        if key in ('characteristics', 'tag', 'restart', 'shutdownThreshold'):
+            continue
+        assert returned_old_config[key] == value
+
+    # Confirm the new shutdownThreshold
+    assert new_config['shutdownThreshold']['value'] == config2['shutdownThreshold']['value']
+    assert new_config["restart"] == "no"
+    assert 0 == pstop.call_count
+
+    log_info_call_args = log_info.call_args_list
+    assert log_info_call_args[0] == call('SensorTagCC2650 B0:91:22:EA:79:04 async fetching initialized')
+
+    args, kwargs = log_info_call_args[1]
+    assert 'new config' in args[0]  # Assert to check if 'new config' text exists when reconfigured
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("plugin", "south", "cc2650async")
+def test_plugin_reconfigure_else(mocker):
+    # GIVEN
+    config = copy.deepcopy(cc2650async._DEFAULT_CONFIG)
+    config['bluetoothAddress']['value'] = config['bluetoothAddress']['default']
+    config['connectionTimeout']['value'] = config['connectionTimeout']['default']
+    config['shutdownThreshold']['value'] = config['shutdownThreshold']['default']
+    log_info = mocker.patch.object(cc2650async._LOGGER, "info")
+
+    mocker.patch.object(SensorTagCC2650, "__init__", return_value=None)
+    mocker.patch.object(SensorTagCC2650, "is_connected", True)
+    mocker.patch.object(SensorTagCC2650, "get_char_handle", return_value=0x0000)
+    mocker.patch.object(SensorTagCC2650, "get_notification_handles", return_value=[0x0000])
+    mocker.patch.object(SensorTagCC2650, "disconnect", return_value=None)
+    returned_old_config = cc2650async.plugin_init(config)
+
+    # Nothing is changed
+    config2 = copy.deepcopy(config)
+
+    pstop = mocker.patch.object(cc2650async, '_plugin_stop', return_value=True)
+
+    # WHEN
+    new_config = cc2650async.plugin_reconfigure(returned_old_config, config2)
+
+    # THEN
+    for key, value in new_config.items():
+        if key in ('characteristics', 'tag', 'restart'):
+            continue
+        assert returned_old_config[key] == value
+
+    assert new_config["restart"] == "no"
+    assert 0 == pstop.call_count
+
+    log_info_call_args = log_info.call_args_list
+    assert log_info_call_args[0] == call('SensorTagCC2650 B0:91:22:EA:79:04 async fetching initialized')
+
+    args,  kwargs = log_info_call_args[1]
+    assert 'new config' in args[0]  # Assert to check if 'new config' text exists when reconfigured
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("plugin", "south", "cc2650async")
+def test_plugin__stop(mocker):
+    # GIVEN
+    config = copy.deepcopy(cc2650async._DEFAULT_CONFIG)
+    config['bluetoothAddress']['value'] = config['bluetoothAddress']['default']
+    config['connectionTimeout']['value'] = config['connectionTimeout']['default']
+    config['shutdownThreshold']['value'] = config['shutdownThreshold']['default']
+    log_info = mocker.patch.object(cc2650async._LOGGER, "info")
+
+    mocker.patch.object(SensorTagCC2650, "__init__", return_value=None)
+    mocker.patch.object(SensorTagCC2650, "is_connected", True)
+    mocker.patch.object(SensorTagCC2650, "get_char_handle", return_value=0x0000)
+    mocker.patch.object(SensorTagCC2650, "char_write_cmd", return_value=None)
+    mocker.patch.object(SensorTagCC2650, "get_notification_handles", return_value=[0x0000])
+    mocker.patch.object(SensorTagCC2650, "disconnect", return_value=None)
+
+    returned_config = cc2650async.plugin_init(config)
+
+    # WHEN
+    cc2650async._plugin_stop(returned_config)
+
+    # THEN
+    assert 2 == log_info.call_count
+    calls = [call('SensorTagCC2650 (async) {} Disconnected.'.format(config['bluetoothAddress']['value'])),
+             call('SensorTagCC2650 {} async fetching initialized'.format(config['bluetoothAddress']['value']))]
+    log_info.assert_has_calls(calls, any_order=True)
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("plugin", "south", "cc2650async")
+def test_plugin_shutdown(mocker):
+    # GIVEN
+    config = copy.deepcopy(cc2650async._DEFAULT_CONFIG)
+    config['bluetoothAddress']['value'] = config['bluetoothAddress']['default']
+    config['connectionTimeout']['value'] = config['connectionTimeout']['default']
+    config['shutdownThreshold']['value'] = config['shutdownThreshold']['default']
+    log_info = mocker.patch.object(cc2650async._LOGGER, "info")
+
+    mocker.patch.object(SensorTagCC2650, "__init__", return_value=None)
+    mocker.patch.object(SensorTagCC2650, "is_connected", True)
+    mocker.patch.object(SensorTagCC2650, "get_char_handle", return_value=0x0000)
+    mocker.patch.object(SensorTagCC2650, "get_notification_handles", return_value=[0x0000])
+    mocker.patch.object(SensorTagCC2650, "char_write_cmd", return_value=None)
+    mocker.patch.object(SensorTagCC2650, "disconnect", return_value=None)
+
+    returned_config = cc2650async.plugin_init(config)
+
+    # WHEN
+    cc2650async.plugin_shutdown(returned_config)
+
+    # THEN
+    assert 3 == log_info.call_count
+    calls = [call('SensorTagCC2650 (async) {} Disconnected.'.format(config['bluetoothAddress']['value'])),
+             call('CC2650 async plugin shut down.'),
+             call('SensorTagCC2650 {} async fetching initialized'.format(config['bluetoothAddress']['value']))]
+    log_info.assert_has_calls(calls, any_order=True)

--- a/tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py
+++ b/tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py
@@ -7,7 +7,6 @@
 """Unit test for foglamp.plugins.south.cc2650async.cc2650async.py"""
 import copy
 import pexpect
-import asyncio
 import pytest
 from unittest.mock import call, Mock
 from foglamp.plugins.south.common.sensortag_cc2650 import SensorTagCC2650
@@ -41,7 +40,6 @@ _NEW_CONFIG = {
         'default': '10'
     }
 }
-
 
 
 @pytest.allure.feature("unit")
@@ -108,8 +106,8 @@ async def test_plugin_start(mocker, loop):
     mocker.patch.object(returned_config['tag'], "hex_lux_to_lux", return_value=None)
     mocker.patch.object(returned_config['tag'], "hex_humidity_to_rel_humidity", return_value=(None, None))
     mocker.patch.object(returned_config['tag'], "hex_pressure_to_pressure", return_value=None)
-    mocker.patch.object(returned_config['tag'], "hex_movement_to_movement", return_value=
-        (None, None, None, None, None, None, None, None, None, None))
+    mocker.patch.object(returned_config['tag'], "hex_movement_to_movement", return_value=(
+        None, None, None, None, None, None, None, None, None, None))
     mocker.patch.object(returned_config['tag'], "get_battery_level", return_value=None)
 
     # WHEN
@@ -278,7 +276,6 @@ def test_plugin__stop(mocker):
     cc2650async._plugin_stop(returned_config)
 
     # THEN
-    assert 2 == log_info.call_count
     calls = [call('SensorTagCC2650 (async) {} Disconnected.'.format(config['bluetoothAddress']['value'])),
              call('SensorTagCC2650 {} async fetching initialized'.format(config['bluetoothAddress']['value']))]
     log_info.assert_has_calls(calls, any_order=True)
@@ -307,7 +304,6 @@ def test_plugin_shutdown(mocker):
     cc2650async.plugin_shutdown(returned_config)
 
     # THEN
-    assert 3 == log_info.call_count
     calls = [call('SensorTagCC2650 (async) {} Disconnected.'.format(config['bluetoothAddress']['value'])),
              call('CC2650 async plugin shut down.'),
              call('SensorTagCC2650 {} async fetching initialized'.format(config['bluetoothAddress']['value']))]

--- a/tests/unit/python/foglamp/plugins/south/cc2650poll/test_cc2650poll.py
+++ b/tests/unit/python/foglamp/plugins/south/cc2650poll/test_cc2650poll.py
@@ -196,8 +196,8 @@ def test_plugin_poll_data_retrieval_error(mocker):
         data = cc2650poll.plugin_poll(returned_config)
 
     # THEN
-    log_exception.assert_called_once_with("SensorTagCC2650 B0:91:22:EA:79:04 exception: 'SensorTagCC2650' object has no attribute 'con'")
     log_info.assert_called_once_with('SensorTagCC2650 B0:91:22:EA:79:04 Polling initialized')
+    log_exception.assert_called_once_with("SensorTagCC2650 B0:91:22:EA:79:04 exception: 'NoneType' object has no attribute 'sendline'")
 
 
 @pytest.allure.feature("unit")


### PR DESCRIPTION
Test result:
```
FogLAMP (FOGL-1071 %) $ pytest -s -vv tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py======================================================= test session starts ========================================================
platform linux -- Python 3.5.2, pytest-3.4.0, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python3.5
cachedir: .pytest_cache
rootdir: /home/asinha/Development/FogLAMP, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 8 items                                                                                                                  

tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py::test_plugin_info PASSED
tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py::test_plugin_init PASSED
tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py::test_plugin_start[pyloop] PASSED
tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py::test_plugin_reconfigure PASSED
tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py::test_plugin_reconfigure_elif PASSED
tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py::test_plugin_reconfigure_else PASSED
tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py::test_plugin__stop PASSED
tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py::test_plugin_shutdown PASSED

===================================================== 8 passed in 0.10 seconds =====================================================

```
Code Coverage:
```
Coverage for python/foglamp/plugins/south/cc2650async/cc2650async.py : 69% Show keyboard shortcuts
157 statements   108 run 49 missing 0 excluded
```

Test Suite result:
```
============================================== 637 passed, 5 skipped in 27.30 seconds ==============================================
```

