### PR TITLE
FOGL-1019, 1178 - Setting a schedule with a repeat that includes a day causes FogLAMP to fail to start

### DIFF
--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -662,8 +662,9 @@ class Scheduler(object):
                 else:
                     interval_days = 0
                     interval_time = row.get('schedule_interval')
+                s_days = int(interval_days)
                 s_interval = datetime.datetime.strptime(interval_time, "%H:%M:%S")
-                interval = datetime.timedelta(hours=s_interval.hour+(int(interval_days)*24), minutes=s_interval.minute,
+                interval = datetime.timedelta(days=s_days, hours=s_interval.hour, minutes=s_interval.minute,
                                               seconds=s_interval.second)
 
                 repeat_seconds = None

--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -651,8 +651,19 @@ class Scheduler(object):
             self._logger.debug('Database command: %s', 'schedules')
             res = self._storage.query_tbl("schedules")
             for row in res['rows']:
-                s_interval = datetime.datetime.strptime(row.get('schedule_interval'), "%H:%M:%S")
-                interval = datetime.timedelta(hours=s_interval.hour, minutes=s_interval.minute,
+                if 'days' in row.get('schedule_interval'):
+                    interval_split = row.get('schedule_interval').split('days')
+                    interval_days = interval_split[0].strip()
+                    interval_time = interval_split[1].strip()
+                elif 'day' in row.get('schedule_interval'):
+                    interval_split = row.get('schedule_interval').split('day')
+                    interval_days = interval_split[0].strip()
+                    interval_time = interval_split[1].strip()
+                else:
+                    interval_days = 0
+                    interval_time = row.get('schedule_interval')
+                s_interval = datetime.datetime.strptime(interval_time, "%H:%M:%S")
+                interval = datetime.timedelta(hours=s_interval.hour+(int(interval_days)*24), minutes=s_interval.minute,
                                               seconds=s_interval.second)
 
                 repeat_seconds = None

--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -681,7 +681,7 @@ class Scheduler(object):
                     id=schedule_id,
                     name=row.get('schedule_name'),
                     type=int(row.get('schedule_type')),
-                    day=int(row.get('schedule_day')) if row.get('schedule_day').strip() else 0,
+                    day=int(row.get('schedule_day')) if row.get('schedule_day').strip() else None,
                     time=schedule_time,
                     repeat=interval,
                     repeat_seconds=repeat_seconds,
@@ -1087,7 +1087,7 @@ class Scheduler(object):
             await audit.information('SCHAD', {'schedule': schedule.toDict()})
 
         repeat_seconds = None
-        if schedule.repeat is not None:
+        if schedule.repeat is not None and schedule.repeat != datetime.timedelta(0):
             repeat_seconds = schedule.repeat.total_seconds()
 
         schedule_row = self._ScheduleRow(

--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -667,7 +667,7 @@ class Scheduler(object):
                                               seconds=s_interval.second)
 
                 repeat_seconds = None
-                if interval is not None:
+                if interval is not None and interval != datetime.timedelta(0):
                     repeat_seconds = interval.total_seconds()
 
                 s_ti = row.get('schedule_time') if row.get('schedule_time') else '00:00:00'

--- a/tests/unit/python/foglamp/services/core/scheduler/test_scheduler.py
+++ b/tests/unit/python/foglamp/services/core/scheduler/test_scheduler.py
@@ -238,7 +238,7 @@ class TestScheduler:
 
         current_time = time.time()
         mocker.patch.multiple(scheduler, _max_running_tasks=10,
-                              _start_time=current_time - 3600)
+                              _start_time=current_time)
         await scheduler._get_schedules()
         mocker.patch.object(scheduler, '_start_task', return_value=asyncio.ensure_future(mock_task()))
 
@@ -247,6 +247,7 @@ class TestScheduler:
 
         # THEN
         assert earliest_start_time is not None
+        print(log_info.call_args_list)
         assert 3 == log_info.call_count
         args0, kwargs0 = log_info.call_args_list[0]
         args1, kwargs1 = log_info.call_args_list[1]
@@ -270,7 +271,7 @@ class TestScheduler:
 
         current_time = time.time()
         mocker.patch.multiple(scheduler, _max_running_tasks=10,
-                              _start_time=current_time - 3600)
+                              _start_time=current_time)
         await scheduler._get_schedules()
 
         sch_id = uuid.UUID("2176eb68-7303-11e7-8cf7-a6006ad3dba0")  # stat collector
@@ -304,7 +305,7 @@ class TestScheduler:
 
         current_time = time.time()
         mocker.patch.multiple(scheduler, _max_running_tasks=10,
-                              _start_time=current_time - 3600)
+                              _start_time=current_time-3600)
         await scheduler._get_schedules()
 
         sch_id = uuid.UUID("2176eb68-7303-11e7-8cf7-a6006ad3dba0")  # stat collector
@@ -326,6 +327,8 @@ class TestScheduler:
         assert 'stats collection' in args0
         assert 'COAP listener south' in args1
         assert 'OMF to PI north' in args2
+        # As part of scheduler._get_schedules(), scheduler._schedule_first_task() also gets executed, hence
+        # "stat collector" appears twice in this list.
         assert 'stats collection' in args3
 
     @pytest.mark.asyncio
@@ -339,7 +342,7 @@ class TestScheduler:
         current_time = time.time()
         curr_time = datetime.datetime.fromtimestamp(current_time)
         mocker.patch.multiple(scheduler, _max_running_tasks=10,
-                              _start_time=current_time - 3600)
+                              _start_time=current_time)
         await scheduler._get_schedules()
 
         sch_id = uuid.UUID("2176eb68-7303-11e7-8cf7-a6006ad3dba0")  # stat collector
@@ -360,6 +363,8 @@ class TestScheduler:
         assert 'stats collection' in args0
         assert 'COAP listener south' in args1
         assert 'OMF to PI north' in args2
+        # As part of scheduler._get_schedules(), scheduler._schedule_first_task() also gets executed, hence
+        # "stat collector" appears twice in this list.
         assert 'stats collection' in args3
 
     @pytest.mark.asyncio

--- a/tests/unit/python/foglamp/services/core/scheduler/test_scheduler.py
+++ b/tests/unit/python/foglamp/services/core/scheduler/test_scheduler.py
@@ -1308,7 +1308,7 @@ class MockStorage(StorageClient):
             "process_name": "North Readings to OCS",
             "schedule_name": "OMF to OCS north",
             "schedule_type": "3",
-            "schedule_interval": "00:00:30",
+            "schedule_interval": "1 day 00:00:40",
             "schedule_time": "",
             "schedule_day": "",
             "exclusive": "t",

--- a/tests/unit/python/foglamp/services/core/scheduler/test_scheduler.py
+++ b/tests/unit/python/foglamp/services/core/scheduler/test_scheduler.py
@@ -247,7 +247,6 @@ class TestScheduler:
 
         # THEN
         assert earliest_start_time is not None
-        print(log_info.call_args_list)
         assert 3 == log_info.call_count
         args0, kwargs0 = log_info.call_args_list[0]
         args1, kwargs1 = log_info.call_args_list[1]


### PR DESCRIPTION
Test suite result:
```
tests/unit/python/foglamp/services/core/scheduler/test_scheduler.py ......s........s...........s..............s......s       [ 88%]
============================================= 746 passed, 11 skipped in 37.92 seconds ==============================================

```