### PR TITLE
FOGL-1106 storage client raise exception on error 

### DIFF
--- a/python/foglamp/common/audit_logger.py
+++ b/python/foglamp/common/audit_logger.py
@@ -6,6 +6,7 @@
 
 from foglamp.common.storage_client.payload_builder import PayloadBuilder
 from foglamp.common.storage_client.storage_client import StorageClient
+from foglamp.common.storage_client.exceptions import StorageServerError
 
 from foglamp.common import logger
 
@@ -58,18 +59,9 @@ class AuditLogger(AuditLoggerSingleton):
             else:
                 payload = PayloadBuilder().INSERT(code=code, level=level, log=log).payload()
 
-            # Get the JSON result of the insert
-            res = self._storage.insert_into_tbl("log", payload)
+            self._storage.insert_into_tbl("log", payload)
 
-            # Check if storage output is a dict (JSON data)
-            if type(res) is dict:
-                # Is error message present?
-                err_msg = res.get('message', None)
-
-                # Raise a Exception
-                if err_msg is not None:
-                    raise Exception(str(err_msg))
-        except Exception as ex:
+        except (StorageServerError, Exception) as ex:
             _logger.exception("Failed to log audit trail entry '%s': %s", code, str(ex))
             raise ex
 

--- a/python/foglamp/common/storage_client/storage_client.py
+++ b/python/foglamp/common/storage_client/storage_client.py
@@ -96,8 +96,6 @@ class StorageClient(AbstractStorage):
         conn.request('GET', url='/foglamp/service?name=FogLAMP%20Storage')
         r = conn.getresponse()
 
-        # TODO: FOGL-615
-        # log error with message if status is 4xx or 5xx
         if r.status in range(400, 500):
             _LOGGER.error("Get Service: Client error code: %d, %s", r.status. r.reason)
         if r.status in range(500, 600):
@@ -160,12 +158,10 @@ class StorageClient(AbstractStorage):
         conn.close()
         jdoc = json.loads(res, strict=False)
 
-        # TODO: FOGL-615
-        # log error with message if status is 4xx or 5xx
         if r.status in range(400, 600):
             _LOGGER.info("POST %s, with payload: %s", post_url, data)
             _LOGGER.error("Error code: %d, reason: %s, details: %s", r.status, r.reason, jdoc)
-            # raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
+            raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
 
         return jdoc
 
@@ -209,12 +205,10 @@ class StorageClient(AbstractStorage):
         conn.close()
         jdoc = json.loads(res, strict=False)
 
-        # TODO: FOGL-615
-        # log error with message if status is 4xx or 5xx
         if r.status in range(400, 600):
             _LOGGER.info("PUT %s, with payload: %s", put_url, data)
             _LOGGER.error("Error code: %d, reason: %s, details: %s", r.status, r.reason, jdoc)
-            # raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
+            raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
 
         return jdoc
 
@@ -251,12 +245,10 @@ class StorageClient(AbstractStorage):
         conn.close()
         jdoc = json.loads(res, strict=False)
 
-        # TODO: FOGL-615
-        # log error with message if status is 4xx or 5xx
         if r.status in range(400, 600):
             _LOGGER.info("DELETE %s, with payload: %s", del_url, condition if condition else '')
             _LOGGER.error("Error code: %d, reason: %s, details: %s", r.status, r.reason, jdoc)
-            # raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
+            raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
 
         return jdoc
 
@@ -288,12 +280,10 @@ class StorageClient(AbstractStorage):
         conn.close()
         jdoc = json.loads(res, strict=False)
 
-        # TODO: FOGL-615
-        # log error with message if status is 4xx or 5xx
         if r.status in range(400, 600):
             _LOGGER.info("GET %s", get_url)
             _LOGGER.error("Error code: %d, reason: %s, details: %s", r.status, r.reason, jdoc)
-            # raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
+            raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
 
         return jdoc
 
@@ -332,12 +322,10 @@ class StorageClient(AbstractStorage):
         conn.close()
         jdoc = json.loads(res, strict=False)
 
