### PR TITLE
Fixed microservice tests failing due to FOGL-1155 merger

### DIFF
--- a/tests/unit/python/foglamp/services/common/test_microservice.py
+++ b/tests/unit/python/foglamp/services/common/test_microservice.py
@@ -2,13 +2,15 @@
 
 import pytest
 import time
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from aiohttp import web
 import asyncio
+from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.common.storage_client.storage_client import ReadingsStorageClient, StorageClient
 from foglamp.common.process import FoglampProcess, SilentArgParse, ArgumentParserError
 from foglamp.services.common.microservice import FoglampMicroservice, _logger
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient
+from foglamp.services.core import connect
 
 
 __author__ = "Ashwin Gopalakrishnan"
@@ -20,6 +22,22 @@ __version__ = "${VERSION}"
 # test FoglampProcess class things it needs
 # test that it registers with core
 # test the microservice management api
+
+_DEFAULT_CONFIG = {
+    'plugin': {
+        'description': 'Python module name of the plugin to load',
+        'type': 'string',
+        'default': 'coap_listen',
+        'value': 'coap_listen'
+    },
+    'management_host': {
+        'description': 'Management host',
+        'type': 'string',
+        'default': '127.0.0.1',
+        'value': '127.0.0.1',
+    }
+}
+
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("common", "foglamp-microservice")
@@ -56,13 +74,22 @@ class TestFoglampMicroservice:
 
     def test_constructor_good(self, loop):
         class FoglampMicroserviceImp(FoglampMicroservice):
+            def __init__(self):
+                super().__init__(_DEFAULT_CONFIG)
+
             def run(self):
                 pass
             async def change(self):
                 pass
             async def shutdown(self):
                 pass
-        
+
+        async def async_mock():
+            return None
+
+        async def config_mock():
+            return _DEFAULT_CONFIG
+
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
             with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
@@ -72,7 +99,11 @@ class TestFoglampMicroservice:
                                  with patch.object(FoglampMicroservice, '_run_microservice_management_app', side_effect=None) as run_patch:
                                      with patch.object(FoglampProcess, 'register_service_with_core', return_value={'id':'bla'}) as reg_patch:
                                          with patch.object(FoglampMicroservice, '_get_service_registration_payload', return_value=None) as payload_patch:
-                                             fm = FoglampMicroserviceImp()
+                                            storage_client_mock = MagicMock(StorageClient)
+                                            c_mgr = ConfigurationManager(storage_client_mock)
+                                            with patch.object(c_mgr, 'create_category', return_value=async_mock()):
+                                                with patch.object(c_mgr, 'get_category_all_items', return_value=config_mock()):
+                                                    fm = FoglampMicroserviceImp()
         # from FoglampProcess
         assert fm._core_management_host is 'corehost'
         assert fm._core_management_port is 0
@@ -93,12 +124,22 @@ class TestFoglampMicroservice:
 
     def test_constructor_exception(self, loop):
         class FoglampMicroserviceImp(FoglampMicroservice):
+            def __init__(self):
+                super().__init__(_DEFAULT_CONFIG)
+
             def run(self):
                 pass
             async def change(self):
                 pass
             async def shutdown(self):
                 pass
+
+        async def async_mock():
+            return None
+
+        async def config_mock():
+            return _DEFAULT_CONFIG
+
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
             with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
@@ -107,18 +148,33 @@ class TestFoglampMicroservice:
                             with patch.object(FoglampMicroservice, '_make_microservice_management_app', side_effect=Exception()) as make_patch:
                                 with patch.object(_logger, 'exception') as logger_patch:
                                     with pytest.raises(Exception) as excinfo:
-                                        fm = FoglampMicroserviceImp()
+                                        storage_client_mock = MagicMock(StorageClient)
+                                        c_mgr = ConfigurationManager(storage_client_mock)
+                                        with patch.object(c_mgr, 'create_category', return_value=async_mock()):
+                                            with patch.object(c_mgr, 'get_category_all_items',
+                                                              return_value=config_mock()):
+                                                fm = FoglampMicroserviceImp()
         logger_patch.assert_called_once_with('Unable to intialize FoglampMicroservice due to exception %s', '')
 
     @pytest.mark.asyncio
     async def test_ping(self, loop):
         class FoglampMicroserviceImp(FoglampMicroservice):
+            def __init__(self):
+                super().__init__(_DEFAULT_CONFIG)
+
             def run(self):
                 pass
             async def change(self):
                 pass
             async def shutdown(self):
                 pass
+
+        async def async_mock():
+            return None
+
+        async def config_mock():
+            return _DEFAULT_CONFIG
+
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
             with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
