### PR TITLE
FOGL-1239 fixed audit and user model tests as per payload builder modifications 

### DIFF
--- a/tests/unit/python/foglamp/services/core/api/test_audit.py
+++ b/tests/unit/python/foglamp/services/core/api/test_audit.py
@@ -93,13 +93,13 @@ class TestAudit:
             log_code_patch.assert_called_once_with('log_codes')
 
     @pytest.mark.parametrize("request_params, payload", [
-        ('', '{"where": {"column": "1", "condition": "=", "value": "1"}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}'),
-        ('?source=PURGE', '{"where": {"column": "1", "condition": "=", "value": "1", "and": {"column": "code", "condition": "=", "value": "PURGE"}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}'),
-        ('?skip=1', '{"where": {"column": "1", "condition": "=", "value": "1"}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20, "skip": 1}'),
-        ('?severity=failure', '{"where": {"column": "1", "condition": "=", "value": "1", "and": {"column": "level", "condition": "=", "value": 1}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}'),
-        ('?severity=FAILURE&limit=1', '{"where": {"column": "1", "condition": "=", "value": "1", "and": {"column": "level", "condition": "=", "value": 1}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 1}'),
-        ('?severity=INFORMATION&limit=1&skip=1', '{"where": {"column": "1", "condition": "=", "value": "1", "and": {"column": "level", "condition": "=", "value": 4}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 1, "skip": 1}'),
-        ('?source=&severity=&limit=&skip=', '{"where": {"column": "1", "condition": "=", "value": "1"}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}')
+        ('', '{"where": {"column": "1", "condition": "=", "value": 1}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}'),
+        ('?source=PURGE', '{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "code", "condition": "=", "value": "PURGE"}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}'),
+        ('?skip=1', '{"where": {"column": "1", "condition": "=", "value": 1}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20, "skip": 1}'),
+        ('?severity=failure', '{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "level", "condition": "=", "value": 1}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}'),
+        ('?severity=FAILURE&limit=1', '{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "level", "condition": "=", "value": 1}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 1}'),
+        ('?severity=INFORMATION&limit=1&skip=1', '{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "level", "condition": "=", "value": 4}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 1, "skip": 1}'),
+        ('?source=&severity=&limit=&skip=', '{"where": {"column": "1", "condition": "=", "value": 1}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}')
     ])
     async def test_get_audit_with_params(self, client, request_params, payload, get_log_codes):
         storage_client_mock = MagicMock(StorageClient)

--- a/tests/unit/python/foglamp/services/core/test_user_model.py
+++ b/tests/unit/python/foglamp/services/core/test_user_model.py
@@ -65,7 +65,7 @@ class TestUserModel:
 
     def test_get_all(self):
         expected = {'rows': [], 'count': 0}
-        payload = '{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "True"}}'
+        payload = '{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "t"}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=expected) as query_tbl_patch:
@@ -74,10 +74,10 @@ class TestUserModel:
             query_tbl_patch.assert_called_once_with('users', payload)
 
     @pytest.mark.parametrize("kwargs, payload", [
-        ({'username': None, 'uid': None}, '{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "True"}}'),
-        ({'username': None, 'uid': 1}, '{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "True", "and": {"column": "id", "condition": "=", "value": 1}}}'),
-        ({'username': 'aj', 'uid': None}, '{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "True", "and": {"column": "uname", "condition": "=", "value": "aj"}}}'),
-        ({'username': 'aj', 'uid': 1}, '{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "True", "and": {"column": "id", "condition": "=", "value": 1, "and": {"column": "uname", "condition": "=", "value": "aj"}}}}')
+        ({'username': None, 'uid': None}, '{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "t"}}'),
+        ({'username': None, 'uid': 1}, '{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "t", "and": {"column": "id", "condition": "=", "value": 1}}}'),
+        ({'username': 'aj', 'uid': None}, '{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "t", "and": {"column": "uname", "condition": "=", "value": "aj"}}}'),
+        ({'username': 'aj', 'uid': 1}, '{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "t", "and": {"column": "id", "condition": "=", "value": 1, "and": {"column": "uname", "condition": "=", "value": "aj"}}}}')
     ])
     def test_get_filter(self, kwargs, payload):
         expected = {'rows': [], 'count': 0}
@@ -159,7 +159,7 @@ class TestUserModel:
 
     def test_delete_user(self):
         p1 = '{"where": {"column": "user_id", "condition": "=", "value": 2}}'
-        p2 = '{"values": {"enabled": "False"}, "where": {"column": "id", "condition": "=", "value": 2, "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
+        p2 = '{"values": {"enabled": "f"}, "where": {"column": "id", "condition": "=", "value": 2, "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         r1 = {'response': 'deleted', 'rows_affected': 1}
         r2 = {'response': 'updated', 'rows_affected': 1}
 