-        # TODO: FOGL-615
-        # log error with message if status is 4xx or 5xx
         if r.status in range(400, 600):
             _LOGGER.info("PUT %s, with query payload: %s", put_url, query_payload)
             _LOGGER.error("Error code: %d, reason: %s, details: %s", r.status, r.reason, jdoc)
-            # raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
+            raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
 
         return jdoc
 
@@ -394,12 +382,10 @@ class ReadingsStorageClient(StorageClient):
         conn.close()
         jdoc = json.loads(res, strict=False)
 
-        # TODO: FOGL-615
-        # log error with message if status is 4xx or 5xx
         if r.status in range(400, 600):
             _LOGGER.error("POST url %s with payload: %s, Error code: %d, reason: %s, details: %s",
                           '/storage/reading', readings, r.status, r.reason, jdoc)
-            # raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
+            raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
 
         return jdoc
 
@@ -436,11 +422,9 @@ class ReadingsStorageClient(StorageClient):
         conn.close()
         jdoc = json.loads(res, strict=False)
 
-        # TODO: FOGL-615
-        # log error with message if status is 4xx or 5xx
         if r.status in range(400, 600):
             _LOGGER.error("GET url: %s, Error code: %d, reason: %s, details: %s", get_url, r.status, r.reason, jdoc)
-            # raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
+            raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
 
         return jdoc
 
@@ -478,12 +462,10 @@ class ReadingsStorageClient(StorageClient):
         conn.close()
         jdoc = json.loads(res, strict=False)
 
-        # TODO: FOGL-615
-        # log error with message if status is 4xx or 5xx
         if r.status in range(400, 600):
             _LOGGER.error("PUT url %s with query payload: %s, Error code: %d, reason: %s, details: %s",
                           '/storage/reading/query', query_payload, r.status, r.reason, jdoc)
-            # raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
+            raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
 
         return jdoc
 
@@ -544,11 +526,9 @@ class ReadingsStorageClient(StorageClient):
         conn.close()
         jdoc = json.loads(res, strict=False)
 
-        # TODO: FOGL-615
-        # log error with message if status is 4xx or 5xx
+        # NOTE: If the data could not be deleted because of a conflict, then the error “409 Conflict” will be returned.
         if r.status in range(400, 600):
             _LOGGER.error("PUT url %s, Error code: %d, reason: %s, details: %s", put_url, r.status, r.reason, jdoc)
-            # raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
+            raise StorageServerError(code=r.status, reason=r.reason, error=jdoc)
 
-        # NOTE: If the data could not be deleted because of a conflict, then the error “409 Conflict” will be returned.
         return jdoc

--- a/tests/unit/python/foglamp/common/storage_client/test_storage_client.py
+++ b/tests/unit/python/foglamp/common/storage_client/test_storage_client.py
@@ -254,23 +254,27 @@ class TestStorageClient:
         for response in await asyncio.gather(*futures):
             assert {"k": "v"} == response["called"]
 
-        with patch.object(_LOGGER, "error") as log_e:
-            with patch.object(_LOGGER, "info") as log_i:
-                args = "aTable", json.dumps({"bad_request": "v"})
-                futures = [event_loop.run_in_executor(None, sc.insert_into_tbl, *args)]
-                for response in await asyncio.gather(*futures):
-                    pass
-        log_i.assert_called_once_with("POST %s, with payload: %s", '/storage/table/aTable', '{"bad_request": "v"}')
-        log_e.assert_called_once_with('Error code: %d, reason: %s, details: %s', 400, 'bad data', {'key': 'value'})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                with patch.object(_LOGGER, "info") as log_i:
+                    args = "aTable", json.dumps({"bad_request": "v"})
+                    futures = [event_loop.run_in_executor(None, sc.insert_into_tbl, *args)]
+                    for response in await asyncio.gather(*futures):
+                        pass
+            log_i.assert_called_once_with("POST %s, with payload: %s", '/storage/table/aTable', '{"bad_request": "v"}')
+            log_e.assert_called_once_with('Error code: %d, reason: %s, details: %s', 400, 'bad data', {'key': 'value'})
+        assert excinfo.type is StorageServerError
 
