### PR TITLE
FOGL-1189 - handle Ping route based on allowPing=>True config

### DIFF
--- a/python/foglamp/common/web/middleware.py
+++ b/python/foglamp/common/web/middleware.py
@@ -77,7 +77,6 @@ async def auth_middleware(app, handler):
             except (jwt.DecodeError, jwt.ExpiredSignatureError) as e:
                 raise web.HTTPUnauthorized(reason=e)
         else:
-            # TODO: bypass ping route based on allowPing=>True
             if str(handler).startswith("<function ping"):
                 pass
             elif str(handler).startswith("<function login"):

--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -48,7 +48,7 @@ async def ping(request):
     except AttributeError:
         cfg_mgr = ConfigurationManager(connect.get_storage())
         category_item = await cfg_mgr.get_category_item('rest_api', 'allowPing')
-        allow_ping = True if category_item['value'] == 'true' else False
+        allow_ping = True if category_item['value'].lower() == 'true' else False
         if request.is_auth_optional is False and allow_ping is False:
             raise web.HTTPForbidden
 

--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -46,10 +46,10 @@ async def ping(request):
     try:
         auth_token = request.token
     except AttributeError:
-        cf_mgr = ConfigurationManager(connect.get_storage())
-        category_item = await cf_mgr.get_category_item('rest_api', 'allowPing')
-        allowPing = True if category_item['value'] == 'true' else False
-        if request.is_auth_optional is False and allowPing is False:
+        cfg_mgr = ConfigurationManager(connect.get_storage())
+        category_item = await cfg_mgr.get_category_item('rest_api', 'allowPing')
+        allow_ping = True if category_item['value'] == 'true' else False
+        if request.is_auth_optional is False and allow_ping is False:
             raise web.HTTPForbidden
 
     def get_stats(k):

--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -11,6 +11,8 @@ from foglamp.common import logger
 from aiohttp import web
 from foglamp.services.core import server
 from foglamp.services.core.api.statistics import get_statistics