@@ -179,7 +179,7 @@ class TestUserModel:
 
     def test_delete_user_exception(self):
         expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'delete'}
-        payload = '{"values": {"enabled": "False"}, "where": {"column": "id", "condition": "=", "value": 2, "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
+        payload = '{"values": {"enabled": "f"}, "where": {"column": "id", "condition": "=", "value": 2, "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'update_tbl', side_effect=StorageServerError(code=400, reason="blah",
@@ -232,7 +232,7 @@ class TestUserModel:
 
     def test_update_user_storage_exception(self):
         expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'update'}
-        payload = '{"values": {"role_id": 2}, "where": {"column": "id", "condition": "=", "value": 2, "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
+        payload = '{"values": {"role_id": 2}, "where": {"column": "id", "condition": "=", "value": 2, "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'update_tbl', side_effect=StorageServerError(code=400, reason="blah", error=expected)) as update_tbl_patch:
@@ -242,7 +242,7 @@ class TestUserModel:
         update_tbl_patch.assert_called_once_with('users', payload)
 
     def test_update_user_exception(self):
-        payload = '{"values": {"role_id": "blah"}, "where": {"column": "id", "condition": "=", "value": 2, "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
+        payload = '{"values": {"role_id": "blah"}, "where": {"column": "id", "condition": "=", "value": 2, "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         msg = 'Bad role id'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
@@ -257,7 +257,7 @@ class TestUserModel:
         async def mock_get_category_item():
             return {"value": "0"}
 
-        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "admin", "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
+        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "admin", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat_patch:
@@ -275,7 +275,7 @@ class TestUserModel:
             return {"value": "0"}
 
         pwd_result = {'count': 1, 'rows': [{'role_id': '2', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '2', 'pwd_last_changed': '2018-03-30 12:32:08.216159+05:30'}]}
-        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
+        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat_patch:
@@ -295,7 +295,7 @@ class TestUserModel:
             return {"value": "30"}
 
         pwd_result = {'count': 1, 'rows': [{'role_id': '2', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '2', 'pwd_last_changed': '2018-01-30 12:32:08.216159+05:30'}]}
-        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
+        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat_patch:
@@ -316,7 +316,7 @@ class TestUserModel:
         async def mock_get_category_item():
             return {"value": "0"}
 
-        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
+        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat_patch:
@@ -344,7 +344,7 @@ class TestUserModel:
 
         pwd_result = {'count': 1, 'rows': [{'role_id': '1', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '1', 'pwd_last_changed': '2018-03-30 12:32:08.216159+05:30'}]}
         expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'delete'}
-        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "True"}}}'
+        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat_patch:
@@ -458,7 +458,7 @@ class TestUserModel:
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value={'rows': []}) as query_tbl_patch:
                 result = User.Objects.is_user_exists('blah', 'blah')
                 assert result is None
-            query_tbl_patch.assert_called_once_with('users', '{"return": ["id", "pwd"], "where": {"column": "uname", "condition": "=", "value": "blah", "and": {"column": "enabled", "condition": "=", "value": "True"}}}')
+            query_tbl_patch.assert_called_once_with('users', '{"return": ["id", "pwd"], "where": {"column": "uname", "condition": "=", "value": "blah", "and": {"column": "enabled", "condition": "=", "value": "t"}}}')
 
     @pytest.mark.parametrize("ret_val_check_pwd, expected", [(True, 1), (False, None)])
     def test_user_exists(self, ret_val_check_pwd, expected):
@@ -470,7 +470,7 @@ class TestUserModel:
                     actual = User.Objects.is_user_exists('admin', 'admin')
                     assert expected == actual
                 check_pwd_patch.assert_called_once_with(ret_val['rows'][0]['pwd'], 'admin')
-            query_tbl_patch.assert_called_once_with('users', '{"return": ["id", "pwd"], "where": {"column": "uname", "condition": "=", "value": "admin", "and": {"column": "enabled", "condition": "=", "value": "True"}}}')
+            query_tbl_patch.assert_called_once_with('users', '{"return": ["id", "pwd"], "where": {"column": "uname", "condition": "=", "value": "admin", "and": {"column": "enabled", "condition": "=", "value": "t"}}}')
 
     def test__get_password_history(self):
         storage_client_mock = MagicMock(StorageClient)


### PR DESCRIPTION
https://scaledb.atlassian.net/browse/FOGL-1239

**Fixed tests**

- [x] test_user_model.py
- [x] test_audit.py