-        with patch.object(_LOGGER, "error") as log_e:
-            with patch.object(_LOGGER, "info") as log_i:
-                args = "aTable", json.dumps({"internal_server_err": "v"})
-                futures = [event_loop.run_in_executor(None, sc.insert_into_tbl, *args)]
-                for response in await asyncio.gather(*futures):
-                    pass
-        log_i.assert_called_once_with("POST %s, with payload: %s", '/storage/table/aTable', '{"internal_server_err": "v"}')
-        log_e.assert_called_once_with('Error code: %d, reason: %s, details: %s', 500, 'something wrong', {'key': 'value'})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                with patch.object(_LOGGER, "info") as log_i:
+                    args = "aTable", json.dumps({"internal_server_err": "v"})
+                    futures = [event_loop.run_in_executor(None, sc.insert_into_tbl, *args)]
+                    for response in await asyncio.gather(*futures):
+                        pass
+            log_i.assert_called_once_with("POST %s, with payload: %s", '/storage/table/aTable', '{"internal_server_err": "v"}')
+            log_e.assert_called_once_with('Error code: %d, reason: %s, details: %s', 500, 'something wrong', {'key': 'value'})
+        assert excinfo.type is StorageServerError
 
         await fake_storage_srvr.stop()
 
@@ -319,24 +323,28 @@ class TestStorageClient:
         for response in await asyncio.gather(*futures):
             assert {"k": "v"} == response["called"]
 
-        with patch.object(_LOGGER, "error") as log_e:
-            with patch.object(_LOGGER, "info") as log_i:
-                args = "aTable", json.dumps({"bad_request": "v"})
-                futures = [event_loop.run_in_executor(None, sc.update_tbl, *args)]
-                for response in await asyncio.gather(*futures):
-                    pass
-        log_i.assert_called_once_with("PUT %s, with payload: %s", '/storage/table/aTable', '{"bad_request": "v"}')
-        log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 400, 'bad data', {'key': 'value'})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                with patch.object(_LOGGER, "info") as log_i:
+                    args = "aTable", json.dumps({"bad_request": "v"})
+                    futures = [event_loop.run_in_executor(None, sc.update_tbl, *args)]
+                    for response in await asyncio.gather(*futures):
+                        pass
+            log_i.assert_called_once_with("PUT %s, with payload: %s", '/storage/table/aTable', '{"bad_request": "v"}')
+            log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 400, 'bad data', {'key': 'value'})
+        assert excinfo.type is StorageServerError
 
-        with patch.object(_LOGGER, "error") as log_e:
-            with patch.object(_LOGGER, "info") as log_i:
-                args = "aTable", json.dumps({"internal_server_err": "v"})
-                futures = [event_loop.run_in_executor(None, sc.update_tbl, *args)]
-                for response in await asyncio.gather(*futures):
-                    pass
-        log_i.assert_called_once_with("PUT %s, with payload: %s", '/storage/table/aTable',
-                                      '{"internal_server_err": "v"}')
-        log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 500, 'something wrong', {'key': 'value'})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                with patch.object(_LOGGER, "info") as log_i:
+                    args = "aTable", json.dumps({"internal_server_err": "v"})
+                    futures = [event_loop.run_in_executor(None, sc.update_tbl, *args)]
+                    for response in await asyncio.gather(*futures):
+                        pass
+            log_i.assert_called_once_with("PUT %s, with payload: %s", '/storage/table/aTable',
+                                          '{"internal_server_err": "v"}')
+            log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 500, 'something wrong', {'key': 'value'})
+        assert excinfo.type is StorageServerError
 
         await fake_storage_srvr.stop()
 
@@ -381,24 +389,28 @@ class TestStorageClient:
         for response in await asyncio.gather(*futures):
             assert {"condition": "v"} == response["called"]
 
