### PR TITLE
FOGL-862 handling for day fixes when timed schedule

### DIFF
--- a/python/foglamp/services/core/api/scheduler.py
+++ b/python/foglamp/services/core/api/scheduler.py
@@ -10,8 +10,7 @@ from aiohttp import web
 from foglamp.services.core import server
 from foglamp.services.core.scheduler.entities import Schedule, StartUpSchedule, TimedSchedule, IntervalSchedule, \
     ManualSchedule, Task
-from foglamp.services.core.scheduler.exceptions import TaskNotFoundError, ScheduleNotFoundError, TaskNotRunningError, \
-    NotReadyError
+from foglamp.services.core.scheduler.exceptions import *
 from foglamp.services.core import connect
 from foglamp.common.storage_client.payload_builder import PayloadBuilder
 
@@ -210,7 +209,7 @@ async def _check_schedule_post_parameters(data, curr_value=None):
     scheduled_process = _storage.query_tbl_with_payload('scheduled_processes', payload)
 
     if len(scheduled_process['rows']) == 0:
-        _errors.append('No such Scheduled Process name: {}'.format(_schedule.get('schedule_process_name')))
+        raise ScheduleProcessNameNotFoundError('No such Scheduled Process name: {}'.format(_schedule.get('schedule_process_name')))
 
     # Raise error if exclusive is wrong
     if _schedule.get('schedule_exclusive') not in ['True', 'False']:
@@ -455,8 +454,10 @@ async def post_schedule(request):
         }
 
         return web.json_response({'schedule': schedule})
-    except (ValueError, ScheduleNotFoundError) as ex:
+    except (ScheduleNotFoundError, ScheduleProcessNameNotFoundError) as ex:
         raise web.HTTPNotFound(reason=str(ex))
+    except ValueError as ex:
+        raise web.HTTPBadRequest(reason=str(ex))
 
 
 async def update_schedule(request):
@@ -478,7 +479,7 @@ async def update_schedule(request):
 
         sch = await server.Server.scheduler.get_schedule(uuid.UUID(schedule_id))
         if not sch:
-            raise ValueError('No such Schedule: {}.'.format(schedule_id))
+            raise ScheduleNotFoundError(schedule_id)
 
         curr_value = dict()
         curr_value['schedule_id'] = sch.schedule_id
@@ -512,8 +513,10 @@ async def update_schedule(request):
         }
 
         return web.json_response({'schedule': schedule})
-    except (ValueError, ScheduleNotFoundError) as ex:
+    except (ScheduleNotFoundError, ScheduleProcessNameNotFoundError) as ex:
         raise web.HTTPNotFound(reason=str(ex))
+    except ValueError as ex:
+        raise web.HTTPBadRequest(reason=str(ex))
 
 
 async def delete_schedule(request):

--- a/python/foglamp/services/core/api/scheduler.py
+++ b/python/foglamp/services/core/api/scheduler.py
@@ -97,8 +97,9 @@ def _extract_args(data, curr_value):
         if 'type' in data and (not isinstance(data['type'], int) and not data['type'].isdigit()):
             raise ValueError('Error in type: {}'.format(data['type']))
 
-        if 'day' in data and (not isinstance(data['day'], int) and (data['day'].strip() != "" and not data['day'].isdigit())):
-            raise ValueError('Error in day: {}'.format(data['day']))
+        if 'day' in data:
+            if isinstance(data['day'], float) or (isinstance(data['day'], str) and (data['day'].strip() != "" and not data['day'].isdigit())):
+                raise ValueError('Error in day: {}'.format(data['day']))
 
         if 'time' in data and (not isinstance(data['time'], int) and not data['time'].isdigit()):
             raise ValueError('Error in time: {}'.format(data['time']))

--- a/python/foglamp/services/core/scheduler/exceptions.py
+++ b/python/foglamp/services/core/scheduler/exceptions.py
@@ -13,7 +13,8 @@ __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
-__all__ = ('NotReadyError', 'DuplicateRequestError', 'TaskNotRunningError', 'TaskNotFoundError', 'ScheduleNotFoundError')
+__all__ = ('NotReadyError', 'DuplicateRequestError', 'TaskNotRunningError', 'TaskNotFoundError', 'ScheduleNotFoundError',
+           'ScheduleProcessNameNotFoundError')
 
 class NotReadyError(RuntimeError):
     pass
@@ -46,3 +47,5 @@ class ScheduleNotFoundError(ValueError):
             "Schedule not found: {}".format(schedule_id), *args)
 
 
+class ScheduleProcessNameNotFoundError(ValueError):
+    pass