+from foglamp.services.core import connect
+from foglamp.common.configuration_manager import ConfigurationManager
 
 __author__ = "Amarendra K. Sinha, Ashish Jabble"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -40,6 +42,15 @@ async def ping(request):
     :Example:
            curl -X GET http://localhost:8081/foglamp/ping
     """
+
+    try:
+        auth_token = request.token
+    except AttributeError:
+        cf_mgr = ConfigurationManager(connect.get_storage())
+        category_item = await cf_mgr.get_category_item('rest_api', 'allowPing')
+        allowPing = True if category_item['value'] == 'true' else False
+        if request.is_auth_optional is False and allowPing is False:
+            raise web.HTTPForbidden
 
     def get_stats(k):
         v = [a['value'] for a in stats if a['key'] == k]

--- a/tests/unit/python/foglamp/services/core/api/test_common_ping.py
+++ b/tests/unit/python/foglamp/services/core/api/test_common_ping.py
@@ -23,11 +23,15 @@ from foglamp.services.core import routes
 from foglamp.services.core import connect
 from foglamp.common.web import middleware
 from foglamp.common.storage_client.storage_client import StorageClient
+from foglamp.common.configuration_manager import ConfigurationManager
 
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
-async def test_ping_http(test_server, test_client, loop):
+async def test_ping_http_allow_ping_true(test_server, test_client, loop):
+    async def mock_get_category_item(self, category_name, item_name):
+        return {"value": "true"}
+
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
     result = {"rows": [
                 {"value": 1, "key": "PURGED", "description": "blah6"},
@@ -42,33 +46,82 @@ async def test_ping_http(test_server, test_client, loop):
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
-                # fill route table
-                routes.setup(app)
+                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                    app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
+                    # fill route table
+                    routes.setup(app)
 
-                server = await test_server(app)
-                server.start_server(loop=loop)
+                    server = await test_server(app)
+                    server.start_server(loop=loop)
 
-                client = await test_client(server)
-                # note: If the parameter is app aiohttp.web.Application
-                # the tool creates TestServer implicitly for serving the application.
-                resp = await client.get('/foglamp/ping', headers={'authorization': "token"})
-                assert 200 == resp.status
-                content = await resp.text()
-                content_dict = json.loads(content)
-                assert 0.0 < content_dict["uptime"]
-                assert 2 == content_dict["dataRead"]
-                assert 18 == content_dict["dataSent"]
-                assert 1 == content_dict["dataPurged"]
-                assert content_dict["authenticationOptional"] is True
-        query_patch.assert_called_once_with('statistics', payload)
-    log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
-    logger_info.assert_called_once_with(*log_params)
+                    client = await test_client(server)
+                    # note: If the parameter is app aiohttp.web.Application
+                    # the tool creates TestServer implicitly for serving the application.
+                    resp = await client.get('/foglamp/ping', headers={'authorization': "token"})
+                    assert 200 == resp.status
+                    content = await resp.text()
+                    content_dict = json.loads(content)
+                    assert 0.0 < content_dict["uptime"]
+                    assert 2 == content_dict["dataRead"]
+                    assert 18 == content_dict["dataSent"]
+                    assert 1 == content_dict["dataPurged"]
+                    assert content_dict["authenticationOptional"] is True
+            query_patch.assert_called_once_with('statistics', payload)
+        log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
+        logger_info.assert_called_once_with(*log_params)
 
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
-async def test_ping_http_auth_required(test_server, test_client, loop):
+async def test_ping_http_allow_ping_false(test_server, test_client, loop):
+    async def mock_get_category_item(self, category_name, item_name):
+        return {"value": "false"}
+
+    payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
+    result = {"rows": [
+        {"value": 1, "key": "PURGED", "description": "blah6"},
+        {"value": 2, "key": "READINGS", "description": "blah1"},
+        {"value": 3, "key": "SENT_1", "description": "blah2"},
+        {"value": 4, "key": "SENT_2", "description": "blah3"},
+        {"value": 5, "key": "SENT_3", "description": "blah4"},
+        {"value": 6, "key": "SENT_4", "description": "blah5"},
+    ]}
+
+    mockedStorageClient = MagicMock(StorageClient)
+    with patch.object(middleware._logger, 'info') as logger_info:
+        with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
+            with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
+                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                    app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
+                    # fill route table
+                    routes.setup(app)
+
+                    server = await test_server(app)
+                    server.start_server(loop=loop)
+
+                    client = await test_client(server)
+                    # note: If the parameter is app aiohttp.web.Application
+                    # the tool creates TestServer implicitly for serving the application.
+                    resp = await client.get('/foglamp/ping', headers={'authorization': "token"})
+                    assert 200 == resp.status
+                    content = await resp.text()
+                    content_dict = json.loads(content)
+                    assert 0.0 < content_dict["uptime"]
+                    assert 2 == content_dict["dataRead"]
+                    assert 18 == content_dict["dataSent"]
+                    assert 1 == content_dict["dataPurged"]
+                    assert content_dict["authenticationOptional"] is True
+            query_patch.assert_called_once_with('statistics', payload)
+        log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
+        logger_info.assert_called_once_with(*log_params)
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("api", "common")
+async def test_ping_http_auth_required_allow_ping_true(test_server, test_client, loop):
+    async def mock_get_category_item(self, category_name, item_name):
+        return {"value": "true"}
+
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
     result = {"rows": [
                 {"value": 1, "key": "PURGED", "description": "blah6"},
@@ -83,29 +136,67 @@ async def test_ping_http_auth_required(test_server, test_client, loop):
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                app = web.Application(loop=loop, middlewares=[middleware.auth_middleware])
-                # fill route table
-                routes.setup(app)
+                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                    app = web.Application(loop=loop, middlewares=[middleware.auth_middleware])
+                    # fill route table
+                    routes.setup(app)
 
-                server = await test_server(app)
-                server.start_server(loop=loop)
+                    server = await test_server(app)
+                    server.start_server(loop=loop)
 
-                client = await test_client(server)
-                # note: If the parameter is app aiohttp.web.Application
-                # the tool creates TestServer implicitly for serving the application.
-                resp = await client.get('/foglamp/ping')
-                assert 200 == resp.status
-                content = await resp.text()
-                content_dict = json.loads(content)
-                assert 0.0 < content_dict["uptime"]
-                assert 2 == content_dict["dataRead"]
-                assert 18 == content_dict["dataSent"]
-                assert 1 == content_dict["dataPurged"]
-                assert content_dict["authenticationOptional"] is False
-        query_patch.assert_called_once_with('statistics', payload)
-    log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
-    logger_info.assert_called_once_with(*log_params)
+                    client = await test_client(server)
+                    # note: If the parameter is app aiohttp.web.Application
+                    # the tool creates TestServer implicitly for serving the application.
+                    resp = await client.get('/foglamp/ping')
+                    assert 200 == resp.status
+                    content = await resp.text()
+                    content_dict = json.loads(content)
+                    assert 0.0 < content_dict["uptime"]
+                    assert 2 == content_dict["dataRead"]
+                    assert 18 == content_dict["dataSent"]
+                    assert 1 == content_dict["dataPurged"]
+                    assert content_dict["authenticationOptional"] is False
+            query_patch.assert_called_once_with('statistics', payload)
+        log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
+        logger_info.assert_called_once_with(*log_params)
 
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("api", "common")
+async def test_ping_http_auth_required_allow_ping_false(test_server, test_client, loop):
+    async def mock_get_category_item(self, category_name, item_name):
+        return {"value": "false"}
+
+    payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
+    result = {"rows": [
+        {"value": 1, "key": "PURGED", "description": "blah6"},
+        {"value": 2, "key": "READINGS", "description": "blah1"},
+        {"value": 3, "key": "SENT_1", "description": "blah2"},
+        {"value": 4, "key": "SENT_2", "description": "blah3"},
+        {"value": 5, "key": "SENT_3", "description": "blah4"},
+        {"value": 6, "key": "SENT_4", "description": "blah5"},
+    ]}
+
+    mockedStorageClient = MagicMock(StorageClient)
+    with patch.object(middleware._logger, 'info') as logger_info:
+        with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
+            with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
+                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                    app = web.Application(loop=loop, middlewares=[middleware.auth_middleware])
+                    # fill route table
+                    routes.setup(app)
+
+                    server = await test_server(app)
+                    server.start_server(loop=loop)
+
+                    client = await test_client(server)
+                    # note: If the parameter is app aiohttp.web.Application
+                    # the tool creates TestServer implicitly for serving the application.
+                    resp = await client.get('/foglamp/ping')
+                    assert 403 == resp.status
+            assert 0 == query_patch.call_count
+        log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
+        logger_info.assert_called_once_with(*log_params)
 
 @pytest.fixture
 def certs_path():
@@ -123,7 +214,10 @@ def ssl_ctx(certs_path):
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
-async def test_ping_https(test_server, ssl_ctx, test_client, loop):
+async def test_ping_https_allow_ping_true(test_server, ssl_ctx, test_client, loop):
+    async def mock_get_category_item(self, category_name, item_name):
+        return {"value": "true"}
+
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
     result = {"rows": [
                 {"value": 1, "key": "PURGED", "description": "blah6"},
@@ -138,58 +232,125 @@ async def test_ping_https(test_server, ssl_ctx, test_client, loop):
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
-                # fill route table
-                routes.setup(app)
+                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                    app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
+                    # fill route table
+                    routes.setup(app)
 
-                server = await test_server(app, ssl=ssl_ctx)
-                server.start_server(loop=loop)
+                    server = await test_server(app, ssl=ssl_ctx)
+                    server.start_server(loop=loop)
 
-                url = 'https://127.0.0.1:{}/foglamp/ping'.format(server.port)
-                async with aiohttp.ClientSession(loop=loop) as session:
-                    async with session.get(url, verify_ssl=False) as resp:
-                        assert 200 == resp.status
-                        content = await resp.text()
-                        content_dict = json.loads(content)
-                        assert 0.0 < content_dict["uptime"]
+                    url = 'https://127.0.0.1:{}/foglamp/ping'.format(server.port)
+                    async with aiohttp.ClientSession(loop=loop) as session:
+                        async with session.get(url, verify_ssl=False) as resp:
+                            assert 200 == resp.status
+                            content = await resp.text()
+                            content_dict = json.loads(content)
+                            assert 0.0 < content_dict["uptime"]
 
-                with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
-                    client = await test_client(server)
-                    resp = await client.get('/foglamp/ping')
-                assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
+                    with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
+                        client = await test_client(server)
+                        resp = await client.get('/foglamp/ping')
+                    assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
 
-                with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
-                    # self signed certificate,
-                    # and we are not using SSL context here for client as verifier
-                    connector = aiohttp.TCPConnector(verify_ssl=True, loop=loop)
+                    with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
+                        # self signed certificate,
+                        # and we are not using SSL context here for client as verifier
+                        connector = aiohttp.TCPConnector(verify_ssl=True, loop=loop)
+                        client = await test_client(server, connector=connector)
+                        await client.get('/foglamp/ping')
+                    assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
+
+                    connector = aiohttp.TCPConnector(verify_ssl=False, loop=loop)
                     client = await test_client(server, connector=connector)
-                    await client.get('/foglamp/ping')
-                assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
-
-                connector = aiohttp.TCPConnector(verify_ssl=False, loop=loop)
-                client = await test_client(server, connector=connector)
-                resp = await client.get('/foglamp/ping')
-                s = resp.request_info.url.human_repr()
-                assert "https" == s[:5]
-                assert 200 == resp.status
-                content = await resp.text()
-                content_dict = json.loads(content)
-                assert 0.0 < content_dict["uptime"]
-                assert 2 == content_dict["dataRead"]
-                assert 18 == content_dict["dataSent"]
-                assert 1 == content_dict["dataPurged"]
-                assert content_dict["authenticationOptional"] is True
-        calls = [call('statistics', payload),
-                 call('statistics', payload)]
-        query_patch.assert_has_calls(calls)
-    calls = [call('Received %s request for %s', 'GET', '/foglamp/ping'),
-             call('Received %s request for %s', 'GET', '/foglamp/ping')]
-    logger_info.assert_has_calls(calls)
+                    resp = await client.get('/foglamp/ping')
+                    s = resp.request_info.url.human_repr()
+                    assert "https" == s[:5]
+                    assert 200 == resp.status
+                    content = await resp.text()
+                    content_dict = json.loads(content)
+                    assert 0.0 < content_dict["uptime"]
+                    assert 2 == content_dict["dataRead"]
+                    assert 18 == content_dict["dataSent"]
+                    assert 1 == content_dict["dataPurged"]
+                    assert content_dict["authenticationOptional"] is True
+            calls = [call('statistics', payload),
+                     call('statistics', payload)]
+            query_patch.assert_has_calls(calls)
+        calls = [call('Received %s request for %s', 'GET', '/foglamp/ping'),
+                 call('Received %s request for %s', 'GET', '/foglamp/ping')]
+        logger_info.assert_has_calls(calls)
 
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
-async def test_ping_https_auth_required(test_server, ssl_ctx, test_client, loop):
+async def test_ping_https_allow_ping_false(test_server, ssl_ctx, test_client, loop):
+    async def mock_get_category_item(self, category_name, item_name):
+        return {"value": "false"}
+
+    payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
+    result = {"rows": [
+        {"value": 1, "key": "PURGED", "description": "blah6"},
+        {"value": 2, "key": "READINGS", "description": "blah1"},
+        {"value": 3, "key": "SENT_1", "description": "blah2"},
+        {"value": 4, "key": "SENT_2", "description": "blah3"},
+        {"value": 5, "key": "SENT_3", "description": "blah4"},
+        {"value": 6, "key": "SENT_4", "description": "blah5"},
+    ]}
+
+    mockedStorageClient = MagicMock(StorageClient)
+    with patch.object(middleware._logger, 'info') as logger_info:
+        with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
+            with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
+                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                    app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
+                    # fill route table
+                    routes.setup(app)
+
+                    server = await test_server(app, ssl=ssl_ctx)
+                    server.start_server(loop=loop)
+
+                    url = 'https://127.0.0.1:{}/foglamp/ping'.format(server.port)
+                    async with aiohttp.ClientSession(loop=loop) as session:
+                        async with session.get(url, verify_ssl=False) as resp:
+                            assert 200 == resp.status
+                            content = await resp.text()
+                            content_dict = json.loads(content)
+                            assert 0.0 < content_dict["uptime"]
+
+                    with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
+                        client = await test_client(server)
+                        resp = await client.get('/foglamp/ping')
+                    assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
+
+                    with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
+                        # self signed certificate,
+                        # and we are not using SSL context here for client as verifier
+                        connector = aiohttp.TCPConnector(verify_ssl=True, loop=loop)
+                        client = await test_client(server, connector=connector)
+                        await client.get('/foglamp/ping')
+                    assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
+
+                    connector = aiohttp.TCPConnector(verify_ssl=False, loop=loop)
+                    client = await test_client(server, connector=connector)
+                    resp = await client.get('/foglamp/ping')
+                    s = resp.request_info.url.human_repr()
+                    assert "https" == s[:5]
+                    assert 200 == resp.status
+            calls = [call('statistics', payload),
+                     call('statistics', payload)]
+            query_patch.assert_has_calls(calls)
+        calls = [call('Received %s request for %s', 'GET', '/foglamp/ping'),
+                 call('Received %s request for %s', 'GET', '/foglamp/ping')]
+        logger_info.assert_has_calls(calls)
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("api", "common")
+async def test_ping_https_auth_required_allow_ping_true(test_server, ssl_ctx, test_client, loop):
+    async def mock_get_category_item(self, category_name, item_name):
+        return {"value": "true"}
+
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
     result = {"rows": [
                 {"value": 1, "key": "PURGED", "description": "blah6"},
@@ -204,53 +365,112 @@ async def test_ping_https_auth_required(test_server, ssl_ctx, test_client, loop)
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                app = web.Application(loop=loop, middlewares=[middleware.auth_middleware])
-                # fill route table
-                routes.setup(app)
+                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                    app = web.Application(loop=loop, middlewares=[middleware.auth_middleware])
+                    # fill route table
+                    routes.setup(app)
 
-                server = await test_server(app, ssl=ssl_ctx)
-                server.start_server(loop=loop)
+                    server = await test_server(app, ssl=ssl_ctx)
+                    server.start_server(loop=loop)
 
-                url = 'https://127.0.0.1:{}/foglamp/ping'.format(server.port)
-                async with aiohttp.ClientSession(loop=loop) as session:
-                    async with session.get(url, verify_ssl=False) as resp:
-                        assert 200 == resp.status
-                        content = await resp.text()
-                        content_dict = json.loads(content)
-                        assert 0.0 < content_dict["uptime"]
+                    url = 'https://127.0.0.1:{}/foglamp/ping'.format(server.port)
+                    async with aiohttp.ClientSession(loop=loop) as session:
+                        async with session.get(url, verify_ssl=False) as resp:
+                            assert 200 == resp.status
+                            content = await resp.text()
+                            content_dict = json.loads(content)
+                            assert 0.0 < content_dict["uptime"]
 
-                with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
-                    client = await test_client(server)
-                    await client.get('/foglamp/ping')
-                assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
+                    with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
+                        client = await test_client(server)
+                        await client.get('/foglamp/ping')
+                    assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
 
-                with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
-                    # self signed certificate,
-                    # and we are not using SSL context here for client as verifier
-                    connector = aiohttp.TCPConnector(verify_ssl=True, loop=loop)
+                    with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
+                        # self signed certificate,
+                        # and we are not using SSL context here for client as verifier
+                        connector = aiohttp.TCPConnector(verify_ssl=True, loop=loop)
+                        client = await test_client(server, connector=connector)
+                        resp = await client.get('/foglamp/ping')
+                    assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
+
+                    connector = aiohttp.TCPConnector(verify_ssl=False, loop=loop)
                     client = await test_client(server, connector=connector)
                     resp = await client.get('/foglamp/ping')
-                assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
+                    s = resp.request_info.url.human_repr()
+                    assert "https" == s[:5]
+                    assert 200 == resp.status
+                    content = await resp.text()
+                    content_dict = json.loads(content)
+                    assert 0.0 < content_dict["uptime"]
+                    assert 2 == content_dict["dataRead"]
+                    assert 18 == content_dict["dataSent"]
+                    assert 1 == content_dict["dataPurged"]
+                    assert content_dict["authenticationOptional"] is False
+            calls = [call('statistics', payload),
+                     call('statistics', payload)]
+            query_patch.assert_has_calls(calls)
+        calls = [call('Received %s request for %s', 'GET', '/foglamp/ping'),
+                 call('Received %s request for %s', 'GET', '/foglamp/ping')]
+        logger_info.assert_has_calls(calls)
 
-                connector = aiohttp.TCPConnector(verify_ssl=False, loop=loop)
-                client = await test_client(server, connector=connector)
-                resp = await client.get('/foglamp/ping')
-                s = resp.request_info.url.human_repr()
-                assert "https" == s[:5]
-                assert 200 == resp.status
-                content = await resp.text()
-                content_dict = json.loads(content)
-                assert 0.0 < content_dict["uptime"]
-                assert 2 == content_dict["dataRead"]
-                assert 18 == content_dict["dataSent"]
-                assert 1 == content_dict["dataPurged"]
-                assert content_dict["authenticationOptional"] is False
-        calls = [call('statistics', payload),
-                 call('statistics', payload)]
-        query_patch.assert_has_calls(calls)
-    calls = [call('Received %s request for %s', 'GET', '/foglamp/ping'),
-             call('Received %s request for %s', 'GET', '/foglamp/ping')]
-    logger_info.assert_has_calls(calls)
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("api", "common")
+async def test_ping_https_auth_required_allow_ping_false(test_server, ssl_ctx, test_client, loop):
+    async def mock_get_category_item(self, category_name, item_name):
+        return {"value": "false"}
+
+    payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
+    result = {"rows": [
+                {"value": 1, "key": "PURGED", "description": "blah6"},
+                {"value": 2, "key": "READINGS", "description": "blah1"},
+                {"value": 3, "key": "SENT_1", "description": "blah2"},
+                {"value": 4, "key": "SENT_2", "description": "blah3"},
+                {"value": 5, "key": "SENT_3", "description": "blah4"},
+                {"value": 6, "key": "SENT_4", "description": "blah5"},
+               ]}
+
+    mockedStorageClient = MagicMock(StorageClient)
+    with patch.object(middleware._logger, 'info') as logger_info:
+        with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
+            with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
+                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                    app = web.Application(loop=loop, middlewares=[middleware.auth_middleware])
+                    # fill route table
+                    routes.setup(app)
+
+                    server = await test_server(app, ssl=ssl_ctx)
+                    server.start_server(loop=loop)
+
+                    url = 'https://127.0.0.1:{}/foglamp/ping'.format(server.port)
+                    async with aiohttp.ClientSession(loop=loop) as session:
+                        async with session.get(url, verify_ssl=False) as resp:
+                            assert 403 == resp.status
+
+                    with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
+                        client = await test_client(server)
+                        await client.get('/foglamp/ping')
+                    assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
+
+                    with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
+                        # self signed certificate,
+                        # and we are not using SSL context here for client as verifier
+                        connector = aiohttp.TCPConnector(verify_ssl=True, loop=loop)
+                        client = await test_client(server, connector=connector)
+                        resp = await client.get('/foglamp/ping')
+                    assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed" in str(error_exec)
+
+                    connector = aiohttp.TCPConnector(verify_ssl=False, loop=loop)
+                    client = await test_client(server, connector=connector)
+                    resp = await client.get('/foglamp/ping')
+                    s = resp.request_info.url.human_repr()
+                    assert "https" == s[:5]
+                    assert 403 == resp.status
+            assert 0 == query_patch.call_count
+        calls = [call('Received %s request for %s', 'GET', '/foglamp/ping'),
+                 call('Received %s request for %s', 'GET', '/foglamp/ping')]
+        logger_info.assert_has_calls(calls)
 
 
 @pytest.allure.feature("unit")

--- a/tests/unit/python/foglamp/services/core/api/test_common_ping.py
+++ b/tests/unit/python/foglamp/services/core/api/test_common_ping.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 
 # FOGLAMP_BEGIN
@@ -12,6 +13,7 @@ These 2 def shall be tested via python/foglamp/services/core/server.py
 This test file assumes those 2 units are tested
 """
 
