### PR TITLE
FOGL-1183/1111

### DIFF
--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -9,7 +9,6 @@
 from abc import ABC, abstractmethod
 import argparse
 import time
-
 from foglamp.common.storage_client.storage_client import ReadingsStorageClient, StorageClient
 from foglamp.common import logger
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient

--- a/python/foglamp/services/common/microservice.py
+++ b/python/foglamp/services/common/microservice.py
@@ -6,15 +6,15 @@
 
 """Common FoglampMicroservice Class"""
 
-import asyncio
 from aiohttp import web
-from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.services.common.microservice_management import routes
 from foglamp.common import logger
 from foglamp.common.process import FoglampProcess
 from foglamp.common.web import middleware
 from abc import abstractmethod
 import time
+import json
+import asyncio
 
 __author__ = "Ashwin Gopalakrishnan"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -57,10 +57,16 @@ class FoglampMicroservice(FoglampProcess):
 
             # ----- Ref: FOGL-1155. We need to fetch host from configuration of plugin
             category = self._name
-            config_descr = '{} Service'.format(self._name)
-            cfg_manager = ConfigurationManager(self._storage)
-            loop.run_until_complete(cfg_manager.create_category(category, default_config, config_descr, True))
-            config = loop.run_until_complete(cfg_manager.get_category_all_items(category))
+            config = default_config
+            config_descr = '{} Device'.format(self._name)
+            config_payload = json.dumps({
+                "key": category,
+                "description": config_descr,
+                "value": config,
+                "keep_original_items": True
+            })
+            self._core_microservice_management_client.create_configuration_category(config_payload)
+            config = self._core_microservice_management_client.get_configuration_category(category_name=category)
             host = config['management_host']['value']
             # -----
 

--- a/python/foglamp/services/south/ingest.py
+++ b/python/foglamp/services/south/ingest.py
@@ -11,10 +11,7 @@ import datetime
 import time
 import uuid
 from typing import List, Union
-
-# import dateutil.parser
 import json
-
 from foglamp.common import logger
 from foglamp.common.statistics import Statistics
 from foglamp.common.storage_client.storage_client import ReadingsStorageClient, StorageClient

--- a/tests/unit/python/foglamp/services/common/test_microservice.py
+++ b/tests/unit/python/foglamp/services/common/test_microservice.py
@@ -5,7 +5,6 @@ import time
 from unittest.mock import patch, MagicMock
 from aiohttp import web
 import asyncio
-from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.common.storage_client.storage_client import ReadingsStorageClient, StorageClient
 from foglamp.common.process import FoglampProcess, SilentArgParse, ArgumentParserError
 from foglamp.services.common.microservice import FoglampMicroservice, _logger
@@ -83,12 +82,6 @@ class TestFoglampMicroservice:
             async def shutdown(self):
                 pass
 
-        async def async_mock():
-            return None
-
-        async def config_mock():
-            return _DEFAULT_CONFIG
-
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
             with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
@@ -100,11 +93,7 @@ class TestFoglampMicroservice:
                                          with patch.object(FoglampMicroservice, '_run_microservice_management_app', side_effect=None) as run_patch:
                                              with patch.object(FoglampProcess, 'register_service_with_core', return_value={'id':'bla'}) as reg_patch:
                                                  with patch.object(FoglampMicroservice, '_get_service_registration_payload', return_value=None) as payload_patch:
-                                                    storage_client_mock = MagicMock(StorageClient)
-                                                    c_mgr = ConfigurationManager(storage_client_mock)
-                                                    with patch.object(c_mgr, 'create_category', return_value=async_mock()):
-                                                        with patch.object(c_mgr, 'get_category_all_items', return_value=config_mock()):
-                                                            fm = FoglampMicroserviceImp()
+                                                    fm = FoglampMicroserviceImp()
         # from FoglampProcess
         assert fm._core_management_host is 'corehost'
         assert fm._core_management_port is 0
@@ -135,12 +124,6 @@ class TestFoglampMicroservice:
             async def shutdown(self):
                 pass
 
-        async def async_mock():
-            return None
-
-        async def config_mock():
-            return _DEFAULT_CONFIG
-
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
             with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
