### PR TITLE
FOGL-1127 - Fetch support bundle functionality along with unit tests

### DIFF
--- a/python/foglamp/services/core/api/support.py
+++ b/python/foglamp/services/core/api/support.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+import os
+from aiohttp import web
+from foglamp.common import logger
+
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+_FOGLAMP_DATA = os.getenv("FOGLAMP_DATA", default=None)
+_FOGLAMP_ROOT = os.getenv("FOGLAMP_ROOT", default='/usr/local/foglamp')
+
+
+_logger = logger.setup(__name__, level=20)
+
+_help = """
+    -------------------------------------------------------------------------------
+    | GET POST        | /foglamp/support                                          |
+    | GET             | /foglamp/support/{bundle}                                 |
+    -------------------------------------------------------------------------------
+"""
+
+
+async def fetch_support_bundle(request):
+    """ get list of available support bundles
+
+    :Example:
+        curl -X GET http://localhost:8081/foglamp/support
+    """
+    # Get support directory path
+    support_dir = _get_support_dir()
+    valid_extension = '.tar.gz'
+    found_files = []
+    for root, dirs, files in os.walk(support_dir):
+        found_files = [f for f in files if f.endswith(valid_extension)]
+
+    return web.json_response({"bundles": found_files})
+
+
+async def fetch_support_bundle_item(request):
+    """
+    :Example:
+        curl -X GET http://localhost:8081/foglamp/support/support-180301-13%3A35%3A23.tar.gz
+    """
+    bundle_name = request.match_info.get('bundle', None)
+
+    if not str(bundle_name).endswith('.tar.gz'):
+        return web.HTTPBadRequest(reason="Bundle file extension is invalid")
+
+    if not os.path.isdir(_get_support_dir()):
+        raise web.HTTPNotFound(reason="Support bundle directory does not exist")
+
+    for root, dirs, files in os.walk(_get_support_dir()):
+        if str(bundle_name) not in files:
+            raise web.HTTPNotFound(reason='{} not found'.format(bundle_name))
+
+    return web.json_response()
+
+
+async def create_support_bundle(request):
+    # TODO: FOGL-1126
+    raise web.HTTPNotImplemented(reason='Create support bundle method is not implemented yet')
+
+
+def _get_support_dir():
+    if _FOGLAMP_DATA:
+        support_dir = os.path.expanduser(_FOGLAMP_DATA + '/tmp/support')
+    else:
+        support_dir = os.path.expanduser(_FOGLAMP_ROOT + '/data/tmp/support')
+
+    return support_dir

--- a/python/foglamp/services/core/api/support.py
+++ b/python/foglamp/services/core/api/support.py
@@ -46,9 +46,10 @@ async def fetch_support_bundle(request):
 
 
 async def fetch_support_bundle_item(request):
-    """
+    """ check existence of a bundle support by name
+
     :Example:
