### PR TITLE
optional with forbidden for create, update, delete user & other enhancements

### DIFF
--- a/python/foglamp/services/core/api/auth.py
+++ b/python/foglamp/services/core/api/auth.py
@@ -43,6 +43,8 @@ PASSWORD_REGEX_PATTERN = '((?=.*\d)(?=.*[A-Z])(?=.*\W).{6,}$)'
 PASSWORD_ERROR_MSG = 'Password must contain at least one digit, one lowercase, one uppercase & one special character ' \
                      'and length of minimum 6 characters'
 
+FORBIDDEN_MSG = 'Resource you were trying to reach is absolutely forbidden for some reason'
+
 # TODO: remove me, use from roles table
 ADMIN_ROLE_ID = 1
 DEFAULT_ROLE_ID = 2
@@ -192,8 +194,11 @@ async def create_user(request):
         curl -H "authorization: <token>" -X POST -d '{"username": "any1", "password": "User@123"}' http://localhost:8081/foglamp/user
         curl -H "authorization: <token>" -X POST -d '{"username": "admin1", "password": "F0gl@mp!", "role_id": 1}' http://localhost:8081/foglamp/user
     """
+    if request.is_auth_optional:
+        _logger.warning(FORBIDDEN_MSG)
+        raise web.HTTPForbidden
+    
     data = await request.json()
-
     username = data.get('username')
     password = data.get('password')
     role_id = data.get('role_id', DEFAULT_ROLE_ID)
@@ -259,15 +264,12 @@ async def update_user(request):
         curl -H "authorization: <token>" -X PUT -d '{"password": "F0gl@mp!"}' http://localhost:8081/foglamp/user/<id>
         curl -H "authorization: <token>" -X PUT -d '{"role_id": 1, "password": "F0gl@mp!"}' http://localhost:8081/foglamp/user/<id>
     """
+    if request.is_auth_optional:
+        _logger.warning(FORBIDDEN_MSG)
+        raise web.HTTPForbidden
 
     # we don't have any user profile info yet, let's allow to update role or password only
     user_id = request.match_info.get('id')
-
-    if (request.is_auth_optional is True) and int(user_id) == 1:
-        msg = "Super admin user can not be updated"
-        _logger.warning(msg)
-        raise web.HTTPNotAcceptable(reason=msg)  # auth is optional
-
     data = await request.json()
     role_id = data.get('role_id')
     password = data.get('password')
@@ -285,7 +287,7 @@ async def update_user(request):
         _logger.warning(msg)
         raise web.HTTPUnauthorized(reason=msg)
 
-    if (request.is_auth_optional is False) and (int(user_id) == 1 and role_id):
+    if int(user_id) == 1 and role_id:
         msg = "Role updation restricted for Super Admin user"
         _logger.warning(msg)
         raise web.HTTPNotAcceptable(reason=msg)  # auth is mandatory
@@ -329,6 +331,10 @@ async def delete_user(request):
     :Example:
         curl -H "authorization: <token>" -X DELETE  http://localhost:8081/foglamp/user/1
     """
+    if request.is_auth_optional:
+        _logger.warning(FORBIDDEN_MSG)
+        raise web.HTTPForbidden
+
     # TODO: we should not prevent this, when we have at-least 1 admin (super) user
     try:
         user_id = int(request.match_info.get('id'))
@@ -342,11 +348,10 @@ async def delete_user(request):
         raise web.HTTPNotAcceptable(reason=msg)
 
     # Requester should not be able to delete her/himself
-    if request.is_auth_optional is False:
-        if user_id == request.user["id"]:
-            msg = "Only admin can disable or delete the account"
-            _logger.warning(msg)
-            raise web.HTTPBadRequest(reason=msg)
+    if user_id == request.user["id"]:
+        msg = "Only admin can disable or delete the account"
+        _logger.warning(msg)
+        raise web.HTTPBadRequest(reason=msg)
 
     check_authorization(request, user_id, "delete")
 

--- a/python/foglamp/services/core/api/auth.py
+++ b/python/foglamp/services/core/api/auth.py
@@ -347,6 +347,12 @@ async def delete_user(request):
         msg = "Super admin user can not be deleted"
         _logger.warning(msg)
         raise web.HTTPNotAcceptable(reason=msg)
+    
+    # Requester should not be able to delete her/himself
+    if user_id == request.user["id"]:
+        msg = "You can not delete your own account"
+        _logger.warning(msg)
+        raise web.HTTPBadRequest(reason=msg)
 
     try:
         result = User.Objects.delete(user_id)

--- a/python/foglamp/services/core/api/auth.py
+++ b/python/foglamp/services/core/api/auth.py
@@ -325,6 +325,7 @@ async def update_user(request):
     return web.json_response({'message': 'User with id:<{}> has been updated successfully'.format(user_id)})
 
 
+@has_permission("admin")
 async def delete_user(request):
     """ Delete a user from users table
 
@@ -346,14 +347,6 @@ async def delete_user(request):
         msg = "Super admin user can not be deleted"
         _logger.warning(msg)
         raise web.HTTPNotAcceptable(reason=msg)
-
-    # Requester should not be able to delete her/himself
-    if user_id == request.user["id"]:
-        msg = "Only admin can disable or delete the account"
-        _logger.warning(msg)
-        raise web.HTTPBadRequest(reason=msg)
-
-    check_authorization(request, user_id, "delete")
 
     try:
         result = User.Objects.delete(user_id)

--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -29,8 +29,8 @@ from foglamp.services.core.service_registry.service_registry import ServiceRegis
 from foglamp.services.core.service_registry import exceptions as service_registry_exceptions
 from foglamp.services.common import utils
 
-__author__ = "Terris Linenbach, Amarendra K Sinha"
-__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__author__ = "Terris Linenbach, Amarendra K Sinha, Massimiliano Pinto"
+__copyright__ = "Copyright (c) 2017-2018 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
@@ -677,11 +677,22 @@ class Scheduler(object):
 
                 schedule_id = uuid.UUID(row.get('id'))
 