@@ -151,12 +134,7 @@ class TestFoglampMicroservice:
                                     with patch.object(FoglampMicroservice, '_make_microservice_management_app', side_effect=Exception()) as make_patch:
                                         with patch.object(_logger, 'exception') as logger_patch:
                                             with pytest.raises(Exception) as excinfo:
-                                                storage_client_mock = MagicMock(StorageClient)
-                                                c_mgr = ConfigurationManager(storage_client_mock)
-                                                with patch.object(c_mgr, 'create_category', return_value=async_mock()):
-                                                    with patch.object(c_mgr, 'get_category_all_items',
-                                                                      return_value=config_mock()):
-                                                        fm = FoglampMicroserviceImp()
+                                                fm = FoglampMicroserviceImp()
         logger_patch.assert_called_once_with('Unable to intialize FoglampMicroservice due to exception %s', '')
 
     @pytest.mark.asyncio
@@ -172,12 +150,6 @@ class TestFoglampMicroservice:
             async def shutdown(self):
                 pass
 
-        async def async_mock():
-            return None
-
-        async def config_mock():
-            return _DEFAULT_CONFIG
-
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
             with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
@@ -192,12 +164,6 @@ class TestFoglampMicroservice:
                                                      with patch.object(web, 'json_response', return_value=None) as response_patch:
                                                          # called once on FoglampProcess init for _start_time, once for ping
                                                          with patch.object(time, 'time', return_value=1) as time_patch:
-                                                             storage_client_mock = MagicMock(StorageClient)
-                                                             c_mgr = ConfigurationManager(storage_client_mock)
-                                                             with patch.object(c_mgr, 'create_category',
-                                                                               return_value=async_mock()):
-                                                                 with patch.object(c_mgr, 'get_category_all_items',
-                                                                                   return_value=config_mock()):
-                                                                     fm = FoglampMicroserviceImp()
-                                                                     await fm.ping(None)
+                                                             fm = FoglampMicroserviceImp()
+                                                             await fm.ping(None)
         response_patch.assert_called_once_with({'uptime': 0})

--- a/tests/unit/python/foglamp/services/common/test_microservice.py
+++ b/tests/unit/python/foglamp/services/common/test_microservice.py
@@ -92,17 +92,19 @@ class TestFoglampMicroservice:
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
             with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
-                    with patch.object(ReadingsStorageClient, '__init__', return_value=None) as rsc_patch:
-                        with patch.object(StorageClient, '__init__', return_value=None) as sc_patch:
-                            with patch.object(FoglampMicroservice, '_make_microservice_management_app', return_value=None) as make_patch:
-                                 with patch.object(FoglampMicroservice, '_run_microservice_management_app', side_effect=None) as run_patch:
-                                     with patch.object(FoglampProcess, 'register_service_with_core', return_value={'id':'bla'}) as reg_patch:
-                                         with patch.object(FoglampMicroservice, '_get_service_registration_payload', return_value=None) as payload_patch:
-                                            storage_client_mock = MagicMock(StorageClient)
-                                            c_mgr = ConfigurationManager(storage_client_mock)
-                                            with patch.object(c_mgr, 'create_category', return_value=async_mock()):
-                                                with patch.object(c_mgr, 'get_category_all_items', return_value=config_mock()):
-                                                    fm = FoglampMicroserviceImp()
+                    with patch.object(MicroserviceManagementClient, 'create_configuration_category', return_value=None):
+                        with patch.object(MicroserviceManagementClient, 'get_configuration_category', return_value=_DEFAULT_CONFIG):
+                            with patch.object(ReadingsStorageClient, '__init__', return_value=None) as rsc_patch:
+                                with patch.object(StorageClient, '__init__', return_value=None) as sc_patch:
+                                    with patch.object(FoglampMicroservice, '_make_microservice_management_app', return_value=None) as make_patch:
+                                         with patch.object(FoglampMicroservice, '_run_microservice_management_app', side_effect=None) as run_patch:
+                                             with patch.object(FoglampProcess, 'register_service_with_core', return_value={'id':'bla'}) as reg_patch:
+                                                 with patch.object(FoglampMicroservice, '_get_service_registration_payload', return_value=None) as payload_patch:
+                                                    storage_client_mock = MagicMock(StorageClient)
+                                                    c_mgr = ConfigurationManager(storage_client_mock)
+                                                    with patch.object(c_mgr, 'create_category', return_value=async_mock()):
+                                                        with patch.object(c_mgr, 'get_category_all_items', return_value=config_mock()):
+                                                            fm = FoglampMicroserviceImp()
         # from FoglampProcess
         assert fm._core_management_host is 'corehost'
         assert fm._core_management_port is 0