-        with patch.object(_LOGGER, "error") as log_e:
-            with patch.object(_LOGGER, "info") as log_i:
-                args = "aTable", json.dumps({"bad_request": "v"})
-                futures = [event_loop.run_in_executor(None, sc.delete_from_tbl, *args)]
-                for response in await asyncio.gather(*futures):
-                    pass
-        log_i.assert_called_once_with("DELETE %s, with payload: %s", '/storage/table/aTable', '{"bad_request": "v"}')
-        log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 400, 'bad data', {'key': 'value'})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                with patch.object(_LOGGER, "info") as log_i:
+                    args = "aTable", json.dumps({"bad_request": "v"})
+                    futures = [event_loop.run_in_executor(None, sc.delete_from_tbl, *args)]
+                    for response in await asyncio.gather(*futures):
+                        pass
+            log_i.assert_called_once_with("DELETE %s, with payload: %s", '/storage/table/aTable', '{"bad_request": "v"}')
+            log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 400, 'bad data', {'key': 'value'})
+        assert excinfo.type is StorageServerError
 
-        with patch.object(_LOGGER, "error") as log_e:
-            with patch.object(_LOGGER, "info") as log_i:
-                args = "aTable", json.dumps({"internal_server_err": "v"})
-                futures = [event_loop.run_in_executor(None, sc.delete_from_tbl, *args)]
-                for response in await asyncio.gather(*futures):
-                    pass
-        log_i.assert_called_once_with("DELETE %s, with payload: %s", '/storage/table/aTable',
-                                      '{"internal_server_err": "v"}')
-        log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 500, 'something wrong', {'key': 'value'})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                with patch.object(_LOGGER, "info") as log_i:
+                    args = "aTable", json.dumps({"internal_server_err": "v"})
+                    futures = [event_loop.run_in_executor(None, sc.delete_from_tbl, *args)]
+                    for response in await asyncio.gather(*futures):
+                        pass
+            log_i.assert_called_once_with("DELETE %s, with payload: %s", '/storage/table/aTable',
+                                          '{"internal_server_err": "v"}')
+            log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 500, 'something wrong', {'key': 'value'})
+        assert excinfo.type is StorageServerError
 
         await fake_storage_srvr.stop()
 
@@ -435,23 +447,27 @@ class TestStorageClient:
         for response in await asyncio.gather(*futures):
             assert 'foo passed' == response["called"]
 
-        with patch.object(_LOGGER, "error") as log_e:
-            with patch.object(_LOGGER, "info") as log_i:
-                args = "aTable", 'bad_foo=1'
-                futures = [event_loop.run_in_executor(None, sc.query_tbl, *args)]
-                for response in await asyncio.gather(*futures):
-                    pass
-        log_i.assert_called_once_with("GET %s", '/storage/table/aTable?bad_foo=1')
-        log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 400, 'bad data', {'key': 'value'})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                with patch.object(_LOGGER, "info") as log_i:
+                    args = "aTable", 'bad_foo=1'
+                    futures = [event_loop.run_in_executor(None, sc.query_tbl, *args)]
+                    for response in await asyncio.gather(*futures):
+                        pass
+            log_i.assert_called_once_with("GET %s", '/storage/table/aTable?bad_foo=1')
+            log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 400, 'bad data', {'key': 'value'})
+        assert excinfo.type is StorageServerError
 
-        with patch.object(_LOGGER, "error") as log_e:
-            with patch.object(_LOGGER, "info") as log_i:
-                args = "aTable", 'internal_server_err_foo=1'
-                futures = [event_loop.run_in_executor(None, sc.query_tbl, *args)]
-                for response in await asyncio.gather(*futures):
-                    pass
-        log_i.assert_called_once_with("GET %s", '/storage/table/aTable?internal_server_err_foo=1')
-        log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 500, 'something wrong', {'key': 'value'})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                with patch.object(_LOGGER, "info") as log_i:
+                    args = "aTable", 'internal_server_err_foo=1'
+                    futures = [event_loop.run_in_executor(None, sc.query_tbl, *args)]
+                    for response in await asyncio.gather(*futures):
+                        pass
+            log_i.assert_called_once_with("GET %s", '/storage/table/aTable?internal_server_err_foo=1')
+            log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 500, 'something wrong', {'key': 'value'})
+        assert excinfo.type is StorageServerError
 
         await fake_storage_srvr.stop()
 