+                #
+                # row.get('schedule_day') returns an int, say 0, from SQLite
+                # and "0", as a string, from Postgres
+                # We handle here this difference
+                #
+
+                if type(row.get('schedule_day')) is str:
+                    s_day = int(row.get('schedule_day')) if row.get('schedule_day').strip() else None
+                else:
+                    s_day = int(row.get('schedule_day'))
+
                 schedule = self._ScheduleRow(
                     id=schedule_id,
                     name=row.get('schedule_name'),
                     type=int(row.get('schedule_type')),
-                    day=int(row.get('schedule_day')) if row.get('schedule_day').strip() else None,
+                    day=s_day,
                     time=schedule_time,
                     repeat=interval,
                     repeat_seconds=repeat_seconds,

--- a/python/foglamp/services/core/user_model.py
+++ b/python/foglamp/services/core/user_model.py
@@ -27,7 +27,7 @@ __version__ = "${VERSION}"
 JWT_SECRET = 'f0gl@mp'
 JWT_ALGORITHM = 'HS256'
 JWT_EXP_DELTA_SECONDS = 30*60  # 30 minutes
-
+ERROR_MSG = 'Something went wrong'
 
 class User:
 
@@ -97,7 +97,7 @@ class User:
             except StorageServerError as ex:
                 if ex.error["retryable"]:
                     pass  # retry INSERT
-                raise ValueError(ex.error['message'])
+                raise ValueError(ERROR_MSG)
             return result
 
         @classmethod
@@ -124,7 +124,7 @@ class User:
             except StorageServerError as ex:
                 if ex.error["retryable"]:
                     pass  # retry INSERT
-                raise ValueError(ex.error['message'])
+                raise ValueError(ERROR_MSG)
             return result
 
         @classmethod
@@ -156,7 +156,7 @@ class User:
             except StorageServerError as ex:
                 if ex.error["retryable"]:
                     pass  # retry UPDATE
-                raise ValueError(ex.error['message'])
+                raise ValueError(ERROR_MSG)
             except Exception:
                 raise
 
@@ -283,7 +283,7 @@ class User:
             except StorageServerError as ex:
                 if ex.error["retryable"]:
                     pass  # retry INSERT
-                raise ValueError(ex.error['message'])
+                raise ValueError(ERROR_MSG)
 
             # TODO remove hard code role id to return is_admin info
             if int(found_user['role_id']) == 1:
@@ -300,7 +300,7 @@ class User:
             except StorageServerError as ex:
                 if not ex.error["retryable"]:
                     pass
-                raise ValueError(ex.error['message'])
+                raise ValueError(ERROR_MSG)
 
             return res
 
@@ -313,7 +313,7 @@ class User:
             except StorageServerError as ex:
                 if not ex.error["retryable"]:
                     pass
-                raise ValueError(ex.error['message'])
+                raise ValueError(ERROR_MSG)
 
             return res
 

--- a/tests/unit/python/foglamp/services/core/api/test_auth_mandatory.py
+++ b/tests/unit/python/foglamp/services/core/api/test_auth_mandatory.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+import json
+from unittest.mock import patch
+from aiohttp import web
+import pytest
+
+from foglamp.common.web import middleware
+from foglamp.services.core import routes
+from foglamp.services.core.user_model import User
+from foglamp.services.core.api import auth
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+HEADERS = {'content-type': 'application/json', 'Authorization': 'token'}
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("api", "auth-mandatory")
+class TestAuthMandatory:
+
+    @pytest.fixture
+    def client(self, loop, test_server, test_client):
+        app = web.Application(loop=loop,  middlewares=[middleware.auth_middleware])
+        # fill the routes table
+        routes.setup(app)
+        server = loop.run_until_complete(test_server(app))
+        server.start_server(loop=loop)
+        client = loop.run_until_complete(test_client(server))
+        return client
+
+    def auth_token_fixture(self, mocker):
+        user = {'id': '1', 'uname': 'admin', 'role_id': '1'}
+        patch_logger_info = mocker.patch.object(middleware._logger, 'info')
+        patch_validate_token = mocker.patch.object(User.Objects, 'validate_token', return_value=1)
+        patch_refresh_token = mocker.patch.object(User.Objects, 'refresh_token_expiry', return_value=None)
+        patch_user_get = mocker.patch.object(User.Objects, 'get', return_value=user)
+
+        return patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get
+
+    async def test_get_roles(self, client, mocker):
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+        with patch.object(User.Objects, 'get_roles', return_value=[]) as patch_user_role:
+            resp = await client.get('/foglamp/user/role', headers=HEADERS)
+            assert 200 == resp.status
+            r = await resp.text()
+            assert {'roles': []} == json.loads(r)
+        patch_user_role.assert_called_once_with()
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with('token')
+        patch_validate_token.assert_called_once_with('token')
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/foglamp/user/role')
+
+    @pytest.mark.parametrize("request_data", [
+        {},
+        {"invalid": 1},
+        {"role": 1},
+        {"pwd": "blah"},
+        {"role": 1, "pwd": 12}
+    ])
+    async def test_update_user_with_bad_data(self, client, mocker, request_data):
+        warn_msg = 'Nothing to update the user'
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+        with patch.object(auth._logger, 'warning') as patch_logger_warning:
+            resp = await client.put('/foglamp/user/2', data=json.dumps(request_data), headers=HEADERS)
+            assert 400 == resp.status
+            assert warn_msg == resp.reason
+        patch_logger_warning.assert_called_once_with(warn_msg)
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with('token')
+        patch_validate_token.assert_called_once_with('token')
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
+
+    @pytest.mark.parametrize("request_data", [
+        {'role_id': -3},
+        {'role_id': 'blah'},
+    ])
+    async def test_update_user_with_bad_role(self, client, mocker, request_data):
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+        with patch.object(auth, 'is_valid_role', return_value=False) as patch_role:
+            with patch.object(auth._logger, 'warning') as patch_logger_warning:
+                resp = await client.put('/foglamp/user/2', data=json.dumps(request_data), headers=HEADERS)
+                assert 400 == resp.status
+                assert 'Invalid or bad role id' == resp.reason
+            patch_logger_warning.assert_called_once_with('Update user requested with bad role id')
+        patch_role.assert_called_once_with(request_data['role_id'])
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with('token')
+        patch_validate_token.assert_called_once_with('token')
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
+
+    @pytest.mark.parametrize("request_data", [
+        {'password': 1},
+        {'password': "blah"}
+    ])
+    async def test_update_bad_password(self, client, mocker, request_data):
+        msg = 'Password must contain at least one digit, one lowercase, one uppercase & one special character and length of minimum 6 characters'
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+        with patch.object(auth._logger, 'warning') as patch_logger_warning:
+            resp = await client.put('/foglamp/user/2', data=json.dumps(request_data), headers=HEADERS)
+            assert 400 == resp.status
+            assert msg == resp.reason
+        patch_logger_warning.assert_called_once_with(msg)
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with('token')
+        patch_validate_token.assert_called_once_with('token')
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
+
+    async def test_update_user(self, client, mocker):
+        ret_val = {'response': 'updated', 'rows_affected': 1}
+        user_id = 2
+        msg = 'User with id:<{}> has been updated successfully'.format(user_id)
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+        with patch.object(auth, 'check_authorization', return_value=True) as patch_check_authorization:
+            with patch.object(User.Objects, 'update', return_value=ret_val) as patch_user_update:
+                with patch.object(auth._logger, 'info') as patch_auth_logger_info:
+                    resp = await client.put('/foglamp/user/{}'.format(user_id),
+                                            data=json.dumps({'password': 'F0gl@mp'}), headers=HEADERS)
+                    assert 200 == resp.status
+                    r = await resp.text()
+                    assert {'message': msg} == json.loads(r)
+                patch_user_update.assert_called_once_with(str(user_id), {'password': 'F0gl@mp'})
+            patch_auth_logger_info.assert_called_once_with(msg)
+        # TODO: Request patch VERB and Url
+        args, kwargs = patch_check_authorization.call_args
+        assert str(user_id) == args[1]
+        assert 'update' == args[2]
+        # patch_check_authorization.assert_called_once_with()
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with('token')
+        patch_validate_token.assert_called_once_with('token')
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/{}'.format(user_id))
+
+    @pytest.mark.parametrize("exception_name, code, msg", [
+        (ValueError, 400, 'None'),
+        (User.DoesNotExist, 404, 'User with id:<2> does not exist')
+    ])
+    async def test_update_user_custom_exception(self, client, mocker, exception_name, code, msg):
+        user_id = 2
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+        with patch.object(auth, 'check_authorization', return_value=True) as patch_check_authorization:
+            with patch.object(User.Objects, 'update', side_effect=exception_name(msg)) as patch_user_update:
+                with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
+                    resp = await client.put('/foglamp/user/{}'.format(user_id), data=json.dumps({'password': 'F0gl@mp'}), headers=HEADERS)
+                    assert code == resp.status
+                    assert msg == resp.reason
+                patch_user_update.assert_called_once_with(str(user_id), {'password': 'F0gl@mp'})
+                patch_auth_logger_warn.assert_called_once_with(msg)
+        # TODO: Request patch VERB and Url
+        args, kwargs = patch_check_authorization.call_args
+        assert str(user_id) == args[1]
+        assert 'update' == args[2]
+        # patch_check_authorization.assert_called_once_with()
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with('token')
+        patch_validate_token.assert_called_once_with('token')
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/{}'.format(user_id))
+
+    async def test_update_user_exception(self, client, mocker):
+        user_id = 2
+        msg = 'Something went wrong'
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(auth, 'check_authorization', return_value=True) as patch_check_authorization:
+            with patch.object(User.Objects, 'update', side_effect=Exception(msg)) as patch_user_update:
+                with patch.object(auth._logger, 'exception') as patch_auth_logger_warn:
+                    resp = await client.put('/foglamp/user/{}'.format(user_id),
+                                            data=json.dumps({'password': 'F0gl@mp'}), headers=HEADERS)
+                    assert 500 == resp.status
+                    assert msg == resp.reason
+                patch_user_update.assert_called_once_with(str(user_id), {'password': 'F0gl@mp'})
+                patch_auth_logger_warn.assert_called_once_with(msg)
+        # TODO: Request patch VERB and Url
+        args, kwargs = patch_check_authorization.call_args
+        assert str(user_id) == args[1]
+        assert 'update' == args[2]
+        # patch_check_authorization.assert_called_once_with()
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with('token')
+        patch_validate_token.assert_called_once_with('token')
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/{}'.format(user_id))
+
+    async def test_logout_me(self, client, mocker):
+        ret_val = {'response': 'deleted', 'rows_affected': 1}
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(auth._logger, 'info') as patch_auth_logger_info:
+            with patch.object(User.Objects, 'delete_token', return_value=ret_val) as patch_delete_token:
+                resp = await client.put('/foglamp/logout', headers=HEADERS)
+                assert 200 == resp.status
+                r = await resp.text()
+                assert {'logout': True} == json.loads(r)
+            patch_delete_token.assert_called_once_with('token')
+        patch_auth_logger_info.assert_called_once_with('User has been logged out successfully')
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with('token')
+        patch_validate_token.assert_called_once_with('token')
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/logout')
+
+    async def test_logout_me_with_bad_token(self, client, mocker):
+        ret_val = {'response': 'deleted', 'rows_affected': 0}
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
+            with patch.object(User.Objects, 'delete_token', return_value=ret_val) as patch_delete_token:
+                resp = await client.put('/foglamp/logout', headers=HEADERS)
+                assert 404 == resp.status
+            patch_delete_token.assert_called_once_with('token')
+        patch_auth_logger_warn.assert_called_once_with('Logout requested with bad user token')
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with('token')
+        patch_validate_token.assert_called_once_with('token')
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/logout')
+
+    # TODO: create, update, delete, logout

--- a/tests/unit/python/foglamp/services/core/api/test_auth_mandatory.py
+++ b/tests/unit/python/foglamp/services/core/api/test_auth_mandatory.py
@@ -19,7 +19,8 @@ __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
-HEADERS = {'content-type': 'application/json', 'Authorization': 'token'}
+ADMIN_USER_HEADER = {'content-type': 'application/json', 'Authorization': 'admin_user_token'}
+NORMAL_USER_HEADER = {'content-type': 'application/json', 'Authorization': 'normal_user_token'}
 
 
 @pytest.allure.feature("unit")
@@ -36,27 +37,229 @@ class TestAuthMandatory:
         client = loop.run_until_complete(test_client(server))
         return client
 
-    def auth_token_fixture(self, mocker):
-        user = {'id': '1', 'uname': 'admin', 'role_id': '1'}
+    def auth_token_fixture(self, mocker, is_admin=True):
+        user = {'id': 1, 'uname': 'admin', 'role_id': '1'} if is_admin else {'id': 2, 'uname': 'user', 'role_id': '2'}
         patch_logger_info = mocker.patch.object(middleware._logger, 'info')
-        patch_validate_token = mocker.patch.object(User.Objects, 'validate_token', return_value=1)
+        patch_validate_token = mocker.patch.object(User.Objects, 'validate_token', return_value=user['id'])
         patch_refresh_token = mocker.patch.object(User.Objects, 'refresh_token_expiry', return_value=None)
         patch_user_get = mocker.patch.object(User.Objects, 'get', return_value=user)
 
         return patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get
 
-    async def test_get_roles(self, client, mocker):
+    @pytest.mark.parametrize("request_data", [
+        {},
+        {"username": 12},
+        {"password": 12},
+        {"username": "blah"},
+        {"password": "blah"},
+        {"invalid": "blah"},
+        {"username": "blah", "pwd": "blah"},
+        {"uname": "blah", "password": "blah"},
+    ])
+    async def test_create_bad_user(self, client, mocker, request_data):
         patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
-        with patch.object(User.Objects, 'get_roles', return_value=[]) as patch_user_role:
-            resp = await client.get('/foglamp/user/role', headers=HEADERS)
-            assert 200 == resp.status
-            r = await resp.text()
-            assert {'roles': []} == json.loads(r)
-        patch_user_role.assert_called_once_with()
+
+        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+            with patch.object(auth._logger, 'warning') as patch_logger_warn:
+                resp = await client.post('/foglamp/user', data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
+                assert 400 == resp.status
+                assert 'Username or password is missing' == resp.reason
+                patch_logger_warn.assert_called_once_with('Username and password are required to create user')
+        patch_role_id.assert_called_once_with('admin')
         patch_user_get.assert_called_once_with(uid=1)
-        patch_refresh_token.assert_called_once_with('token')
-        patch_validate_token.assert_called_once_with('token')
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/foglamp/user/role')
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
+
+    @pytest.mark.parametrize("request_data", [
+        {"username": "blah", "password": 1},
+        {"username": "blah", "password": "blah"}
+    ])
+    async def test_create_user_bad_password(self, client, mocker, request_data):
+        msg = 'Password must contain at least one digit, one lowercase, one uppercase & one special character and length of minimum 6 characters'
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+            with patch.object(auth._logger, 'warning') as patch_logger_warning:
+                resp = await client.post('/foglamp/user', data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
+                assert 400 == resp.status
+                assert msg == resp.reason
+            patch_logger_warning.assert_called_once_with(msg)
+        patch_role_id.assert_called_once_with('admin')
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
+
+    @pytest.mark.parametrize("request_data", [
+        {"username": "aj", "password": "F0gl@mp", "role_id": -3},
+        {"username": "aj", "password": "F0gl@mp", "role_id": "blah"}
+    ])
+    async def test_create_user_with_bad_role(self, client, mocker, request_data):
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+            with patch.object(auth, 'is_valid_role', return_value=False) as patch_role:
+                with patch.object(auth._logger, 'warning') as patch_logger_warning:
+                    resp = await client.post('/foglamp/user', data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
+                    assert 400 == resp.status
+                    assert 'Invalid or bad role id' == resp.reason
+                patch_logger_warning.assert_called_once_with('Create user requested with bad role id')
+            patch_role.assert_called_once_with(request_data['role_id'])
+        patch_role_id.assert_called_once_with('admin')
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
+
+    @pytest.mark.parametrize("request_data", [
+        {"username": "bla", "password": "F0gl@mp"},
+        {"username": "  b", "password": "F0gl@mp"},
+        {"username": "b  ", "password": "F0gl@mp"},
+        {"username": "  b la", "password": "F0gl@mp"},
+        {"username": "b l A  ", "password": "F0gl@mp"},
+        {"username": "Bla", "password": "F0gl@mp"},
+        {"username": "BLA", "password": "F0gl@mp"}
+    ])
+    async def test_create_user_bad_username(self, client, mocker, request_data):
+        msg = 'Username should be of minimum 4 characters'
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+            with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
+                with patch.object(auth._logger, 'warning') as patch_logger_warning:
+                    resp = await client.post('/foglamp/user', data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
+                    assert 400 == resp.status
+                    assert msg == resp.reason
+                patch_logger_warning.assert_called_once_with(msg)
+            patch_role.assert_called_once_with(2)
+        patch_role_id.assert_called_once_with('admin')
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
+
+    async def test_create_dupe_user_name(self, client):
+        request_data = {"username": "ajtest", "password": "F0gl@mp"}
+        valid_user = {'id': 1, 'uname': 'admin', 'role_id': '1'}
+        with patch.object(middleware._logger, 'info') as patch_logger_info:
+            with patch.object(User.Objects, 'validate_token', return_value=valid_user['id']) as patch_validate_token:
+                with patch.object(User.Objects, 'refresh_token_expiry', return_value=None) as patch_refresh_token:
+                    with patch.object(User.Objects, 'get', side_effect=[valid_user, {'role_id': '2', 'uname': 'ajtest', 'id': '2'}]) as patch_user_get:
+                        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+                            with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
+                                with patch.object(auth._logger, 'warning') as patch_logger_warning:
+                                    resp = await client.post('/foglamp/user', data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
+                                    assert 409 == resp.status
+                                    assert 'User with the requested username already exists' == resp.reason
+                                patch_logger_warning.assert_called_once_with('Can not create a user, username already exists')
+                            patch_role.assert_called_once_with(2)
+                        patch_role_id.assert_called_once_with('admin')
+                    assert 2 == patch_user_get.call_count
+                    args, kwargs = patch_user_get.call_args_list[0]
+                    assert {'uid': valid_user['id']} == kwargs
+                    args, kwargs = patch_user_get.call_args_list[1]
+                    assert {'username': request_data['username']} == kwargs
+                patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+            patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
+
+    async def test_create_user(self, client):
+        data = {'id': '3', 'uname': 'ajtest', 'role_id': '2'}
+        expected = {}
+        expected.update(data)
+        request_data = {"username": "ajtest", "password": "F0gl@mp"}
+        ret_val = {"response": "inserted", "rows_affected": 1}
+        msg = 'User has been created successfully'
+
+        valid_user = {'id': 1, 'uname': 'admin', 'role_id': '1'}
+        with patch.object(middleware._logger, 'info') as patch_logger_info:
+            with patch.object(User.Objects, 'validate_token', return_value=valid_user['id']) as patch_validate_token:
+                with patch.object(User.Objects, 'refresh_token_expiry', return_value=None) as patch_refresh_token:
+                    with patch.object(User.Objects, 'get', side_effect=[valid_user, User.DoesNotExist, data]) as patch_user_get:
+                        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+                            with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
+                                with patch.object(User.Objects, 'create', return_value=ret_val) as patch_create_user:
+                                    with patch.object(auth._logger, 'info') as patch_audit_logger_info:
+                                        resp = await client.post('/foglamp/user', data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
+                                        assert 200 == resp.status
+                                        r = await resp.text()
+                                        actual = json.loads(r)
+                                        assert msg == actual['message']
+                                        assert expected['id'] == actual['user']['userId']
+                                        assert expected['uname'] == actual['user']['userName']
+                                        assert expected['role_id'] == actual['user']['roleId']
+                                    patch_audit_logger_info.assert_called_once_with(msg)
+                                patch_create_user.assert_called_once_with(request_data['username'], request_data['password'], int(expected['role_id']))
+                            patch_role.assert_called_once_with(int(expected['role_id']))
+                        patch_role_id.assert_called_once_with('admin')
+                    assert 3 == patch_user_get.call_count
+                    args, kwargs = patch_user_get.call_args_list[0]
+                    assert {'uid': valid_user['id']} == kwargs
+                    args, kwargs = patch_user_get.call_args_list[1]
+                    assert {'username': request_data['username']} == kwargs
+                    args, kwargs = patch_user_get.call_args_list[2]
+                    assert {'username': expected['uname']} == kwargs
+                patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+            patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
+
+    async def test_create_user_exception(self, client):
+        request_data = {"username": "ajtest", "password": "F0gl@mp"}
+        exc_msg = "Something went wrong"
+        valid_user = {'id': 1, 'uname': 'admin', 'role_id': '1'}
+
+        with patch.object(middleware._logger, 'info') as patch_logger_info:
+            with patch.object(User.Objects, 'validate_token', return_value=valid_user['id']) as patch_validate_token:
+                with patch.object(User.Objects, 'refresh_token_expiry', return_value=None) as patch_refresh_token:
+                    with patch.object(User.Objects, 'get', side_effect=[valid_user, User.DoesNotExist]) as patch_user_get:
+                        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+                            with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
+                                with patch.object(User.Objects, 'create', side_effect=Exception(exc_msg)) as patch_create_user:
+                                    with patch.object(auth._logger, 'exception') as patch_audit_logger_exc:
+                                        resp = await client.post('/foglamp/user', data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
+                                        assert 500 == resp.status
+                                        assert exc_msg == resp.reason
+                                    patch_audit_logger_exc.assert_called_once_with(exc_msg)
+                                patch_create_user.assert_called_once_with(request_data['username'], request_data['password'], 2)
+                            patch_role.assert_called_once_with(2)
+                        patch_role_id.assert_called_once_with('admin')
+                assert 2 == patch_user_get.call_count
+                args, kwargs = patch_user_get.call_args_list[0]
+                assert {'uid': valid_user['id']} == kwargs
+                args, kwargs = patch_user_get.call_args_list[1]
+                assert {'username': request_data['username']} == kwargs
+                patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+            patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
+
+    async def test_create_user_value_error(self, client):
+        valid_user = {'id': 1, 'uname': 'admin', 'role_id': '1'}
+        request_data = {"username": "ajtest", "password": "F0gl@mp"}
+        exc_msg = "Value Error occurred"
+        with patch.object(middleware._logger, 'info') as patch_logger_info:
+            with patch.object(User.Objects, 'validate_token', return_value=valid_user['id']) as patch_validate_token:
+                with patch.object(User.Objects, 'refresh_token_expiry', return_value=None) as patch_refresh_token:
+                    with patch.object(User.Objects, 'get', side_effect=[valid_user, User.DoesNotExist]) as patch_user_get:
+                        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+                            with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
+                                with patch.object(User.Objects, 'create', side_effect=ValueError(exc_msg)) as patch_create_user:
+                                    with patch.object(auth._logger, 'warning') as patch_audit_logger_warn:
+                                        resp = await client.post('/foglamp/user', data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
+                                        assert 400 == resp.status
+                                        assert exc_msg == resp.reason
+                                    patch_audit_logger_warn.assert_called_once_with(exc_msg)
+                                patch_create_user.assert_called_once_with(request_data['username'], request_data['password'], 2)
+                            patch_role.assert_called_once_with(2)
+                        patch_role_id.assert_called_once_with('admin')
+                    assert 2 == patch_user_get.call_count
+                    args, kwargs = patch_user_get.call_args_list[0]
+                    assert {'uid': valid_user['id']} == kwargs
+                    args, kwargs = patch_user_get.call_args_list[1]
+                    assert {'username': request_data['username']} == kwargs
+                patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+            patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
 
     @pytest.mark.parametrize("request_data", [
         {},
@@ -69,13 +272,13 @@ class TestAuthMandatory:
         warn_msg = 'Nothing to update the user'
         patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
         with patch.object(auth._logger, 'warning') as patch_logger_warning:
-            resp = await client.put('/foglamp/user/2', data=json.dumps(request_data), headers=HEADERS)
+            resp = await client.put('/foglamp/user/2', data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
             assert 400 == resp.status
             assert warn_msg == resp.reason
         patch_logger_warning.assert_called_once_with(warn_msg)
         patch_user_get.assert_called_once_with(uid=1)
-        patch_refresh_token.assert_called_once_with('token')
-        patch_validate_token.assert_called_once_with('token')
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
 
     @pytest.mark.parametrize("request_data", [
@@ -86,14 +289,87 @@ class TestAuthMandatory:
         patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
         with patch.object(auth, 'is_valid_role', return_value=False) as patch_role:
             with patch.object(auth._logger, 'warning') as patch_logger_warning:
-                resp = await client.put('/foglamp/user/2', data=json.dumps(request_data), headers=HEADERS)
+                resp = await client.put('/foglamp/user/2', data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
                 assert 400 == resp.status
                 assert 'Invalid or bad role id' == resp.reason
             patch_logger_warning.assert_called_once_with('Update user requested with bad role id')
         patch_role.assert_called_once_with(request_data['role_id'])
         patch_user_get.assert_called_once_with(uid=1)
-        patch_refresh_token.assert_called_once_with('token')
-        patch_validate_token.assert_called_once_with('token')
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
+
+    @pytest.mark.parametrize("request_data", [
+        {'role_id': 1},
+        {'role_id': 2}
+    ])
+    async def test_update_role_with_normal_user(self, client, mocker, request_data):
+        msg = 'Only admin can update the role for a user'
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker, is_admin=False)
+
+        with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
+            with patch.object(auth, 'has_admin_permissions', return_value=False) as patch_admin_permission:
+                with patch.object(auth._logger, 'warning') as patch_logger_warning:
+                    resp = await client.put('/foglamp/user/2', data=json.dumps(request_data), headers=NORMAL_USER_HEADER)
+                    assert 401 == resp.status
+                    assert msg == resp.reason
+                patch_logger_warning.assert_called_once_with(msg)
+            # TODO: Request patch VERB and Url
+            # patch_admin_permission.assert_called_once_with()
+        patch_role.assert_called_once_with(request_data['role_id'])
+        patch_user_get.assert_called_once_with(uid=2)
+        patch_refresh_token.assert_called_once_with(NORMAL_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(NORMAL_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
+
+    async def test_update_admin_role(self, client, mocker):
+        msg = 'Role updation restricted for Super Admin user'
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
+            with patch.object(auth, 'has_admin_permissions', return_value=True) as patch_admin_permission:
+                with patch.object(auth._logger, 'warning') as patch_logger_warning:
+                    resp = await client.put('/foglamp/user/1', data=json.dumps({'role_id': 2}), headers=ADMIN_USER_HEADER)
+                    assert 406 == resp.status
+                    assert msg == resp.reason
+                patch_logger_warning.assert_called_once_with(msg)
+            # TODO: Request patch VERB and Url
+            # patch_admin_permission.assert_called_once_with()
+        patch_role.assert_called_once_with(2)
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/1')
+
+    async def test_update_role(self, client, mocker):
+        request_data = {'role_id': 2}
+        ret_val = {'response': 'updated', 'rows_affected': 1}
+        user_id = 2
+        msg = 'User with id:<{}> has been updated successfully'.format(user_id)
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
+            with patch.object(auth, 'has_admin_permissions', return_value=True) as patch_admin_permission:
+                with patch.object(auth, 'check_authorization', return_value=True) as patch_check_authorization:
+                    with patch.object(User.Objects, 'update', return_value=ret_val) as patch_user_update:
+                        with patch.object(auth._logger, 'info') as patch_auth_logger_info:
+                            resp = await client.put('/foglamp/user/{}'.format(user_id), data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
+                            assert 200 == resp.status
+                            r = await resp.text()
+                            assert {'message': msg} == json.loads(r)
+                        patch_auth_logger_info.assert_called_once_with(msg)
+                    patch_user_update.assert_called_once_with(str(user_id), request_data)
+                # patch_check_authorization.assert_called_once_with()
+                # TODO: Request patch VERB and Url
+                args, kwargs = patch_check_authorization.call_args
+                assert str(user_id) == args[1]
+                assert 'update' == args[2]
+            # TODO: Request patch VERB and Url
+            # patch_admin_permission.assert_called_once_with()
+        patch_role.assert_called_once_with(request_data['role_id'])
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
 
     @pytest.mark.parametrize("request_data", [
@@ -104,13 +380,13 @@ class TestAuthMandatory:
         msg = 'Password must contain at least one digit, one lowercase, one uppercase & one special character and length of minimum 6 characters'
         patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
         with patch.object(auth._logger, 'warning') as patch_logger_warning:
-            resp = await client.put('/foglamp/user/2', data=json.dumps(request_data), headers=HEADERS)
+            resp = await client.put('/foglamp/user/2', data=json.dumps(request_data), headers=ADMIN_USER_HEADER)
             assert 400 == resp.status
             assert msg == resp.reason
         patch_logger_warning.assert_called_once_with(msg)
         patch_user_get.assert_called_once_with(uid=1)
-        patch_refresh_token.assert_called_once_with('token')
-        patch_validate_token.assert_called_once_with('token')
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
 
     async def test_update_user(self, client, mocker):
@@ -121,8 +397,7 @@ class TestAuthMandatory:
         with patch.object(auth, 'check_authorization', return_value=True) as patch_check_authorization:
             with patch.object(User.Objects, 'update', return_value=ret_val) as patch_user_update:
                 with patch.object(auth._logger, 'info') as patch_auth_logger_info:
-                    resp = await client.put('/foglamp/user/{}'.format(user_id),
-                                            data=json.dumps({'password': 'F0gl@mp'}), headers=HEADERS)
+                    resp = await client.put('/foglamp/user/{}'.format(user_id), data=json.dumps({'password': 'F0gl@mp'}), headers=ADMIN_USER_HEADER)
                     assert 200 == resp.status
                     r = await resp.text()
                     assert {'message': msg} == json.loads(r)
@@ -134,8 +409,8 @@ class TestAuthMandatory:
         assert 'update' == args[2]
         # patch_check_authorization.assert_called_once_with()
         patch_user_get.assert_called_once_with(uid=1)
-        patch_refresh_token.assert_called_once_with('token')
-        patch_validate_token.assert_called_once_with('token')
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/{}'.format(user_id))
 
     @pytest.mark.parametrize("exception_name, code, msg", [
@@ -148,7 +423,7 @@ class TestAuthMandatory:
         with patch.object(auth, 'check_authorization', return_value=True) as patch_check_authorization:
             with patch.object(User.Objects, 'update', side_effect=exception_name(msg)) as patch_user_update:
                 with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
-                    resp = await client.put('/foglamp/user/{}'.format(user_id), data=json.dumps({'password': 'F0gl@mp'}), headers=HEADERS)
+                    resp = await client.put('/foglamp/user/{}'.format(user_id), data=json.dumps({'password': 'F0gl@mp'}), headers=ADMIN_USER_HEADER)
                     assert code == resp.status
                     assert msg == resp.reason
                 patch_user_update.assert_called_once_with(str(user_id), {'password': 'F0gl@mp'})
@@ -159,8 +434,8 @@ class TestAuthMandatory:
         assert 'update' == args[2]
         # patch_check_authorization.assert_called_once_with()
         patch_user_get.assert_called_once_with(uid=1)
-        patch_refresh_token.assert_called_once_with('token')
-        patch_validate_token.assert_called_once_with('token')
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/{}'.format(user_id))
 
     async def test_update_user_exception(self, client, mocker):
@@ -171,21 +446,128 @@ class TestAuthMandatory:
         with patch.object(auth, 'check_authorization', return_value=True) as patch_check_authorization:
             with patch.object(User.Objects, 'update', side_effect=Exception(msg)) as patch_user_update:
                 with patch.object(auth._logger, 'exception') as patch_auth_logger_warn:
-                    resp = await client.put('/foglamp/user/{}'.format(user_id),
-                                            data=json.dumps({'password': 'F0gl@mp'}), headers=HEADERS)
+                    resp = await client.put('/foglamp/user/{}'.format(user_id), data=json.dumps({'password': 'F0gl@mp'}), headers=ADMIN_USER_HEADER)
                     assert 500 == resp.status
                     assert msg == resp.reason
-                patch_user_update.assert_called_once_with(str(user_id), {'password': 'F0gl@mp'})
                 patch_auth_logger_warn.assert_called_once_with(msg)
+            patch_user_update.assert_called_once_with(str(user_id), {'password': 'F0gl@mp'})
         # TODO: Request patch VERB and Url
         args, kwargs = patch_check_authorization.call_args
         assert str(user_id) == args[1]
         assert 'update' == args[2]
         # patch_check_authorization.assert_called_once_with()
         patch_user_get.assert_called_once_with(uid=1)
-        patch_refresh_token.assert_called_once_with('token')
-        patch_validate_token.assert_called_once_with('token')
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/{}'.format(user_id))
+
+    @pytest.mark.parametrize("request_data", [
+        'blah',
+        '123blah'
+    ])
+    async def test_delete_bad_user(self, client, mocker, request_data):
+        msg = "invalid literal for int() with base 10: '{}'".format(request_data)
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+            with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
+                resp = await client.delete('/foglamp/user/{}'.format(request_data), headers=ADMIN_USER_HEADER)
+                assert 400 == resp.status
+                assert msg == resp.reason
+            patch_auth_logger_warn.assert_called_once_with(msg)
+        patch_role_id.assert_called_once_with('admin')
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'DELETE', '/foglamp/user/{}'.format(request_data))
+
+    async def test_delete_admin_user(self, client, mocker):
+        msg = "Super admin user can not be deleted"
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+            with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
+                    resp = await client.delete('/foglamp/user/1', headers=ADMIN_USER_HEADER)
+                    assert 406 == resp.status
+                    assert msg == resp.reason
+            patch_auth_logger_warn.assert_called_once_with(msg)
+        patch_role_id.assert_called_once_with('admin')
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'DELETE', '/foglamp/user/1')
+
+    async def test_delete_own_account(self, client, mocker):
+        msg = "You can not delete your own account"
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker, is_admin=False)
+        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '2'}]) as patch_role_id:
+            with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
+                    resp = await client.delete('/foglamp/user/2', headers=NORMAL_USER_HEADER)
+                    assert 400 == resp.status
+                    assert msg == resp.reason
+            patch_auth_logger_warn.assert_called_once_with(msg)
+        patch_role_id.assert_called_once_with('admin')
+        patch_user_get.assert_called_once_with(uid=2)
+        patch_refresh_token.assert_called_once_with(NORMAL_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(NORMAL_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'DELETE', '/foglamp/user/2')
+
+    async def test_delete_user(self, client, mocker):
+        ret_val = {"response": "deleted", "rows_affected": 1}
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+            with patch.object(auth._logger, 'info') as patch_auth_logger_info:
+                    with patch.object(User.Objects, 'delete', return_value=ret_val) as patch_user_delete:
+                        resp = await client.delete('/foglamp/user/2', headers=ADMIN_USER_HEADER)
+                        assert 200 == resp.status
+                        r = await resp.text()
+                        assert {'message': 'User has been deleted successfully'} == json.loads(r)
+                    patch_user_delete.assert_called_once_with(2)
+            patch_auth_logger_info.assert_called_once_with('User with id:<2> has been deleted successfully.')
+        patch_role_id.assert_called_once_with('admin')
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'DELETE', '/foglamp/user/2')
+
+    @pytest.mark.parametrize("exception_name, code, msg", [
+        (ValueError, 400, 'None'),
+        (User.DoesNotExist, 404, 'User with id:<2> does not exist')
+    ])
+    async def test_delete_user_custom_exception(self, client, mocker, exception_name, code, msg):
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+            with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
+                with patch.object(User.Objects, 'delete', side_effect=exception_name(msg)) as patch_user_delete:
+                    resp = await client.delete('/foglamp/user/2', headers=ADMIN_USER_HEADER)
+                    assert code == resp.status
+                    assert msg == resp.reason
+                patch_user_delete.assert_called_once_with(2)
+            patch_auth_logger_warn.assert_called_once_with(msg)
+        patch_role_id.assert_called_once_with('admin')
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'DELETE', '/foglamp/user/2')
+
+    async def test_delete_user_exception(self, client, mocker):
+        msg = 'Something went wrong'
+        patch_logger_info, patch_validate_token, patch_refresh_token, patch_user_get = self.auth_token_fixture(mocker)
+
+        with patch.object(User.Objects, 'get_role_id_by_name', return_value=[{'id': '1'}]) as patch_role_id:
+            with patch.object(auth._logger, 'exception') as patch_auth_logger_exc:
+                with patch.object(User.Objects, 'delete', side_effect=Exception(msg)) as patch_user_delete:
+                    resp = await client.delete('/foglamp/user/2', headers=ADMIN_USER_HEADER)
+                    assert 500 == resp.status
+                    assert msg == resp.reason
+                patch_user_delete.assert_called_once_with(2)
+            patch_auth_logger_exc.assert_called_once_with(msg)
+        patch_role_id.assert_called_once_with('admin')
+        patch_user_get.assert_called_once_with(uid=1)
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_logger_info.assert_called_once_with('Received %s request for %s', 'DELETE', '/foglamp/user/2')
 
     async def test_logout_me(self, client, mocker):
         ret_val = {'response': 'deleted', 'rows_affected': 1}
@@ -193,15 +575,15 @@ class TestAuthMandatory:
 
         with patch.object(auth._logger, 'info') as patch_auth_logger_info:
             with patch.object(User.Objects, 'delete_token', return_value=ret_val) as patch_delete_token:
-                resp = await client.put('/foglamp/logout', headers=HEADERS)
+                resp = await client.put('/foglamp/logout', headers=ADMIN_USER_HEADER)
                 assert 200 == resp.status
                 r = await resp.text()
                 assert {'logout': True} == json.loads(r)
-            patch_delete_token.assert_called_once_with('token')
+            patch_delete_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
         patch_auth_logger_info.assert_called_once_with('User has been logged out successfully')
         patch_user_get.assert_called_once_with(uid=1)
-        patch_refresh_token.assert_called_once_with('token')
-        patch_validate_token.assert_called_once_with('token')
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/logout')
 
     async def test_logout_me_with_bad_token(self, client, mocker):
@@ -210,13 +592,11 @@ class TestAuthMandatory:
 
         with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
             with patch.object(User.Objects, 'delete_token', return_value=ret_val) as patch_delete_token:
-                resp = await client.put('/foglamp/logout', headers=HEADERS)
+                resp = await client.put('/foglamp/logout', headers=ADMIN_USER_HEADER)
                 assert 404 == resp.status
-            patch_delete_token.assert_called_once_with('token')
+            patch_delete_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
         patch_auth_logger_warn.assert_called_once_with('Logout requested with bad user token')
         patch_user_get.assert_called_once_with(uid=1)
-        patch_refresh_token.assert_called_once_with('token')
-        patch_validate_token.assert_called_once_with('token')
+        patch_refresh_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
+        patch_validate_token.assert_called_once_with(ADMIN_USER_HEADER['Authorization'])
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/logout')
-
-    # TODO: create, update, delete, logout

--- a/tests/unit/python/foglamp/services/core/api/test_auth_optional.py
+++ b/tests/unit/python/foglamp/services/core/api/test_auth_optional.py
@@ -20,6 +20,10 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 
+FORBIDDEN = 'Forbidden'
+WARN_MSG = 'Resource you were trying to reach is absolutely forbidden for some reason'
+
+
 @pytest.allure.feature("unit")
 @pytest.allure.story("api", "auth-optional")
 class TestAuthOptional:
@@ -207,346 +211,32 @@ class TestAuthOptional:
             # patch_check_authorization.assert_called_once_with('<Request PUT /foglamp/1/logout >', '1', 'logout')
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/111/logout')
 
-    async def test_update_admin_user_without_authentication(self, client):
-        warn_msg = 'Super admin user can not be updated'
+    async def test_update_user(self, client):
         with patch.object(middleware._logger, 'info') as patch_logger_info:
             with patch.object(auth._logger, 'warning') as patch_logger_warning:
                 resp = await client.put('/foglamp/user/1')
-                assert 406 == resp.status
-                assert warn_msg == resp.reason
-            patch_logger_warning.assert_called_once_with(warn_msg)
+                assert 403 == resp.status
+                assert FORBIDDEN == resp.reason
+            patch_logger_warning.assert_called_once_with(WARN_MSG)
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/1')
 
-    @pytest.mark.parametrize("request_data", [
-        {},
-        {"invalid": 1},
-        {"role": 1},
-        {"pwd": "blah"},
-        {"role": 1, "pwd": 12}
-    ])
-    async def test_update_user_with_bad_data(self, client, request_data):
-        warn_msg = 'Nothing to update the user'
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth._logger, 'warning') as patch_logger_warning:
-                resp = await client.put('/foglamp/user/2', data=json.dumps(request_data))
-                assert 400 == resp.status
-                assert warn_msg == resp.reason
-            patch_logger_warning.assert_called_once_with(warn_msg)
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
-
-    @pytest.mark.parametrize("request_data", [
-        {'role_id': -3},
-        {'role_id': 'blah'},
-    ])
-    async def test_update_user_with_bad_role(self, client, request_data):
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth, 'is_valid_role', return_value=False) as patch_role:
-                with patch.object(auth._logger, 'warning') as patch_logger_warning:
-                    resp = await client.put('/foglamp/user/2', data=json.dumps(request_data))
-                    assert 400 == resp.status
-                    assert 'Invalid or bad role id' == resp.reason
-                patch_logger_warning.assert_called_once_with('Update user requested with bad role id')
-            patch_role.assert_called_once_with(request_data['role_id'])
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
-
-    @pytest.mark.parametrize("request_data", [
-        {'role_id': 1},
-        {'role_id': 2}
-    ])
-    async def test_update_role_with_normal_user(self, client, request_data):
-        msg = 'Only admin can update the role for a user'
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
-                with patch.object(auth, 'has_admin_permissions', return_value=False) as patch_admin_permission:
-                    with patch.object(auth._logger, 'warning') as patch_logger_warning:
-                        resp = await client.put('/foglamp/user/2', data=json.dumps(request_data))
-                        assert 401 == resp.status
-                        assert msg == resp.reason
-                    patch_logger_warning.assert_called_once_with(msg)
-                # TODO: Request patch VERB and Url
-                # patch_admin_permission.assert_called_once_with()
-            patch_role.assert_called_once_with(request_data['role_id'])
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
-
-    @pytest.mark.parametrize("request_data", [
-        {'password': 1},
-        {'password': "blah"}
-    ])
-    async def test_update_bad_password(self, client, request_data):
-        msg = 'Password must contain at least one digit, one lowercase, one uppercase & one special character and length of minimum 6 characters'
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth._logger, 'warning') as patch_logger_warning:
-                resp = await client.put('/foglamp/user/2', data=json.dumps(request_data))
-                assert 400 == resp.status
-                assert msg == resp.reason
-            patch_logger_warning.assert_called_once_with(msg)
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/2')
-
-    async def test_update_user(self, client):
-        ret_val = {'response': 'updated', 'rows_affected': 1}
-        user_id = 2
-        msg = 'User with id:<{}> has been updated successfully'.format(user_id)
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth, 'check_authorization', return_value=True) as patch_check_authorization:
-                with patch.object(User.Objects, 'update', return_value=ret_val) as patch_user_update:
-                    with patch.object(auth._logger, 'info') as patch_auth_logger_info:
-                        resp = await client.put('/foglamp/user/{}'.format(user_id), data=json.dumps({'password': 'F0gl@mp'}))
-                        assert 200 == resp.status
-                        r = await resp.text()
-                        assert {'message': msg} == json.loads(r)
-                    patch_user_update.assert_called_once_with(str(user_id), {'password': 'F0gl@mp'})
-                patch_auth_logger_info.assert_called_once_with(msg)
-            # TODO: Request patch VERB and Url
-            args, kwargs = patch_check_authorization.call_args
-            assert str(user_id) == args[1]
-            assert 'update' == args[2]
-            # patch_check_authorization.assert_called_once_with()
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/{}'.format(user_id))
-
-    @pytest.mark.parametrize("exception_name, code, msg", [
-        (ValueError, 400, 'None'),
-        (User.DoesNotExist, 404, 'User with id:<2> does not exist')
-    ])
-    async def test_update_user_custom_exception(self, client, exception_name, code, msg):
-        user_id = 2
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth, 'check_authorization', return_value=True) as patch_check_authorization:
-                with patch.object(User.Objects, 'update', side_effect=exception_name(msg)) as patch_user_update:
-                    with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
-                        resp = await client.put('/foglamp/user/{}'.format(user_id), data=json.dumps({'password': 'F0gl@mp'}))
-                        assert code == resp.status
-                        assert msg == resp.reason
-                    patch_user_update.assert_called_once_with(str(user_id), {'password': 'F0gl@mp'})
-                    patch_auth_logger_warn.assert_called_once_with(msg)
-            # TODO: Request patch VERB and Url
-            args, kwargs = patch_check_authorization.call_args
-            assert str(user_id) == args[1]
-            assert 'update' == args[2]
-            # patch_check_authorization.assert_called_once_with()
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/{}'.format(user_id))
-
-    async def test_update_user_exception(self, client):
-        user_id = 2
-        msg = 'Something went wrong'
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth, 'check_authorization', return_value=True) as patch_check_authorization:
-                with patch.object(User.Objects, 'update', side_effect=Exception(msg)) as patch_user_update:
-                    with patch.object(auth._logger, 'exception') as patch_auth_logger_warn:
-                        resp = await client.put('/foglamp/user/{}'.format(user_id), data=json.dumps({'password': 'F0gl@mp'}))
-                        assert 500 == resp.status
-                        assert msg == resp.reason
-                    patch_user_update.assert_called_once_with(str(user_id), {'password': 'F0gl@mp'})
-                    patch_auth_logger_warn.assert_called_once_with(msg)
-            # TODO: Request patch VERB and Url
-            args, kwargs = patch_check_authorization.call_args
-            assert str(user_id) == args[1]
-            assert 'update' == args[2]
-            # patch_check_authorization.assert_called_once_with()
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'PUT', '/foglamp/user/{}'.format(user_id))
-
-    @pytest.mark.parametrize("request_data", [
-        'blah',
-        '123blah'
-    ])
-    async def test_delete_bad_user(self, client, request_data):
-        msg = "invalid literal for int() with base 10: '{}'".format(request_data)
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
-                resp = await client.delete('/foglamp/user/{}'.format(request_data))
-                assert 400 == resp.status
-                assert msg == resp.reason
-            patch_auth_logger_warn.assert_called_once_with(msg)
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'DELETE', '/foglamp/user/{}'.format(request_data))
-
-    async def test_delete_admin_user(self, client):
-        msg = "Super admin user can not be deleted"
+    async def test_delete_user(self, client):
         with patch.object(middleware._logger, 'info') as patch_logger_info:
             with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
                 resp = await client.delete('/foglamp/user/1')
-                assert 406 == resp.status
-                assert msg == resp.reason
-            patch_auth_logger_warn.assert_called_once_with(msg)
+                assert 403 == resp.status
+                assert FORBIDDEN == resp.reason
+            patch_auth_logger_warn.assert_called_once_with(WARN_MSG)
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'DELETE', '/foglamp/user/1')
 
-    async def test_delete_user(self, client):
-        ret_val = {"response": "deleted", "rows_affected": 1}
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth._logger, 'info') as patch_auth_logger_info:
-                with patch.object(User.Objects, 'delete', return_value=ret_val) as patch_user_delete:
-                    resp = await client.delete('/foglamp/user/2')
-                    assert 200 == resp.status
-                    r = await resp.text()
-                    assert {'message': 'User has been deleted successfully'} == json.loads(r)
-                patch_user_delete.assert_called_once_with(2)
-            patch_auth_logger_info.assert_called_once_with('User with id:<2> has been deleted successfully.')
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'DELETE', '/foglamp/user/2')
-
-    @pytest.mark.parametrize("exception_name, code, msg", [
-        (ValueError, 400, 'None'),
-        (User.DoesNotExist, 404, 'User with id:<2> does not exist')
-    ])
-    async def test_delete_user_custom_exception(self, client, exception_name, code, msg):
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth._logger, 'warning') as patch_auth_logger_warn:
-                with patch.object(User.Objects, 'delete', side_effect=exception_name(msg)) as patch_user_delete:
-                    resp = await client.delete('/foglamp/user/2')
-                    assert code == resp.status
-                    assert msg == resp.reason
-                patch_user_delete.assert_called_once_with(2)
-            patch_auth_logger_warn.assert_called_once_with(msg)
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'DELETE', '/foglamp/user/2')
-
-    async def test_delete_user_exception(self, client):
-        msg = 'Something went wrong'
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth._logger, 'exception') as patch_auth_logger_exc:
-                with patch.object(User.Objects, 'delete', side_effect=Exception(msg)) as patch_user_delete:
-                    resp = await client.delete('/foglamp/user/2')
-                    assert 500 == resp.status
-                    assert msg == resp.reason
-                patch_user_delete.assert_called_once_with(2)
-            patch_auth_logger_exc.assert_called_once_with(msg)
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'DELETE', '/foglamp/user/2')
-
-    @pytest.mark.parametrize("request_data", [
-        {},
-        {"username": 12},
-        {"password": 12},
-        {"username": "blah"},
-        {"password": "blah"},
-        {"invalid": "blah"},
-        {"username": "blah", "pwd": "blah"},
-        {"uname": "blah", "password": "blah"},
-    ])
-    async def test_create_bad_user(self, client, request_data):
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth._logger, 'warning') as patch_logger_warn:
-                resp = await client.post('/foglamp/user', data=json.dumps(request_data))
-                assert 400 == resp.status
-                assert 'Username or password is missing' == resp.reason
-                patch_logger_warn.assert_called_once_with('Username and password are required to create user')
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
-
-    @pytest.mark.parametrize("request_data", [
-        {"username": "blah", "password": 1},
-        {"username": "blah", "password": "blah"}
-    ])
-    async def test_create_user_bad_password(self, client, request_data):
-        msg = 'Password must contain at least one digit, one lowercase, one uppercase & one special character and length of minimum 6 characters'
+    async def test_create_user(self, client):
+        request_data = {"username": "ajtest", "password": "F0gl@mp"}
         with patch.object(middleware._logger, 'info') as patch_logger_info:
             with patch.object(auth._logger, 'warning') as patch_logger_warning:
                 resp = await client.post('/foglamp/user', data=json.dumps(request_data))