--- a/tests/unit/python/foglamp/services/core/api/test_scheduler_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_scheduler_api.py
@@ -328,20 +328,20 @@ class TestSchedules:
         ({"day": 'bla'}, 400, "Error in day: bla", {'rows': [{'name': 'bla'}], 'count': 1}),
         ({"time": 'bla'}, 400, "Error in time: bla", {'rows': [{'name': 'bla'}], 'count': 1}),
         ({"repeat": 'bla'}, 400, "Error in repeat: bla", {'rows': [{'name': 'bla'}], 'count': 1}),
-        ({"type": 2, "name": "sch1", "process_name": "p1"}, 404,
+        ({"type": 2, "name": "sch1", "process_name": "p1"}, 400,
          "Errors in request: Schedule time cannot be empty for TIMED schedule. 1",
          {'rows': [{'name': 'bla'}], 'count': 1}),
-        ({"type": 2, "day": 9, "time": 1, "name": "sch1", "process_name": "p1"}, 404,
+        ({"type": 2, "day": 9, "time": 1, "name": "sch1", "process_name": "p1"}, 400,
          "Errors in request: Day must either be None or must be an integer and in range 1-7. 1",
          {'rows': [{'name': 'bla'}], 'count': 1}),
-        ({"type": 2, "day": 5, "time": -1, "name": "sch1", "process_name": "p1"}, 404,
+        ({"type": 2, "day": 5, "time": -1, "name": "sch1", "process_name": "p1"}, 400,
          "Errors in request: Time must be an integer and in range 0-86399. 1",
          {'rows': [{'name': 'bla'}], 'count': 1}),
-        ({"type": 200}, 404,
+        ({"type": 200}, 400,
          "Errors in request: Schedule type error: 200,Schedule name and Process name cannot be empty. 2",
          {'rows': [{'name': 'bla'}], 'count': 1}),
         ({"type": 1, "name": "sch1", "process_name": "p1"}, 404,
-         "Errors in request: No such Scheduled Process name: p1 1",
+         "No such Scheduled Process name: p1",
          {'rows': [], 'count': 0}),
     ])
     async def test_post_schedule_bad_data(self, client, request_data, response_code, error_message, storage_return):
@@ -409,7 +409,7 @@ class TestSchedules:
                           return_value=mock_coro()) as patch_get_schedule:
             resp = await client.put('/foglamp/schedule/{}'.format(self._random_uuid), data=json.dumps({"a": 1}))
             assert 404 == resp.status
-            assert 'No such Schedule: {}.'.format(self._random_uuid) == resp.reason
+            assert 'Schedule not found: {}'.format(self._random_uuid) == resp.reason
         patch_get_schedule.assert_called_once_with(uuid.UUID('{}'.format(self._random_uuid)))
 
     @pytest.mark.parametrize("request_data, response_code, error_message, storage_return", [
@@ -417,20 +417,20 @@ class TestSchedules:
         ({"day": 'bla'}, 400, "Error in day: bla", {'rows': [{'name': 'bla'}], 'count': 1}),
         ({"time": 'bla'}, 400, "Error in time: bla", {'rows': [{'name': 'bla'}], 'count': 1}),
         ({"repeat": 'bla'}, 400, "Error in repeat: bla", {'rows': [{'name': 'bla'}], 'count': 1}),
-        ({"type": 2, "name": "sch1", "process_name": "p1"}, 404,
+        ({"type": 2, "name": "sch1", "process_name": "p1"}, 400,
          "Errors in request: Schedule time cannot be empty for TIMED schedule.",
          {'rows': [{'name': 'bla'}], 'count': 1}),
-        ({"type": 2, "day": 9, "time": 1, "name": "sch1", "process_name": "p1"}, 404,
+        ({"type": 2, "day": 9, "time": 1, "name": "sch1", "process_name": "p1"}, 400,
          "Errors in request: Day must either be None or must be an integer and in range 1-7.",
          {'rows': [{'name': 'bla'}], 'count': 1}),
-        ({"type": 2, "day": 5, "time": -1, "name": "sch1", "process_name": "p1"}, 404,
+        ({"type": 2, "day": 5, "time": -1, "name": "sch1", "process_name": "p1"}, 400,
          "Errors in request: Time must be an integer and in range 0-86399.",
          {'rows': [{'name': 'bla'}], 'count': 1}),
-        ({"type": 200}, 404,
+        ({"type": 200}, 400,
          "Errors in request: Schedule type error: 200",
          {'rows': [{'name': 'bla'}], 'count': 1}),
         ({"type": 1, "name": "sch1", "process_name": "p1"}, 404,
-         "Errors in request: No such Scheduled Process name: p1",
+         "No such Scheduled Process name: p1",
          {'rows': [], 'count': 0}),
     ])
     async def test_update_schedule_bad_data(self, client, request_data, response_code, error_message, storage_return):

--- a/tests/unit/python/foglamp/services/core/scheduler/test_scheduler_exceptions.py
+++ b/tests/unit/python/foglamp/services/core/scheduler/test_scheduler_exceptions.py
@@ -54,3 +54,9 @@ class TestSchedulerExceptions:
         assert excinfo.type is ScheduleNotFoundError
         assert issubclass(excinfo.type, ValueError)
         assert str(excinfo).endswith("Schedule not found: {}".format(schedule_id))
+
+    def test_ScheduleProcessNameNotFound(self):
+        with pytest.raises(ScheduleProcessNameNotFoundError) as excinfo:
+            raise ScheduleProcessNameNotFoundError()
+        assert excinfo.type is ScheduleProcessNameNotFoundError
+        assert issubclass(excinfo.type, ValueError)


### PR DESCRIPTION
No regression found for scheduler_api and exceptions tests after new changes
`pytest -s -vv services/core/api/test_scheduler_api.py`
```
collected 78 items 
== 78 passed in 4.23 seconds ===
```
`pytest -s -vv services/core/scheduler/test_scheduler_exceptions.py`
```
collected 78 items 
== 6 passed in 0.03 seconds ==
```
**Test curl examples:** (Create and Update schedule)

1) day = -1 (POST)
```
curl -d '{"type": 2, "name": "backup", "process_name": "backup", "repeat": "45", "day": -1, "time": 45678}'  -X POST  https://localhost:1995/foglamp/schedule --insecure
400: Errors in request: Day must either be None or must be an integer and in range 1-7. 
```
2) day =123 (POST)
```
curl -d '{"type": 2, "name": "backup", "process_name": "backup", "repeat": "45", "day": 123, "time": 45678}'  -X POST  https://localhost:1995/foglamp/schedule --insecure
400: Errors in request: Day must either be None or must be an integer and in range 1-7. 
```
3) day ="123" (POST)
```
curl -d '{"type": 2, "name": "backup", "process_name": "backup", "repeat": "45", "day": "123", "time": 45678}'  -X POST  https://localhost:1995/foglamp/schedule --insecure
400: Errors in request: Day must either be None or must be an integer and in range 1-7. 
```
4) day ="787982.99999" (POST)
```
curl -d '{"type": 2, "name": "backup", "process_name": "backup", "repeat": "45", "day": "787982.99999", "time": 45678}'  -X POST  https://localhost:1995/foglamp/schedule --insecure
400: Error in day: 787982.99999
```
5) day =787982.99999 (POST)
```
curl -d '{"type": 2, "name": "backup", "process_name": "backup", "repeat": "45", "day": 787982.99999, "time": 45678}'  -X POST  https://localhost:1995/foglamp/schedule --insecure
400: Error in day: 787982.99999
```
6) day =7 (POST)
```
curl -d '{"type": 2, "name": "backup", "process_name": "backup", "repeat": "45", "day": 7, "time": 45678}'  -X POST  https://localhost:1995/foglamp/schedule --insecure
{"schedule": {"id": "2addeed8-660a-4ab5-8e24-940bf158ef68", "enabled": true, "time": 45678, "processName": "backup", "day": 7, "exclusive": true, "repeat": 45.0, "type": "TIMED", "name": "backup"}}
```