@@ -500,25 +516,29 @@ class TestStorageClient:
         for response in await asyncio.gather(*futures):
             assert {"k": "v"} == response["called"]
 
-        with patch.object(_LOGGER, "error") as log_e:
-            with patch.object(_LOGGER, "info") as log_i:
-                args = "aTable", json.dumps({"bad_request": "v"})
-                futures = [event_loop.run_in_executor(None, sc.query_tbl_with_payload, *args)]
-                for response in await asyncio.gather(*futures):
-                    pass
-        log_i.assert_called_once_with("PUT %s, with query payload: %s", '/storage/table/aTable/query',
-                                      '{"bad_request": "v"}')
-        log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 400, 'bad data', {'key': 'value'})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                with patch.object(_LOGGER, "info") as log_i:
+                    args = "aTable", json.dumps({"bad_request": "v"})
+                    futures = [event_loop.run_in_executor(None, sc.query_tbl_with_payload, *args)]
+                    for response in await asyncio.gather(*futures):
+                        pass
+            log_i.assert_called_once_with("PUT %s, with query payload: %s", '/storage/table/aTable/query',
+                                          '{"bad_request": "v"}')
+            log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 400, 'bad data', {'key': 'value'})
+        assert excinfo.type is StorageServerError
 
-        with patch.object(_LOGGER, "error") as log_e:
-            with patch.object(_LOGGER, "info") as log_i:
-                args = "aTable", json.dumps({"internal_server_err": "v"})
-                futures = [event_loop.run_in_executor(None, sc.query_tbl_with_payload, *args)]
-                for response in await asyncio.gather(*futures):
-                    pass
-        log_i.assert_called_once_with("PUT %s, with query payload: %s", '/storage/table/aTable/query',
-                                      '{"internal_server_err": "v"}')
-        log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 500, 'something wrong', {'key': 'value'})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                with patch.object(_LOGGER, "info") as log_i:
+                    args = "aTable", json.dumps({"internal_server_err": "v"})
+                    futures = [event_loop.run_in_executor(None, sc.query_tbl_with_payload, *args)]
+                    for response in await asyncio.gather(*futures):
+                        pass
+            log_i.assert_called_once_with("PUT %s, with query payload: %s", '/storage/table/aTable/query',
+                                          '{"internal_server_err": "v"}')
+            log_e.assert_called_once_with("Error code: %d, reason: %s, details: %s", 500, 'something wrong', {'key': 'value'})
+        assert excinfo.type is StorageServerError
 
         await fake_storage_srvr.stop()
 
@@ -567,22 +587,26 @@ class TestReadingsStorageClient:
         assert excinfo.type is TypeError
         assert "Readings payload must be a valid JSON" in str(excinfo.value)
 
-        with patch.object(_LOGGER, "error") as log_e:
-            readings_bad_payload = json.dumps({"Xreadings": []})
-            futures = [event_loop.run_in_executor(None, rsc.append, readings_bad_payload)]
-            for response in await asyncio.gather(*futures):
-                pass
-        log_e.assert_called_once_with("POST url %s with payload: %s, Error code: %d, reason: %s, details: %s",
-                                      '/storage/reading', '{"Xreadings": []}', 400, 'bad data', {"key": "value"})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                readings_bad_payload = json.dumps({"Xreadings": []})
+                futures = [event_loop.run_in_executor(None, rsc.append, readings_bad_payload)]
+                for response in await asyncio.gather(*futures):
+                    pass
+            log_e.assert_called_once_with("POST url %s with payload: %s, Error code: %d, reason: %s, details: %s",
+                                          '/storage/reading', '{"Xreadings": []}', 400, 'bad data', {"key": "value"})
+        assert excinfo.type is StorageServerError
 