-                assert 400 == resp.status
-                assert msg == resp.reason
-            patch_logger_warning.assert_called_once_with(msg)
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
-
-    @pytest.mark.parametrize("request_data", [
-        {"username": "aj", "password": "F0gl@mp", "role_id": -3},
-        {"username": "aj", "password": "F0gl@mp", "role_id": "blah"}
-    ])
-    async def test_create_user_with_bad_role(self, client, request_data):
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth, 'is_valid_role', return_value=False) as patch_role:
-                with patch.object(auth._logger, 'warning') as patch_logger_warning:
-                    resp = await client.post('/foglamp/user', data=json.dumps(request_data))
-                    assert 400 == resp.status
-                    assert 'Invalid or bad role id' == resp.reason
-                patch_logger_warning.assert_called_once_with('Create user requested with bad role id')
-            patch_role.assert_called_once_with(request_data['role_id'])
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
-
-    @pytest.mark.parametrize("request_data", [
-        {"username": "bla", "password": "F0gl@mp"},
-        {"username": "  b", "password": "F0gl@mp"},
-        {"username": "b  ", "password": "F0gl@mp"},
-        {"username": "  b la", "password": "F0gl@mp"},
-        {"username": "b l A  ", "password": "F0gl@mp"},
-        {"username": "Bla", "password": "F0gl@mp"},
-        {"username": "BLA", "password": "F0gl@mp"}
-    ])
-    async def test_create_user_bad_username(self, client, request_data):
-        msg = 'Username should be of minimum 4 characters'
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
-                with patch.object(auth._logger, 'warning') as patch_logger_warning:
-                    resp = await client.post('/foglamp/user', data=json.dumps(request_data))
-                    assert 400 == resp.status
-                    assert msg == resp.reason
-                patch_logger_warning.assert_called_once_with(msg)
-            patch_role.assert_called_once_with(2)
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
-
-    async def test_create_dupe_user_name(self, client):
-        request_data = {"username": "ajtest", "password": "F0gl@mp"}
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
-                with patch.object(User.Objects, 'get', return_value={'role_id': '2', 'uname': 'ajtest', 'id': '2'}) as patch_get_user:
-                    with patch.object(auth._logger, 'warning') as patch_logger_warning:
-                        resp = await client.post('/foglamp/user', data=json.dumps(request_data))
-                        assert 409 == resp.status
-                        assert 'User with the requested username already exists' == resp.reason
-                    patch_logger_warning.assert_called_once_with('Can not create a user, username already exists')
-                args, kwargs = patch_get_user.call_args
-                assert {'username': 'ajtest'} == kwargs
-            patch_role.assert_called_once_with(2)
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
-
-    async def test_create_user(self, client):
-        data = {'id': '3', 'uname': 'ajtest', 'role_id': '2'}
-        expected = {}
-        expected.update(data)
-        request_data = {"username": "ajtest", "password": "F0gl@mp"}
-        ret_val = {"response": "inserted", "rows_affected": 1}
-        msg = 'User has been created successfully'
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
-                with patch.object(User.Objects, 'get', side_effect=[User.DoesNotExist, data]):
-                    with patch.object(User.Objects, 'create', return_value=ret_val) as patch_create_user:
-                            with patch.object(auth._logger, 'info') as patch_audit_logger_info:
-                                resp = await client.post('/foglamp/user', data=json.dumps(request_data))
-                                assert 200 == resp.status
-                                r = await resp.text()
-                                actual = json.loads(r)
-                                assert msg == actual['message']
-                                assert expected['id'] == actual['user']['userId']
-                                assert expected['uname'] == actual['user']['userName']
-                                assert expected['role_id'] == actual['user']['roleId']
-                            patch_audit_logger_info.assert_called_once_with(msg)
-                    patch_create_user.assert_called_once_with(request_data['username'], request_data['password'], int(expected['role_id']))
-            patch_role.assert_called_once_with(int(expected['role_id']))
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
-
-    async def test_create_user_exception(self, client):
-        request_data = {"username": "ajtest", "password": "F0gl@mp"}
-        exc_msg = "Something went wrong"
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
-                with patch.object(User.Objects, 'get', side_effect=User.DoesNotExist):
-                    with patch.object(User.Objects, 'create', side_effect=Exception(exc_msg)) as patch_create_user:
-                        with patch.object(auth._logger, 'exception') as patch_audit_logger_exc:
-                            resp = await client.post('/foglamp/user', data=json.dumps(request_data))
-                            assert 500 == resp.status
-                            assert exc_msg == resp.reason
-                        patch_audit_logger_exc.assert_called_once_with(exc_msg)
-                    patch_create_user.assert_called_once_with(request_data['username'], request_data['password'], 2)
-            patch_role.assert_called_once_with(2)
-        patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
-
-    async def test_create_user_value_error(self, client):
-        request_data = {"username": "ajtest", "password": "F0gl@mp"}
-        exc_msg = "Value Error occurred"
-        with patch.object(middleware._logger, 'info') as patch_logger_info:
-            with patch.object(auth, 'is_valid_role', return_value=True) as patch_role:
-                with patch.object(User.Objects, 'get', side_effect=User.DoesNotExist):
-                    with patch.object(User.Objects, 'create', side_effect=ValueError(exc_msg)) as patch_create_user:
-                        with patch.object(auth._logger, 'warning') as patch_audit_logger_warn:
-                            resp = await client.post('/foglamp/user', data=json.dumps(request_data))
-                            assert 400 == resp.status
-                            assert exc_msg == resp.reason
-                        patch_audit_logger_warn.assert_called_once_with(exc_msg)
-                    patch_create_user.assert_called_once_with(request_data['username'], request_data['password'], 2)
-            patch_role.assert_called_once_with(2)
+                assert 403 == resp.status
+                assert FORBIDDEN == resp.reason
+            patch_logger_warning.assert_called_once_with(WARN_MSG)
         patch_logger_info.assert_called_once_with('Received %s request for %s', 'POST', '/foglamp/user')
 
     @pytest.mark.parametrize("role_id, expected", [

--- a/tests/unit/python/foglamp/services/core/test_user_model.py
+++ b/tests/unit/python/foglamp/services/core/test_user_model.py
@@ -140,7 +140,7 @@ class TestUserModel:
 
     def test_create_user_exception(self):
         hashed_password = "dd7171406eaf4baa8bc805857f719bca"
-        expected = {'message': 'ERROR: something went wrong', 'retryable': False, 'entryPoint': 'insert'}
+        expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'insert'}
         payload = '{"pwd": "dd7171406eaf4baa8bc805857f719bca", "role_id": 1, "uname": "aj"}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
@@ -177,7 +177,7 @@ class TestUserModel:
         assert str(excinfo.value) == 'Super admin user can not be deleted'
 
     def test_delete_user_exception(self):
-        expected = {'message': 'ERROR: something went wrong', 'retryable': False, 'entryPoint': 'delete'}
+        expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'delete'}
         payload = '{"values": {"enabled": "False"}, "where": {"column": "id", "condition": "=", "value": 2, "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
