### PR TITLE
FOGL-1170 history ts format fixes for stats history

### DIFF
--- a/python/foglamp/services/core/api/statistics.py
+++ b/python/foglamp/services/core/api/statistics.py
@@ -93,16 +93,15 @@ async def get_statistics_history(request):
 
     stats_history_payload = PayloadBuilder(stats_history_chain_payload).payload()
     result_from_storage = storage_client.query_tbl_with_payload('statistics_history', stats_history_payload)
-    result_without_microseconds = []
+    group_dict = []
     for row in result_from_storage['rows']:
-        # Remove microseconds
-        new_dict = {'history_ts': row['history_ts'][:-13], row['key']: row['value']}
-        result_without_microseconds.append(new_dict)
+        new_dict = {'history_ts': row['history_ts'], row['key']: row['value']}
+        group_dict.append(new_dict)
 
     results = []
     temp_dict = {}
     previous_ts = None
-    for row in result_without_microseconds:
+    for row in group_dict:
         # first time or when history_ts changes
         if previous_ts is None or previous_ts != row['history_ts']:
             if previous_ts is not None:

--- a/tests/unit/python/foglamp/services/core/api/test_statistics_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_statistics_api.py
@@ -60,8 +60,8 @@ class TestStatistics:
                 assert "Internal Server Error" == resp.reason
 
     async def test_get_statistics_history(self, client):
-        output = {"interval": 60, 'statistics': [{"READINGS": 1, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:24"},
-                                                 {"READINGS": 0, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:09"}]}
+        output = {"interval": 60, 'statistics': [{"READINGS": 1, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:24.321589+05:30"},
+                                                 {"READINGS": 0, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:09.321589+05:30"}]}
         p1 = {'return': ['history_ts', 'key', 'value'], 'sort': {'direction': 'desc', 'column': 'history_ts'}}
         p2 = {"return": ["schedule_interval"],
               "where": {"column": "process_name", "condition": "=", "value": "stats collector"}}
@@ -92,8 +92,8 @@ class TestStatistics:
         assert 2 == query_patch.call_count
 
     async def test_get_statistics_history_limit(self, client):
-        output = {"interval": 60, 'statistics': [{"READINGS": 1, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:24"},
-                                                 {"READINGS": 0, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:09"}]}
+        output = {"interval": 60, 'statistics': [{"READINGS": 1, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:24.321589+05:30"},
+                                                 {"READINGS": 0, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:09.321589+05:30"}]}
 
         p1 = {"aggregate": {"operation": "count", "column": "*"}}
         # payload limit will be request limit*2 i.e. via p1 query


### PR DESCRIPTION
**Tests O/P**
```
collected 8 items
= 8 passed in 0.58 seconds =
```

**Suite O/P**

```
collected 711 items
== 701 passed, 10 skipped in 34.93 seconds ==
```