-        with patch.object(_LOGGER, "error") as log_e:
-            r = '{"readings": [], "internal_server_err": 1}'
-            futures = [event_loop.run_in_executor(None, rsc.append, r)]
-            for response in await asyncio.gather(*futures):
-                pass
-        log_e.assert_called_once_with("POST url %s with payload: %s, Error code: %d, reason: %s, details: %s",
-                                      '/storage/reading', '{"readings": [], "internal_server_err": 1}',
-                                      500, 'something wrong', {"key": "value"})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                r = '{"readings": [], "internal_server_err": 1}'
+                futures = [event_loop.run_in_executor(None, rsc.append, r)]
+                for response in await asyncio.gather(*futures):
+                    pass
+            log_e.assert_called_once_with("POST url %s with payload: %s, Error code: %d, reason: %s, details: %s",
+                                          '/storage/reading', '{"readings": [], "internal_server_err": 1}',
+                                          500, 'something wrong', {"key": "value"})
+        assert excinfo.type is StorageServerError
 
         readings = json.dumps({"readings": []})
         futures = [event_loop.run_in_executor(None, rsc.append, readings)]
@@ -631,21 +655,24 @@ class TestReadingsStorageClient:
         assert excinfo.type is ValueError
         assert "invalid literal for int() with base 10" in str(excinfo.value)
 
-        with patch.object(_LOGGER, "error") as log_e:
-            args = "bad_data", 3
-            futures = [event_loop.run_in_executor(None, rsc.fetch, *args)]
-            for response in await asyncio.gather(*futures):
-                pass
-        log_e.assert_called_once_with('GET url: %s, Error code: %d, reason: %s, details: %s',
-                                      '/storage/reading?id=bad_data&count=3', 400, 'bad data', {"key": "value"})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                args = "bad_data", 3
+                futures = [event_loop.run_in_executor(None, rsc.fetch, *args)]
+                for response in await asyncio.gather(*futures):
+                    pass
+            log_e.assert_called_once_with('GET url: %s, Error code: %d, reason: %s, details: %s',
+                                          '/storage/reading?id=bad_data&count=3', 400, 'bad data', {"key": "value"})
 
-        with patch.object(_LOGGER, "error") as log_e:
-            args = "internal_server_err", 3
-            futures = [event_loop.run_in_executor(None, rsc.fetch, *args)]
-            for response in await asyncio.gather(*futures):
-                pass
-        log_e.assert_called_once_with('GET url: %s, Error code: %d, reason: %s, details: %s',
-                                      '/storage/reading?id=internal_server_err&count=3', 500, 'something wrong', {"key": "value"})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                args = "internal_server_err", 3
+                futures = [event_loop.run_in_executor(None, rsc.fetch, *args)]
+                for response in await asyncio.gather(*futures):
+                    pass
+            log_e.assert_called_once_with('GET url: %s, Error code: %d, reason: %s, details: %s',
+                                          '/storage/reading?id=internal_server_err&count=3', 500, 'something wrong', {"key": "value"})
+        assert excinfo.type is StorageServerError
 
         args = 2, 3
         futures = [event_loop.run_in_executor(None, rsc.fetch, *args)]
@@ -688,19 +715,23 @@ class TestReadingsStorageClient:
         for response in await asyncio.gather(*futures):
             assert {"k": "v"} == response["called"]
 
-        with patch.object(_LOGGER, "error") as log_e:
-            futures = [event_loop.run_in_executor(None, rsc.query, json.dumps({"bad_request": "v"}))]
-            for response in await asyncio.gather(*futures):
-                pass
-        log_e.assert_called_once_with("PUT url %s with query payload: %s, Error code: %d, reason: %s, details: %s",
-                                      '/storage/reading/query', '{"bad_request": "v"}', 400, 'bad data', {"key": "value"})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                futures = [event_loop.run_in_executor(None, rsc.query, json.dumps({"bad_request": "v"}))]
+                for response in await asyncio.gather(*futures):
+                    pass
+            log_e.assert_called_once_with("PUT url %s with query payload: %s, Error code: %d, reason: %s, details: %s",
+                                          '/storage/reading/query', '{"bad_request": "v"}', 400, 'bad data', {"key": "value"})
+        assert excinfo.type is StorageServerError
 