@@ -142,17 +144,19 @@ class TestFoglampMicroservice:
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
             with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
-                    with patch.object(ReadingsStorageClient, '__init__', return_value=None) as rsc_patch:
-                        with patch.object(StorageClient, '__init__', return_value=None) as sc_patch:
-                            with patch.object(FoglampMicroservice, '_make_microservice_management_app', side_effect=Exception()) as make_patch:
-                                with patch.object(_logger, 'exception') as logger_patch:
-                                    with pytest.raises(Exception) as excinfo:
-                                        storage_client_mock = MagicMock(StorageClient)
-                                        c_mgr = ConfigurationManager(storage_client_mock)
-                                        with patch.object(c_mgr, 'create_category', return_value=async_mock()):
-                                            with patch.object(c_mgr, 'get_category_all_items',
-                                                              return_value=config_mock()):
-                                                fm = FoglampMicroserviceImp()
+                    with patch.object(MicroserviceManagementClient, 'create_configuration_category', return_value=None):
+                        with patch.object(MicroserviceManagementClient, 'get_configuration_category', return_value=_DEFAULT_CONFIG):
+                            with patch.object(ReadingsStorageClient, '__init__', return_value=None) as rsc_patch:
+                                with patch.object(StorageClient, '__init__', return_value=None) as sc_patch:
+                                    with patch.object(FoglampMicroservice, '_make_microservice_management_app', side_effect=Exception()) as make_patch:
+                                        with patch.object(_logger, 'exception') as logger_patch:
+                                            with pytest.raises(Exception) as excinfo:
+                                                storage_client_mock = MagicMock(StorageClient)
+                                                c_mgr = ConfigurationManager(storage_client_mock)
+                                                with patch.object(c_mgr, 'create_category', return_value=async_mock()):
+                                                    with patch.object(c_mgr, 'get_category_all_items',
+                                                                      return_value=config_mock()):
+                                                        fm = FoglampMicroserviceImp()
         logger_patch.assert_called_once_with('Unable to intialize FoglampMicroservice due to exception %s', '')
 
     @pytest.mark.asyncio
@@ -177,21 +181,23 @@ class TestFoglampMicroservice:
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
             with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
-                    with patch.object(ReadingsStorageClient, '__init__', return_value=None) as rsc_patch:
-                        with patch.object(StorageClient, '__init__', return_value=None) as sc_patch:
-                            with patch.object(FoglampMicroservice, '_make_microservice_management_app', return_value=None) as make_patch:
-                                 with patch.object(FoglampMicroservice, '_run_microservice_management_app', side_effect=None) as run_patch:
-                                     with patch.object(FoglampProcess, 'register_service_with_core', return_value={'id':'bla'}) as reg_patch:
-                                         with patch.object(FoglampMicroservice, '_get_service_registration_payload', return_value=None) as payload_patch:
-                                             with patch.object(web, 'json_response', return_value=None) as response_patch:
-                                                 # called once on FoglampProcess init for _start_time, once for ping
-                                                 with patch.object(time, 'time', return_value=1) as time_patch:
-                                                     storage_client_mock = MagicMock(StorageClient)
-                                                     c_mgr = ConfigurationManager(storage_client_mock)
-                                                     with patch.object(c_mgr, 'create_category',
-                                                                       return_value=async_mock()):
-                                                         with patch.object(c_mgr, 'get_category_all_items',
-                                                                           return_value=config_mock()):
-                                                             fm = FoglampMicroserviceImp()
-                                                             await fm.ping(None)
+                    with patch.object(MicroserviceManagementClient, 'create_configuration_category', return_value=None):
+                        with patch.object(MicroserviceManagementClient, 'get_configuration_category', return_value=_DEFAULT_CONFIG):
+                            with patch.object(ReadingsStorageClient, '__init__', return_value=None) as rsc_patch:
+                                with patch.object(StorageClient, '__init__', return_value=None) as sc_patch:
+                                    with patch.object(FoglampMicroservice, '_make_microservice_management_app', return_value=None) as make_patch:
+                                         with patch.object(FoglampMicroservice, '_run_microservice_management_app', side_effect=None) as run_patch:
+                                             with patch.object(FoglampProcess, 'register_service_with_core', return_value={'id':'bla'}) as reg_patch:
+                                                 with patch.object(FoglampMicroservice, '_get_service_registration_payload', return_value=None) as payload_patch:
+                                                     with patch.object(web, 'json_response', return_value=None) as response_patch:
+                                                         # called once on FoglampProcess init for _start_time, once for ping
+                                                         with patch.object(time, 'time', return_value=1) as time_patch:
+                                                             storage_client_mock = MagicMock(StorageClient)
+                                                             c_mgr = ConfigurationManager(storage_client_mock)
+                                                             with patch.object(c_mgr, 'create_category',
+                                                                               return_value=async_mock()):
+                                                                 with patch.object(c_mgr, 'get_category_all_items',
+                                                                                   return_value=config_mock()):
+                                                                     fm = FoglampMicroserviceImp()
+                                                                     await fm.ping(None)
         response_patch.assert_called_once_with({'uptime': 0})