7) day =7 (PUT)
curl -d '{"type": 2, "name": "backup", "process_name": "backup", "repeat": "45", "day": 7, "time": 45678}'  -X PUT  https://localhost:1995/foglamp/schedule/fac8dae6-d8d1-11e7-9296-cec278b6b50a --insecure
{"schedule": {"id": "fac8dae6-d8d1-11e7-9296-cec278b6b50a", "enabled": true, "time": 45678, "processName": "backup", "day": 7, "exclusive": true, "repeat": 45.0, "type": "TIMED", "name": "backup"}}
```
8) day =787982.9999999999 (PUT)
```
curl -d '{"type": 2, "name": "backup", "process_name": "backup", "repeat": "45", "day": 787982.9999999999, "time": 45678}'  -X PUT  https://localhost:1995/foglamp/schedule/fac8dae6-d8d1-11e7-9296-cec278b6b50a --insecure
400: Error in day: 787982.9999999999
```

9) day ="78" (PUT)
```
curl -d '{"type": 2, "name": "backup", "process_name": "backup", "repeat": "45", "day": "78", "time": 45678}'  -X PUT  https://localhost:1995/foglamp/schedule/fac8dae6-d8d1-11e7-9296-cec278b6b50a --insecure
400: Errors in request: Day must either be None or must be an integer and in range 1-7
```

10) day ="1" (PUT)
```
curl -d '{"type": 2, "name": "backup", "process_name": "backup", "repeat": "45", "day": "1", "time": 45678}'  -X PUT  https://localhost:1995/foglamp/schedule/fac8dae6-d8d1-11e7-9296-cec278b6b50a --insecure
{"schedule": {"id": "fac8dae6-d8d1-11e7-9296-cec278b6b50a", "enabled": true, "time": 45678, "processName": "backup", "day": 1, "exclusive": true, "repeat": 45.0, "type": "TIMED", "name": "backup"}}
```