-        with patch.object(_LOGGER, "error") as log_e:
-            futures = [event_loop.run_in_executor(None, rsc.query, json.dumps({"internal_server_err": "v"}))]
-            for response in await asyncio.gather(*futures):
-                pass
-        log_e.assert_called_once_with("PUT url %s with query payload: %s, Error code: %d, reason: %s, details: %s",
-                                      '/storage/reading/query', '{"internal_server_err": "v"}', 500, 'something wrong', {"key": "value"})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                futures = [event_loop.run_in_executor(None, rsc.query, json.dumps({"internal_server_err": "v"}))]
+                for response in await asyncio.gather(*futures):
+                    pass
+            log_e.assert_called_once_with("PUT url %s with query payload: %s, Error code: %d, reason: %s, details: %s",
+                                          '/storage/reading/query', '{"internal_server_err": "v"}', 500, 'something wrong', {"key": "value"})
+        assert excinfo.type is StorageServerError
 
         await fake_storage_srvr.stop()
 
@@ -786,23 +817,27 @@ class TestReadingsStorageClient:
         assert excinfo.type is ValueError
         assert "invalid literal for int() with base 10" in str(excinfo.value)
 
-        with patch.object(_LOGGER, "error") as log_e:
-            kwargs = dict(age=-1, sent_id=1, size=None, flag='retain')
-            func = partial(rsc.purge, **kwargs)
-            futures = [event_loop.run_in_executor(None, func)]
-            for response in await asyncio.gather(*futures):
-                pass
-        log_e.assert_called_once_with('PUT url %s, Error code: %d, reason: %s, details: %s',
-                                      '/storage/reading/purge?age=-1&sent=1&flags=retain', 400, 'age should not be less than 0', {"key": "value"})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                kwargs = dict(age=-1, sent_id=1, size=None, flag='retain')
+                func = partial(rsc.purge, **kwargs)
+                futures = [event_loop.run_in_executor(None, func)]
+                for response in await asyncio.gather(*futures):
+                    pass
+            log_e.assert_called_once_with('PUT url %s, Error code: %d, reason: %s, details: %s',
+                                          '/storage/reading/purge?age=-1&sent=1&flags=retain', 400, 'age should not be less than 0', {"key": "value"})
+        assert excinfo.type is StorageServerError
 
-        with patch.object(_LOGGER, "error") as log_e:
-            kwargs = dict(age=None, sent_id=1, size=4294967296, flag='retain')
-            func = partial(rsc.purge, **kwargs)
-            futures = [event_loop.run_in_executor(None, func)]
-            for response in await asyncio.gather(*futures):
-                pass
-        log_e.assert_called_once_with('PUT url %s, Error code: %d, reason: %s, details: %s',
-                                      '/storage/reading/purge?size=4294967296&sent=1&flags=retain', 500, 'unsigned int range', {"key": "value"})
+        with pytest.raises(Exception) as excinfo:
+            with patch.object(_LOGGER, "error") as log_e:
+                kwargs = dict(age=None, sent_id=1, size=4294967296, flag='retain')
+                func = partial(rsc.purge, **kwargs)
+                futures = [event_loop.run_in_executor(None, func)]
+                for response in await asyncio.gather(*futures):
+                    pass
+            log_e.assert_called_once_with('PUT url %s, Error code: %d, reason: %s, details: %s',
+                                          '/storage/reading/purge?size=4294967296&sent=1&flags=retain', 500, 'unsigned int range', {"key": "value"})
+        assert excinfo.type is StorageServerError
 
         kwargs = dict(age=1, sent_id=1, size=0, flag='retain')
         func = partial(rsc.purge, **kwargs)


### PR DESCRIPTION
- [x] raise exception from storage client when error recieved from storage service;
- [x]  fixed storage client tests; 
- [x] handling added in south ingest;

- [x] remove extra code from audit logger for handling exception re-raise and log message 

- [ ]  next (as identified)