### PR DESCRIPTION
Syslog Dump:
```
FogLAMP (FOGL-1183 *%) $ tail -f -n 10 /var/log/syslog | grep foglamp
Apr  6 16:53:12 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: start core
Apr  6 16:53:12 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Management API started on http://0.0.0.0:37137
Apr  6 16:53:12 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: start storage, from directory /home/asinha/Development/FogLAMP/scripts
Apr  6 16:53:13 nerd51-ThinkPad FogLAMP[23153] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=ead450a5-f6f2-4702-b74f-035c7aab2a46: <FogLAMP Storage, type=Storage, protocol=http, address=localhost, service port=37780, management port=40824, status=1>
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: start scheduler
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Starting
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Starting Scheduler: Management port received is 37137
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'purge' to start at 2018-04-06 17:53:17.541892
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'certificate checker' to start at 2018-04-06 17:05:00
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'HTTP listener south' to start at 2018-04-06 16:53:17.541892
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'COAP listener south' to start at 2018-04-06 16:53:17.541892
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Services monitoring started ...
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'COAP listener south' process 'COAP' task c3c44aa2-b2c5-43b7-8562-34ac94bf5156 pid 23224, 1 running tasks#012['services/south', '--port=37137', '--address=127.0.0.1', '--name=COAP']
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'HTTP listener south' process 'HTTP_SOUTH' task 1875c823-e4a5-49c0-a13d-5156a5247da0 pid 23226, 2 running tasks#012['services/south', '--port=37137', '--address=127.0.0.1', '--name=HTTP_SOUTH']
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 702.3873789310455 seconds
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Loading certificates /home/asinha/Development/FogLAMP/data/etc/certs/foglamp.cert and key /home/asinha/Development/FogLAMP/data/etc/certs/foglamp.key
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Announce management API service
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] WARNING: server: foglamp.services.core.server: A FogLAMP PID file has been found: [/home/asinha/Development/FogLAMP/data/var/run/foglamp.core.pid] found, ignoring it.
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: PID [23153] written in [/home/asinha/Development/FogLAMP/data/var/run/foglamp.core.pid]
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: REST API Server started on https://0.0.0.0:1995
Apr  6 16:53:17 nerd51-ThinkPad FogLAMP[23153] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=5252347d-2d3f-432e-8a01-066c0c774e12: <FogLAMP Core, type=Core, protocol=http, address=0.0.0.0, service port=1995, management port=37137, status=1>
Apr  6 16:53:18 nerd51-ThinkPad FogLAMP[23153] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=c8ed667b-7b6e-4ba5-a6b2-dc874caf06d9: <COAP, type=Southbound, protocol=http, address=127.0.0.1, service port=35468, management port=35468, status=1>
Apr  6 16:53:18 nerd51-ThinkPad FogLAMP[23153] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=4e5da7f1-86ea-40eb-9902-93f259398373: <HTTP_SOUTH, type=Southbound, protocol=http, address=127.0.0.1, service port=41363, management port=41363, status=1>
Apr  6 16:53:18 nerd51-ThinkPad FogLAMP[23225] INFO: coap_listen: foglamp.plugins.south.coap_listen.coap_listen: CoAP listener started on port 5683 with uri sensor-values
Apr  6 16:53:18 nerd51-ThinkPad FogLAMP[23153] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
Apr  6 16:53:18 nerd51-ThinkPad FogLAMP [23049] INFO: script.foglamp: FogLAMP started.
Apr  6 16:53:22 nerd51-ThinkPad FogLAMP[23153] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
Apr  6 16:53:47 nerd51-ThinkPad FogLAMP[23153] message repeated 5 times: [ INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping]
Apr  6 16:53:47 nerd51-ThinkPad FogLAMP[23153] INFO: middleware: foglamp.common.web.middleware: Received PUT request for /foglamp/shutdown
Apr  6 16:53:47 nerd51-ThinkPad FogLAMP[23153] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
Apr  6 16:53:48 nerd51-ThinkPad FogLAMP[23153] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
Apr  6 16:53:49 nerd51-ThinkPad FogLAMP[23153] INFO: common: foglamp.services.core.api.common: Executing controlled shutdown
Apr  6 16:53:49 nerd51-ThinkPad FogLAMP[23153] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Processing stop request
Apr  6 16:53:49 nerd51-ThinkPad FogLAMP[23153] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
Apr  6 16:53:54 nerd51-ThinkPad FogLAMP[23153] message repeated 5 times: [ INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping]
Apr  6 16:53:54 nerd51-ThinkPad FogLAMP[23153] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Stopped
Apr  6 16:53:54 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Shutting down the Southbound service COAP ...
Apr  6 16:53:54 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Shutting down the Southbound service HTTP_SOUTH ...
Apr  6 16:53:54 nerd51-ThinkPad FogLAMP[23225] INFO: coap_listen: foglamp.plugins.south.coap_listen.coap_listen: Stopping South COAP plugin...
Apr  6 16:53:54 nerd51-ThinkPad FogLAMP[23227] INFO: http_south: foglamp.plugins.south.http_south.http_south: Stopping South HTTP plugin.
Apr  6 16:53:54 nerd51-ThinkPad FogLAMP[23225] INFO: coap_listen: foglamp.plugins.south.coap_listen.coap_listen: COAP plugin shut down.
Apr  6 16:53:54 nerd51-ThinkPad FogLAMP[23227] INFO: http_south: foglamp.plugins.south.http_south.http_south: South HTTP plugin shut down.
Apr  6 16:53:55 nerd51-ThinkPad FogLAMP[23153] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
Apr  6 16:53:59 nerd51-ThinkPad FogLAMP[23153] message repeated 4 times: [ INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping]
Apr  6 16:53:59 nerd51-ThinkPad FogLAMP[23153] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Unregistered service instance id=4e5da7f1-86ea-40eb-9902-93f259398373: <HTTP_SOUTH, type=Southbound, protocol=http, address=127.0.0.1, service port=41363, management port=41363, status=1>
Apr  6 16:54:05 nerd51-ThinkPad FogLAMP[23153] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
Apr  6 16:54:05 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Successfully shut down the Southbound service HTTP_SOUTH.
Apr  6 16:54:05 nerd51-ThinkPad FogLAMP[23153] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Unregistered service instance id=c8ed667b-7b6e-4ba5-a6b2-dc874caf06d9: <COAP, type=Southbound, protocol=http, address=127.0.0.1, service port=35468, management port=35468, status=1>
Apr  6 16:54:10 nerd51-ThinkPad FogLAMP[23153] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
Apr  6 16:54:10 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Successfully shut down the Southbound service COAP.
Apr  6 16:54:10 nerd51-ThinkPad FogLAMP[23153] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
Apr  6 16:54:10 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Services monitoring stopped.
Apr  6 16:54:10 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Rest server stopped.
Apr  6 16:54:10 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Shutting down the Storage service FogLAMP Storage ...
Apr  6 16:54:10 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: Successfully shut down the Storage service FogLAMP Storage.
Apr  6 16:54:10 nerd51-ThinkPad FogLAMP[23153] INFO: server: foglamp.services.core.server: FogLAMP PID file [/home/asinha/Development/FogLAMP/data/var/run/foglamp.core.pid] removed.
Apr  6 16:54:11 nerd51-ThinkPad FogLAMP [23267] INFO: script.foglamp: FogLAMP stopped.
```

Test result:
`============================================== 930 passed, 12 skipped, 4 warnings in 44.05 seconds ==============================================
`