-        curl -X GET http://localhost:8081/foglamp/support/support-180301-13%3A35%3A23.tar.gz
+        curl -X GET http://localhost:8081/foglamp/support/support-180301-13-35-23.tar.gz
     """
     bundle_name = request.match_info.get('bundle', None)
 

--- a/python/foglamp/services/core/routes.py
+++ b/python/foglamp/services/core/routes.py
@@ -14,6 +14,7 @@ from foglamp.services.core.api import backup_restore
 from foglamp.services.core.api import update
 from foglamp.services.core.api import service
 from foglamp.services.core.api import certificate_store
+from foglamp.services.core.api import support
 
 __author__ = "Ashish Jabble, Praveen Garg, Massimiliano Pinto"
 __copyright__ = "Copyright (c) 2017-2018 OSIsoft, LLC"
@@ -87,6 +88,11 @@ def setup(app):
     app.router.add_route('GET', '/foglamp/certificate', certificate_store.get_certs)
     app.router.add_route('POST', '/foglamp/certificate', certificate_store.upload)
     app.router.add_route('DELETE', '/foglamp/certificate/{name}', certificate_store.delete_certificate)
+
+    # Support bundle
+    app.router.add_route('GET', '/foglamp/support', support.fetch_support_bundle)
+    app.router.add_route('GET', '/foglamp/support/{bundle}', support.fetch_support_bundle_item)
+    app.router.add_route('POST', '/foglamp/support', support.create_support_bundle)
 
     # enable cors support
     enable_cors(app)

--- a/tests/unit/python/foglamp/services/core/api/test_support.py
+++ b/tests/unit/python/foglamp/services/core/api/test_support.py
@@ -38,8 +38,8 @@ class TestBundleSupport:
         return pathlib.Path(__file__).parent
 
     @pytest.mark.parametrize("data, expected_content, expected_count", [
-        (['support-180301-13:35:23.tar.gz', 'support-180301-13:25:23.tar.gz'], {'bundles': ['support-180301-13:35:23.tar.gz', 'support-180301-13:25:23.tar.gz']}, 2),
-        (['support-180301-13:35:23.tar.gz', 'foglamp.txt'], {'bundles': ['support-180301-13:35:23.tar.gz']}, 1),
+        (['support-180301-13-35-23.tar.gz', 'support-180301-13-13-13.tar.gz'], {'bundles': ['support-180301-13-35-23.tar.gz', 'support-180301-13-13-13.tar.gz']}, 2),
+        (['support-180301-15-25-02.tar.gz', 'foglamp.txt'], {'bundles': ['support-180301-15-25-02.tar.gz']}, 1),
         (['foglamp.txt'], {'bundles': []}, 0),
         ([], {'bundles': []}, 0)
     ])
@@ -56,10 +56,9 @@ class TestBundleSupport:
                 assert expected_content == jdict
             mockwalk.assert_called_once_with(path)
 
-    # FIXME: issue with URL having colon in it even after encoded with %3A manually or urllib parser
     async def test_get_support_bundle_by_name(self, client, support_bundles_dir_path):
         path = support_bundles_dir_path / 'support'
-        bundle_name = 'support-180301-133523.tar.gz'
+        bundle_name = 'support-180301-13-35-23.tar.gz'
         with patch.object(support, '_get_support_dir', return_value=path):
             with patch('os.path.isdir', return_value=True):
                 with patch('os.walk') as mockwalk:
@@ -70,8 +69,8 @@ class TestBundleSupport:
             mockwalk.assert_called_once_with(path)
 
     @pytest.mark.parametrize("data, request_bundle_name", [
-        (['support-180301-133523.tar.gz'], 'xsupport-180301-133523.tar.gz'),
-        ([], 'support-180301-133523.tar.gz')
+        (['support-180301-13-35-23.tar.gz'], 'xsupport-180301-01-15-13.tar.gz'),
+        ([], 'support-180301-13-13-13.tar.gz')
     ])
     async def test_get_support_bundle_by_name_not_found(self, client, support_bundles_dir_path, data, request_bundle_name):
         path = support_bundles_dir_path / 'support'
@@ -85,7 +84,7 @@ class TestBundleSupport:
             mockwalk.assert_called_once_with(path)
 
     async def test_get_support_bundle_by_name_bad_request(self, client):
-        resp = await client.get('/foglamp/support/support-180301-133523.tar')
+        resp = await client.get('/foglamp/support/support-180301-13-35-23.tar')
         assert 400 == resp.status
         assert 'Bundle file extension is invalid' == resp.reason
 

--- a/tests/unit/python/foglamp/services/core/api/test_support.py
+++ b/tests/unit/python/foglamp/services/core/api/test_support.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+
+import json
+import pathlib
+
+from unittest.mock import patch
+
+from aiohttp import web
+import pytest
+
+from foglamp.services.core import routes
+from foglamp.services.core.api import support
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2018 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("api", "bundle-support")
+class TestBundleSupport:
+
+    @pytest.fixture
+    def client(self, loop, test_client):
+        app = web.Application(loop=loop)
+        # fill the routes table
+        routes.setup(app)
+        return loop.run_until_complete(test_client(app))
+
+    @pytest.fixture
+    def support_bundles_dir_path(self):
+        return pathlib.Path(__file__).parent
+
+    @pytest.mark.parametrize("data, expected_content, expected_count", [
+        (['support-180301-13:35:23.tar.gz', 'support-180301-13:25:23.tar.gz'], {'bundles': ['support-180301-13:35:23.tar.gz', 'support-180301-13:25:23.tar.gz']}, 2),
+        (['support-180301-13:35:23.tar.gz', 'foglamp.txt'], {'bundles': ['support-180301-13:35:23.tar.gz']}, 1),
+        (['foglamp.txt'], {'bundles': []}, 0),
+        ([], {'bundles': []}, 0)
+    ])
+    async def test_get_support_bundle(self, client, support_bundles_dir_path, data, expected_content, expected_count):
+        path = support_bundles_dir_path / 'support'
+        with patch.object(support, '_get_support_dir', return_value=path):
+            with patch('os.walk') as mockwalk:
+                mockwalk.return_value = [(path, [], data)]
+                resp = await client.get('/foglamp/support')
+                assert 200 == resp.status
+                res = await resp.text()
+                jdict = json.loads(res)
+                assert expected_count == len(jdict['bundles'])
+                assert expected_content == jdict
+            mockwalk.assert_called_once_with(path)
+
+    # FIXME: issue with URL having colon in it even after encoded with %3A manually or urllib parser
+    async def test_get_support_bundle_by_name(self, client, support_bundles_dir_path):
+        path = support_bundles_dir_path / 'support'
+        bundle_name = 'support-180301-133523.tar.gz'
+        with patch.object(support, '_get_support_dir', return_value=path):
+            with patch('os.path.isdir', return_value=True):
+                with patch('os.walk') as mockwalk:
+                    mockwalk.return_value = [(path, [], [bundle_name])]
+                    resp = await client.get('/foglamp/support/{}'.format(bundle_name))
+                    assert 200 == resp.status
+                    assert 'OK' == resp.reason
+            mockwalk.assert_called_once_with(path)
+
+    @pytest.mark.parametrize("data, request_bundle_name", [
+        (['support-180301-133523.tar.gz'], 'xsupport-180301-133523.tar.gz'),
+        ([], 'support-180301-133523.tar.gz')
+    ])
+    async def test_get_support_bundle_by_name_not_found(self, client, support_bundles_dir_path, data, request_bundle_name):
+        path = support_bundles_dir_path / 'support'
+        with patch.object(support, '_get_support_dir', return_value=path):
+            with patch('os.path.isdir', return_value=True):
+                with patch('os.walk') as mockwalk:
+                    mockwalk.return_value = [(path, [], data)]
+                    resp = await client.get('/foglamp/support/{}'.format(request_bundle_name))
+                    assert 404 == resp.status
+                    assert '{} not found'.format(request_bundle_name) == resp.reason
+            mockwalk.assert_called_once_with(path)
+
+    async def test_get_support_bundle_by_name_bad_request(self, client):
+        resp = await client.get('/foglamp/support/support-180301-133523.tar')
+        assert 400 == resp.status
+        assert 'Bundle file extension is invalid' == resp.reason
+
+    async def test_get_support_bundle_by_name_no_dir(self, client, support_bundles_dir_path):
+        path = support_bundles_dir_path / 'invalid'
+        with patch.object(support, '_get_support_dir', return_value=path):
+            with patch('os.path.isdir', return_value=False) as mockisdir:
+                resp = await client.get('/foglamp/support/bla.tar.gz')
+                assert 404 == resp.status
+                assert 'Support bundle directory does not exist' == resp.reason
+            mockisdir.assert_called_once_with(path)
+
+    async def test_create_support_bundle(self, client):
+        resp = await client.post('/foglamp/support')
+        assert 501 == resp.status
+        assert 'Create support bundle method is not implemented yet' == resp.reason


### PR DESCRIPTION
**Coverage 89%**

```
35 statements   31 run || 4 missing || 0 excluded
```

**Tests O/P**
```
collected 10 items                                                                                                                            

services/core/api/test_support.py::TestBundleSupport::test_get_support_bundle[pyloop-data0-expected_content0-2] PASSED
services/core/api/test_support.py::TestBundleSupport::test_get_support_bundle[pyloop-data1-expected_content1-1] PASSED
services/core/api/test_support.py::TestBundleSupport::test_get_support_bundle[pyloop-data2-expected_content2-0] PASSED
services/core/api/test_support.py::TestBundleSupport::test_get_support_bundle[pyloop-data3-expected_content3-0] PASSED
services/core/api/test_support.py::TestBundleSupport::test_get_support_bundle_by_name[pyloop] PASSED
services/core/api/test_support.py::TestBundleSupport::test_get_support_bundle_by_name_not_found[pyloop-data0-xsupport-180301-133523.tar.gz] PASSED
services/core/api/test_support.py::TestBundleSupport::test_get_support_bundle_by_name_not_found[pyloop-data1-support-180301-133523.tar.gz] PASSED
services/core/api/test_support.py::TestBundleSupport::test_get_support_bundle_by_name_bad_request[pyloop] PASSED
services/core/api/test_support.py::TestBundleSupport::test_get_support_bundle_by_name_no_dir[pyloop] PASSED
services/core/api/test_support.py::TestBundleSupport::test_create_support_bundle[pyloop] PASSED

=== 10 passed in 0.73 seconds ==
```

**Suite**
```
collected 644 items

=== 639 passed, 5 skipped in 31.75 seconds ====
```