@@ -209,7 +209,7 @@ class TestUserModel:
                 hash_pwd_patch.assert_called_once_with(user_data['password'], )
 
     def test_update_user_storage_exception(self):
-        expected = {'message': 'ERROR: something went wrong', 'retryable': False, 'entryPoint': 'update'}
+        expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'update'}
         payload = '{"values": {"role_id": 2}, "where": {"column": "id", "condition": "=", "value": 2, "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
@@ -284,7 +284,7 @@ class TestUserModel:
 
     def test_login_exception(self):
         pwd_result = {'count': 1, 'rows': [{'role_id': '1', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '1'}]}
-        expected = {'message': 'ERROR: something went wrong', 'retryable': False, 'entryPoint': 'delete'}
+        expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'delete'}
         payload = '{"return": ["pwd", "id", "role_id"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
@@ -308,7 +308,7 @@ class TestUserModel:
             delete_tbl_patch.assert_called_once_with('user_logins', payload)
 
     def test_delete_user_tokens_exception(self):
-        expected = {'message': 'ERROR: something went wrong', 'retryable': False, 'entryPoint': 'delete'}
+        expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'delete'}
         payload = '{"where": {"column": "user_id", "condition": "=", "value": 2}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
@@ -374,7 +374,7 @@ class TestUserModel:
             delete_tbl_patch.assert_called_once_with('user_logins', payload)
 
     def test_delete_token_exception(self):
-        expected = {'message': 'ERROR: something went wrong', 'retryable': False, 'entryPoint': 'delete'}
+        expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'delete'}
         payload = '{"where": {"column": "token", "condition": "=", "value": "eyx"}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):


### PR DESCRIPTION
- [x] optional with forbidden for CRUD user
- [x] When storage exception then fixed message to user as we are logging its exception into syslog
- [x] test_auth_optional test fixed
- [x] test_user_model tests fixed

- [x] test_auth_mandatory
- [x] delete/invalidate tokens when "Foglamp" **stop**
- [ ] user login and logout does not make any sense when optional. We should not expose these end points?



**Tests O/P**

_auth mandatory + optional_ with **96%** code coverage
`244 statements   234 run 10 missing 0 excluded`

```
collected 85 items                                                                                                                            

== 85 passed in 4.43 seconds ==
```

**user_model** with **98%** code coverage
`188 statements   184 run 4 missing 0 excluded`

```
collected 41 items                                                                                                                            

== 40 passed, 1 skipped  in 1.16 seconds ==
```
