### PR TITLE
FOGL-1231 - sending_process/blockSize - value reduce

### DIFF
--- a/python/foglamp/tasks/north/sending_process.py
+++ b/python/foglamp/tasks/north/sending_process.py
@@ -319,7 +319,7 @@ class SendingProcess:
         "blockSize": {
             "description": "The size of a block of readings to send in each transmission.",
             "type": "integer",
-            "default": "5000"
+            "default": "500"
         },
         "sleepInterval": {
             "description": "A period of time, expressed in seconds, "


### PR DESCRIPTION
value reduce to avoid the error using the new Connector Relay : 
400 {"code":1,"message":"Payload size exceeds OMF body size limit.","source":"Body","description":"Exceeded maximum allowed body size of 196608 bytes."}