+import asyncio
 import json
 import ssl
 import pathlib
@@ -29,7 +31,7 @@ from foglamp.common.configuration_manager import ConfigurationManager
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
 async def test_ping_http_allow_ping_true(test_server, test_client, loop):
-    async def mock_get_category_item(self, category_name, item_name):
+    async def mock_get_category_item():
         return {"value": "true"}
 
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
@@ -46,7 +48,7 @@ async def test_ping_http_allow_ping_true(test_server, test_client, loop):
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
                     # fill route table
                     routes.setup(app)
@@ -66,6 +68,7 @@ async def test_ping_http_allow_ping_true(test_server, test_client, loop):
                     assert 18 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is True
+                mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
             query_patch.assert_called_once_with('statistics', payload)
         log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
         logger_info.assert_called_once_with(*log_params)
@@ -74,7 +77,7 @@ async def test_ping_http_allow_ping_true(test_server, test_client, loop):
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
 async def test_ping_http_allow_ping_false(test_server, test_client, loop):
-    async def mock_get_category_item(self, category_name, item_name):
+    async def mock_get_category_item():
         return {"value": "false"}
 
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
@@ -91,7 +94,7 @@ async def test_ping_http_allow_ping_false(test_server, test_client, loop):
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
                     # fill route table
                     routes.setup(app)