**Tests O/P**
```
collected 76 items                                                                                                                                    

services/core/api/test_audit.py::TestAudit::test_get_severity[pyloop] PASSED
services/core/api/test_audit.py::TestAudit::test_audit_log_codes[pyloop] PASSED
services/core/api/test_audit.py::TestAudit::test_get_audit_with_params[pyloop--{"where": {"column": "1", "condition": "=", "value": 1}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}] PASSED
services/core/api/test_audit.py::TestAudit::test_get_audit_with_params[pyloop-?source=PURGE-{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "code", "condition": "=", "value": "PURGE"}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}] PASSED
services/core/api/test_audit.py::TestAudit::test_get_audit_with_params[pyloop-?skip=1-{"where": {"column": "1", "condition": "=", "value": 1}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20, "skip": 1}] PASSED
services/core/api/test_audit.py::TestAudit::test_get_audit_with_params[pyloop-?severity=failure-{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "level", "condition": "=", "value": 1}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}] PASSED
services/core/api/test_audit.py::TestAudit::test_get_audit_with_params[pyloop-?severity=FAILURE&limit=1-{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "level", "condition": "=", "value": 1}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 1}] PASSED
services/core/api/test_audit.py::TestAudit::test_get_audit_with_params[pyloop-?severity=INFORMATION&limit=1&skip=1-{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "level", "condition": "=", "value": 4}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 1, "skip": 1}] PASSED
services/core/api/test_audit.py::TestAudit::test_get_audit_with_params[pyloop-?source=&severity=&limit=&skip=-{"where": {"column": "1", "condition": "=", "value": 1}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}] PASSED
services/core/api/test_audit.py::TestAudit::test_source_param_with_bad_data[pyloop-?source=BLA-400-BLA is not a valid source] PASSED
services/core/api/test_audit.py::TestAudit::test_source_param_with_bad_data[pyloop-?source=1234-400-1234 is not a valid source] PASSED
services/core/api/test_audit.py::TestAudit::test_source_param_with_bad_data[pyloop-?limit=invalid-400-Limit must be a positive integer] PASSED
services/core/api/test_audit.py::TestAudit::test_source_param_with_bad_data[pyloop-?limit=-1-400-Limit must be a positive integer] PASSED
services/core/api/test_audit.py::TestAudit::test_source_param_with_bad_data[pyloop-?skip=invalid-400-Skip/Offset must be a positive integer] PASSED
services/core/api/test_audit.py::TestAudit::test_source_param_with_bad_data[pyloop-?skip=-1-400-Skip/Offset must be a positive integer] PASSED
services/core/api/test_audit.py::TestAudit::test_source_param_with_bad_data[pyloop-?severity=BLA-400-'BLA' is not a valid severity] PASSED
services/core/api/test_audit.py::TestAudit::test_get_audit_http_exception[pyloop] PASSED
services/core/api/test_audit.py::TestAudit::test_create_audit_entry[pyloop] PASSED
services/core/api/test_audit.py::TestAudit::test_create_audit_entry_with_bad_data[pyloop-request_data0-Missing required parameter severity] PASSED
services/core/api/test_audit.py::TestAudit::test_create_audit_entry_with_bad_data[pyloop-request_data1-Missing required parameter severity] PASSED
services/core/api/test_audit.py::TestAudit::test_create_audit_entry_with_bad_data[pyloop-request_data2-Missing required parameter source] PASSED
services/core/api/test_audit.py::TestAudit::test_create_audit_entry_with_bad_data[pyloop-request_data3-Missing required parameter source] PASSED
services/core/api/test_audit.py::TestAudit::test_create_audit_entry_with_bad_data[pyloop-request_data4-Missing required parameter details] PASSED
services/core/api/test_audit.py::TestAudit::test_create_audit_entry_with_bad_data[pyloop-request_data5-Details should be a valid json object] PASSED
services/core/api/test_audit.py::TestAudit::test_create_audit_entry_with_attribute_error[pyloop] PASSED
services/core/api/test_audit.py::TestAudit::test_create_audit_entry_with_exception[pyloop] PASSED
services/core/test_user_model.py::TestUserModel::test_initial_value PASSED
services/core/test_user_model.py::TestUserModel::test_value_with_is_admin PASSED
services/core/test_user_model.py::TestUserModel::test_no_value PASSED
services/core/test_user_model.py::TestUserModel::test_get_roles PASSED
services/core/test_user_model.py::TestUserModel::test_get_role_id_by_name PASSED
services/core/test_user_model.py::TestUserModel::test_get_all PASSED
services/core/test_user_model.py::TestUserModel::test_get_filter[kwargs0-{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "t"}}] PASSED
services/core/test_user_model.py::TestUserModel::test_get_filter[kwargs1-{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "t", "and": {"column": "id", "condition": "=", "value": 1}}}] PASSED
services/core/test_user_model.py::TestUserModel::test_get_filter[kwargs2-{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "t", "and": {"column": "uname", "condition": "=", "value": "aj"}}}] PASSED
services/core/test_user_model.py::TestUserModel::test_get_filter[kwargs3-{"return": ["id", "uname", "role_id"], "where": {"column": "enabled", "condition": "=", "value": "t", "and": {"column": "id", "condition": "=", "value": 1, "and": {"column": "uname", "condition": "=", "value": "aj"}}}}] PASSED
services/core/test_user_model.py::TestUserModel::test_get_exception[exp_kwargs0-] PASSED
services/core/test_user_model.py::TestUserModel::test_get_exception[exp_kwargs1-User with id:<1> does not exist] PASSED
services/core/test_user_model.py::TestUserModel::test_get_exception[exp_kwargs2-User with name:<aj> does not exist] PASSED
services/core/test_user_model.py::TestUserModel::test_get_exception[exp_kwargs3-User with id:<1> and name:<aj> does not exist] PASSED
services/core/test_user_model.py::TestUserModel::test_get PASSED
services/core/test_user_model.py::TestUserModel::test_hash_password_check[True-foglamp] PASSED
services/core/test_user_model.py::TestUserModel::test_hash_password_check[False-invalid] PASSED
services/core/test_user_model.py::TestUserModel::test_create_user PASSED
services/core/test_user_model.py::TestUserModel::test_create_user_exception PASSED
services/core/test_user_model.py::TestUserModel::test_delete_user PASSED
services/core/test_user_model.py::TestUserModel::test_delete_admin_user PASSED
services/core/test_user_model.py::TestUserModel::test_delete_user_exception PASSED
services/core/test_user_model.py::TestUserModel::test_update_user_role[user_data0-{"values": {"role_id": 2}, "where": {"column": "id", "condition": "=", "value": 2}}] PASSED
services/core/test_user_model.py::TestUserModel::test_update_user_role[user_data1-{"values": {"role_id": "2"}, "where": {"column": "id", "condition": "=", "value": 2}}] PASSED
services/core/test_user_model.py::TestUserModel::test_update_user_password[user_data0-{"values": {"pwd": "HASHED_PASSWORD"}, "where": {"column": "id", "condition": "=", "value": 2}}] PASSED
services/core/test_user_model.py::TestUserModel::test_update_user_storage_exception PASSED
services/core/test_user_model.py::TestUserModel::test_update_user_exception PASSED
services/core/test_user_model.py::TestUserModel::test_login_if_no_user_exists PASSED
services/core/test_user_model.py::TestUserModel::test_login_if_invalid_password PASSED
services/core/test_user_model.py::TestUserModel::test_login_age_pwd_expiration PASSED
services/core/test_user_model.py::TestUserModel::test_login[user_data0] PASSED
services/core/test_user_model.py::TestUserModel::test_login[user_data1] PASSED
services/core/test_user_model.py::TestUserModel::test_login_exception PASSED
services/core/test_user_model.py::TestUserModel::test_delete_user_tokens PASSED
services/core/test_user_model.py::TestUserModel::test_delete_user_tokens_exception PASSED
services/core/test_user_model.py::TestUserModel::test_refresh_token_expiry PASSED
services/core/test_user_model.py::TestUserModel::test_invalid_token PASSED
services/core/test_user_model.py::TestUserModel::test_validate_token PASSED
services/core/test_user_model.py::TestUserModel::test_token_expiration SKIPPED
services/core/test_user_model.py::TestUserModel::test_delete_token PASSED
services/core/test_user_model.py::TestUserModel::test_delete_token_exception PASSED
services/core/test_user_model.py::TestUserModel::test_delete_all_user_tokens PASSED
services/core/test_user_model.py::TestUserModel::test_no_user_exists PASSED
services/core/test_user_model.py::TestUserModel::test_user_exists[True-1] PASSED
services/core/test_user_model.py::TestUserModel::test_user_exists[False-None] PASSED
services/core/test_user_model.py::TestUserModel::test__get_password_history PASSED
services/core/test_user_model.py::TestUserModel::test__get_password_history_exception PASSED
services/core/test_user_model.py::TestUserModel::test__insert_pwd_history[HASHED_PWD_1-pwd_history_list0-{"pwd": "HASHED_PWD_1", "user_id": 2}] PASSED
services/core/test_user_model.py::TestUserModel::test__insert_pwd_history[HASHED_PWD_2-pwd_history_list1-{"pwd": "HASHED_PWD_2", "user_id": 2}] PASSED
services/core/test_user_model.py::TestUserModel::test__insert_pwd_history_and_delete_oldest_pwd_if_count_exceeds[HASHED_PWD_4-pwd_history_list0] PASSED

======================================================== 75 passed, 1 skipped in 1.56 seconds =========================================================

```