### PR TITLE
FOGL-1196 fixed issue when create support bundle requested with https

### DIFF
--- a/python/foglamp/services/core/support.py
+++ b/python/foglamp/services/core/support.py
@@ -152,7 +152,8 @@ class SupportBuilder:
         temp_file = self._interim_file_path + "/" + "service_registry-{}".format(file_spec)
         loop = asyncio.get_event_loop() if loop is None else loop
         url_ping = self._base_url+'/service'
-        async with aiohttp.ClientSession(loop=loop) as session:
+        connector = aiohttp.TCPConnector(verify_ssl=False)
+        async with aiohttp.ClientSession(loop=loop, connector=connector) as session:
             async with session.get(url_ping) as resp:
                 r = await resp.json()
                 data = {


### PR DESCRIPTION
service registry records are being fetched via client session to internal REST interface, hence client should be able to communicate via https scheme (and when using self signed  certificate,  we should make verify ssl false)