@@ -111,6 +114,7 @@ async def test_ping_http_allow_ping_false(test_server, test_client, loop):
                     assert 18 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is True
+                mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
             query_patch.assert_called_once_with('statistics', payload)
         log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
         logger_info.assert_called_once_with(*log_params)
@@ -119,7 +123,7 @@ async def test_ping_http_allow_ping_false(test_server, test_client, loop):
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
 async def test_ping_http_auth_required_allow_ping_true(test_server, test_client, loop):
-    async def mock_get_category_item(self, category_name, item_name):
+    async def mock_get_category_item():
         return {"value": "true"}
 
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
@@ -136,7 +140,7 @@ async def test_ping_http_auth_required_allow_ping_true(test_server, test_client,
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.auth_middleware])
                     # fill route table
                     routes.setup(app)
@@ -156,6 +160,7 @@ async def test_ping_http_auth_required_allow_ping_true(test_server, test_client,
                     assert 18 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is False
+                mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
             query_patch.assert_called_once_with('statistics', payload)
         log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
         logger_info.assert_called_once_with(*log_params)
@@ -164,7 +169,7 @@ async def test_ping_http_auth_required_allow_ping_true(test_server, test_client,
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
 async def test_ping_http_auth_required_allow_ping_false(test_server, test_client, loop):
-    async def mock_get_category_item(self, category_name, item_name):
+    async def mock_get_category_item():
         return {"value": "false"}
 
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
@@ -181,7 +186,7 @@ async def test_ping_http_auth_required_allow_ping_false(test_server, test_client
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.auth_middleware])
                     # fill route table
                     routes.setup(app)
@@ -194,6 +199,7 @@ async def test_ping_http_auth_required_allow_ping_false(test_server, test_client
                     # the tool creates TestServer implicitly for serving the application.
                     resp = await client.get('/foglamp/ping')
                     assert 403 == resp.status
+                mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
             assert 0 == query_patch.call_count
         log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
         logger_info.assert_called_once_with(*log_params)
@@ -215,7 +221,7 @@ def ssl_ctx(certs_path):
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
 async def test_ping_https_allow_ping_true(test_server, ssl_ctx, test_client, loop):
-    async def mock_get_category_item(self, category_name, item_name):
+    async def mock_get_category_item():
         return {"value": "true"}
 
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
@@ -232,21 +238,13 @@ async def test_ping_https_allow_ping_true(test_server, ssl_ctx, test_client, loo
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
                     # fill route table
                     routes.setup(app)
 
                     server = await test_server(app, ssl=ssl_ctx)
                     server.start_server(loop=loop)
-
-                    url = 'https://127.0.0.1:{}/foglamp/ping'.format(server.port)
-                    async with aiohttp.ClientSession(loop=loop) as session:
-                        async with session.get(url, verify_ssl=False) as resp:
-                            assert 200 == resp.status
-                            content = await resp.text()
-                            content_dict = json.loads(content)
-                            assert 0.0 < content_dict["uptime"]
 
                     with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
                         client = await test_client(server)
@@ -274,18 +272,15 @@ async def test_ping_https_allow_ping_true(test_server, ssl_ctx, test_client, loo
                     assert 18 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is True
-            calls = [call('statistics', payload),
-                     call('statistics', payload)]
-            query_patch.assert_has_calls(calls)
-        calls = [call('Received %s request for %s', 'GET', '/foglamp/ping'),
-                 call('Received %s request for %s', 'GET', '/foglamp/ping')]
-        logger_info.assert_has_calls(calls)
+                mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
+            query_patch.assert_called_once_with('statistics', payload)
+        logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/foglamp/ping')
 
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
 async def test_ping_https_allow_ping_false(test_server, ssl_ctx, test_client, loop):
-    async def mock_get_category_item(self, category_name, item_name):
+    async def mock_get_category_item():
         return {"value": "false"}
 
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
@@ -302,21 +297,13 @@ async def test_ping_https_allow_ping_false(test_server, ssl_ctx, test_client, lo
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
                     # fill route table
                     routes.setup(app)
 
                     server = await test_server(app, ssl=ssl_ctx)
                     server.start_server(loop=loop)
-
-                    url = 'https://127.0.0.1:{}/foglamp/ping'.format(server.port)
-                    async with aiohttp.ClientSession(loop=loop) as session:
-                        async with session.get(url, verify_ssl=False) as resp:
-                            assert 200 == resp.status
-                            content = await resp.text()
-                            content_dict = json.loads(content)
-                            assert 0.0 < content_dict["uptime"]
 
                     with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
                         client = await test_client(server)
@@ -337,18 +324,15 @@ async def test_ping_https_allow_ping_false(test_server, ssl_ctx, test_client, lo
                     s = resp.request_info.url.human_repr()
                     assert "https" == s[:5]
                     assert 200 == resp.status
-            calls = [call('statistics', payload),
-                     call('statistics', payload)]
-            query_patch.assert_has_calls(calls)
-        calls = [call('Received %s request for %s', 'GET', '/foglamp/ping'),
-                 call('Received %s request for %s', 'GET', '/foglamp/ping')]
-        logger_info.assert_has_calls(calls)
+                mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
+            query_patch.assert_called_once_with('statistics', payload)
+        logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/foglamp/ping')
 
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
 async def test_ping_https_auth_required_allow_ping_true(test_server, ssl_ctx, test_client, loop):
-    async def mock_get_category_item(self, category_name, item_name):
+    async def mock_get_category_item():
         return {"value": "true"}
 
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
@@ -365,21 +349,13 @@ async def test_ping_https_auth_required_allow_ping_true(test_server, ssl_ctx, te
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.auth_middleware])
                     # fill route table
                     routes.setup(app)
 
                     server = await test_server(app, ssl=ssl_ctx)
                     server.start_server(loop=loop)
-
-                    url = 'https://127.0.0.1:{}/foglamp/ping'.format(server.port)
-                    async with aiohttp.ClientSession(loop=loop) as session:
-                        async with session.get(url, verify_ssl=False) as resp:
-                            assert 200 == resp.status
-                            content = await resp.text()
-                            content_dict = json.loads(content)
-                            assert 0.0 < content_dict["uptime"]
 
                     with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
                         client = await test_client(server)
@@ -407,18 +383,15 @@ async def test_ping_https_auth_required_allow_ping_true(test_server, ssl_ctx, te
                     assert 18 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is False
-            calls = [call('statistics', payload),
-                     call('statistics', payload)]
-            query_patch.assert_has_calls(calls)
-        calls = [call('Received %s request for %s', 'GET', '/foglamp/ping'),
-                 call('Received %s request for %s', 'GET', '/foglamp/ping')]
-        logger_info.assert_has_calls(calls)
+                    mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
+                query_patch.assert_called_once_with('statistics', payload)
+            logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/foglamp/ping')
 
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "common")
 async def test_ping_https_auth_required_allow_ping_false(test_server, ssl_ctx, test_client, loop):
-    async def mock_get_category_item(self, category_name, item_name):
+    async def mock_get_category_item():
         return {"value": "false"}
 
     payload = '{"return": ["key", "description", "value"], "sort": {"column": "key", "direction": "asc"}}'
@@ -435,18 +408,13 @@ async def test_ping_https_auth_required_allow_ping_false(test_server, ssl_ctx, t
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage', return_value=mockedStorageClient):
             with patch.object(mockedStorageClient, 'query_tbl_with_payload', return_value=result) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", mock_get_category_item):
+                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.auth_middleware])
                     # fill route table
                     routes.setup(app)
 
                     server = await test_server(app, ssl=ssl_ctx)
                     server.start_server(loop=loop)
-
-                    url = 'https://127.0.0.1:{}/foglamp/ping'.format(server.port)
-                    async with aiohttp.ClientSession(loop=loop) as session:
-                        async with session.get(url, verify_ssl=False) as resp:
-                            assert 403 == resp.status
 
                     with pytest.raises(aiohttp.ClientConnectorSSLError) as error_exec:
                         client = await test_client(server)
@@ -467,10 +435,9 @@ async def test_ping_https_auth_required_allow_ping_false(test_server, ssl_ctx, t
                     s = resp.request_info.url.human_repr()
                     assert "https" == s[:5]
                     assert 403 == resp.status
+                mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
             assert 0 == query_patch.call_count
-        calls = [call('Received %s request for %s', 'GET', '/foglamp/ping'),
-                 call('Received %s request for %s', 'GET', '/foglamp/ping')]
-        logger_info.assert_has_calls(calls)
+        logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/foglamp/ping')
 
 
 @pytest.allure.feature("unit")


### PR DESCRIPTION
Test result:
`===================================================== 9 passed in 0.47 seconds =====================================================
`
Test suite result:
`============================================= 883 passed, 12 skipped in 42.10 seconds ==============================================
`
**Checklist:**
- [x] unit test modification

- [x] Works well on Raspbian with https + auth mandatory 

- [x] Works well  with https + auth optional

- [x] warning and error logs added

- [x]  proper HTTP status code added for raise