@@ -131,19 +187,35 @@ class TestFoglampMicroservice:
                                              with patch.object(web, 'json_response', return_value=None) as response_patch:
                                                  # called once on FoglampProcess init for _start_time, once for ping
                                                  with patch.object(time, 'time', return_value=1) as time_patch:
-                                                     fm = FoglampMicroserviceImp()
-                                                     await fm.ping(None)
+                                                     storage_client_mock = MagicMock(StorageClient)
+                                                     c_mgr = ConfigurationManager(storage_client_mock)
+                                                     with patch.object(c_mgr, 'create_category',
+                                                                       return_value=async_mock()):
+                                                         with patch.object(c_mgr, 'get_category_all_items',
+                                                                           return_value=config_mock()):
+                                                             fm = FoglampMicroserviceImp()
+                                                             await fm.ping(None)
         response_patch.assert_called_once_with({'uptime': 0})
 
     @pytest.mark.asyncio
     async def test_core_only_ms_api(self, loop):
         class FoglampMicroserviceImp(FoglampMicroservice):
+            def __init__(self):
+                super().__init__(_DEFAULT_CONFIG)
+
             def run(self):
                 pass
             async def change(self):
                 pass
             async def shutdown(self):
                 pass
+
+        async def async_mock():
+            return None
+
+        async def config_mock():
+            return _DEFAULT_CONFIG
+
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
             with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
@@ -154,16 +226,21 @@ class TestFoglampMicroservice:
                                      with patch.object(FoglampProcess, 'register_service_with_core', return_value={'id':'bla'}) as reg_patch:
                                          with patch.object(FoglampMicroservice, '_get_service_registration_payload', return_value=None) as payload_patch:
                                              with pytest.raises(web.HTTPBadRequest) as excinfo:
-                                                 fm = FoglampMicroserviceImp()
-                                                 await fm.register(None)
-                                                 assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)
-                                                 await fm.unregister(None)
-                                                 assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)
-                                                 await fm.get_service(None)
-                                                 assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)
-                                                 await fm.register_interest(None)
-                                                 assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)
-                                                 await fm.unregister_interest(None)
-                                                 assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)
-                                                 await fm.get_interest(None)
-                                                 assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)
+                                                 storage_client_mock = MagicMock(StorageClient)
+                                                 c_mgr = ConfigurationManager(storage_client_mock)
+                                                 with patch.object(c_mgr, 'create_category', return_value=async_mock()):
+                                                     with patch.object(c_mgr, 'get_category_all_items',
+                                                                       return_value=config_mock()):
+                                                         fm = FoglampMicroserviceImp()
+                                                         await fm.register(None)
+                                                         assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)
+                                                         await fm.unregister(None)
+                                                         assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)
+                                                         await fm.get_service(None)
+                                                         assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)
+                                                         await fm.register_interest(None)
+                                                         assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)
+                                                         await fm.unregister_interest(None)
+                                                         assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)
+                                                         await fm.get_interest(None)
+                                                         assert 'Service registration requests are handled by core microservice, not by sname microservice' in str(excinfo.value)

--- a/tests/unit/python/foglamp/services/common/test_microservice.py
+++ b/tests/unit/python/foglamp/services/common/test_microservice.py
@@ -10,7 +10,6 @@ from foglamp.common.storage_client.storage_client import ReadingsStorageClient, 
 from foglamp.common.process import FoglampProcess, SilentArgParse, ArgumentParserError
 from foglamp.services.common.microservice import FoglampMicroservice, _logger
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient
-from foglamp.services.core import connect
 
 
 __author__ = "Ashwin Gopalakrishnan"


### PR DESCRIPTION
Test result:
```
FogLAMP (fix_microservice_tests %) $ pytest -s -vv tests/unit/python/foglamp/services/common/test_microservice.py
======================================================= test session starts ========================================================
platform linux -- Python 3.5.2, pytest-3.4.0, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python3.5
cachedir: .pytest_cache
rootdir: /home/asinha/Development/FogLAMP, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 5 items                                                                                                                  

tests/unit/python/foglamp/services/common/test_microservice.py::TestFoglampMicroservice::test_constructor_abstract_method_missing PASSED
tests/unit/python/foglamp/services/common/test_microservice.py::TestFoglampMicroservice::test_constructor_good[pyloop] PASSED
tests/unit/python/foglamp/services/common/test_microservice.py::TestFoglampMicroservice::test_constructor_exception[pyloop] PASSED
tests/unit/python/foglamp/services/common/test_microservice.py::TestFoglampMicroservice::test_ping[pyloop] PASSED
tests/unit/python/foglamp/services/common/test_microservice.py::TestFoglampMicroservice::test_core_only_ms_api[pyloop] PASSED

===================================================== 5 passed in 0.14 seconds =====================================================

```

Test Suite result:
`============================================= 722 passed, 10 skipped in 32.49 seconds ==============================================
`