### PR TITLE
FOGL-1241 removed +00:00 UTC representation for user and user_login tables in sqlite and postgres will remain as with tz

### DIFF
--- a/python/foglamp/services/core/user_model.py
+++ b/python/foglamp/services/core/user_model.py
@@ -255,8 +255,8 @@ class User:
             """
 
             storage_client = connect.get_storage()
-            token_expiration_format = '{"column": "token_expiration", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "token_expiration"}'
-            payload = PayloadBuilder().SELECT(token_expiration_format).WHERE(['token', '=', token]).payload()
+            token_expiration = '{"column": "token_expiration", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "token_expiration"}'
+            payload = PayloadBuilder().SELECT(token_expiration).WHERE(['token', '=', token]).payload()
             result = storage_client.query_tbl_with_payload('user_logins', payload)
 
             if len(result['rows']) == 0:
@@ -297,8 +297,8 @@ class User:
             age = int(category_item['value'])
 
             # get user info on the basis of username
-            pwd_last_changed_format = '{"column": "pwd_last_changed", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "pwd_last_changed"}'
-            payload = PayloadBuilder().SELECT("pwd", "id", "role_id", pwd_last_changed_format).WHERE(['uname', '=', username]).\
+            pwd_last_changed = '{"column": "pwd_last_changed", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "pwd_last_changed"}'
+            payload = PayloadBuilder().SELECT("pwd", "id", "role_id", pwd_last_changed).WHERE(['uname', '=', username]).\
                 AND_WHERE(['enabled', '=', 't']).payload()
             result = storage_client.query_tbl_with_payload('users', payload)
             if len(result['rows']) == 0:

--- a/python/foglamp/services/core/user_model.py
+++ b/python/foglamp/services/core/user_model.py
@@ -255,7 +255,8 @@ class User:
             """
 
             storage_client = connect.get_storage()
-            payload = PayloadBuilder().SELECT("token_expiration").WHERE(['token', '=', token]).payload()
+            token_expiration_format = '{"column": "token_expiration", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "token_expiration"}'
+            payload = PayloadBuilder().SELECT(token_expiration_format).WHERE(['token', '=', token]).payload()
             result = storage_client.query_tbl_with_payload('user_logins', payload)
 
             if len(result['rows']) == 0:
@@ -296,7 +297,8 @@ class User:
             age = int(category_item['value'])
 
             # get user info on the basis of username
-            payload = PayloadBuilder().SELECT("pwd", "id", "role_id", "pwd_last_changed").WHERE(['uname', '=', username]).\
+            pwd_last_changed_format = '{"column": "pwd_last_changed", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "pwd_last_changed"}'
+            payload = PayloadBuilder().SELECT("pwd", "id", "role_id", pwd_last_changed_format).WHERE(['uname', '=', username]).\
                 AND_WHERE(['enabled', '=', 't']).payload()
             result = storage_client.query_tbl_with_payload('users', payload)
             if len(result['rows']) == 0:

--- a/python/foglamp/services/core/user_model.py
+++ b/python/foglamp/services/core/user_model.py
@@ -262,7 +262,7 @@ class User:
                 raise User.InvalidToken("Token appears to be invalid")
 
             r = result['rows'][0]
-            token_expiry = r["token_expiration"][:-6]
+            token_expiry = r["token_expiration"]
 
             curr_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
 
@@ -306,7 +306,7 @@ class User:
 
             # check age of password
             t1 = datetime.now()
-            t2 = datetime.strptime(found_user['pwd_last_changed'][:-6], "%Y-%m-%d %H:%M:%S.%f")  # ignore timezone
+            t2 = datetime.strptime(found_user['pwd_last_changed'], "%Y-%m-%d %H:%M:%S.%f")
             delta = t1 - t2
             if age == 0:
                 # user will not be forced to change their password.

--- a/scripts/plugins/storage/postgres/init.sql
+++ b/scripts/plugins/storage/postgres/init.sql
@@ -568,7 +568,7 @@ CREATE TABLE foglamp.users (
        pwd               character varying(255)      COLLATE pg_catalog."default",
        public_key        character varying(255)      COLLATE pg_catalog."default",
        enabled           boolean                     NOT NULL DEFAULT TRUE,
-       pwd_last_changed  timestamp(6) with time zone NOT NULL DEFAULT now(),
+       pwd_last_changed  timestamp(6) without time zone NOT NULL DEFAULT now(),
        access_method smallint                        NOT NULL DEFAULT 0,
           CONSTRAINT users_pkey PRIMARY KEY (id),
           CONSTRAINT users_fk1 FOREIGN KEY (role_id)
@@ -588,9 +588,9 @@ CREATE TABLE foglamp.user_logins (
        id               integer                     NOT NULL DEFAULT nextval('foglamp.user_logins_id_seq'::regclass),
        user_id          integer                     NOT NULL,
        ip               inet                        NOT NULL DEFAULT '0.0.0.0'::inet,
-       ts               timestamp(6) with time zone NOT NULL DEFAULT now(),
+       ts               timestamp(6) without time zone NOT NULL DEFAULT now(),
        token            character varying(255)      NOT NULL,
-       token_expiration timestamp(6) with time zone NOT NULL,
+       token_expiration timestamp(6) without time zone NOT NULL,
        CONSTRAINT user_logins_pkey PRIMARY KEY (id),
        CONSTRAINT user_logins_fk1 FOREIGN KEY (user_id)
        REFERENCES foglamp.users (id) MATCH SIMPLE

--- a/scripts/plugins/storage/postgres/init.sql
+++ b/scripts/plugins/storage/postgres/init.sql
@@ -568,7 +568,7 @@ CREATE TABLE foglamp.users (
        pwd               character varying(255)      COLLATE pg_catalog."default",
        public_key        character varying(255)      COLLATE pg_catalog."default",
        enabled           boolean                     NOT NULL DEFAULT TRUE,
-       pwd_last_changed  timestamp(6) without time zone NOT NULL DEFAULT now(),
+       pwd_last_changed  timestamp(6) with time zone NOT NULL DEFAULT now(),
        access_method smallint                        NOT NULL DEFAULT 0,
           CONSTRAINT users_pkey PRIMARY KEY (id),
           CONSTRAINT users_fk1 FOREIGN KEY (role_id)
@@ -588,9 +588,9 @@ CREATE TABLE foglamp.user_logins (
        id               integer                     NOT NULL DEFAULT nextval('foglamp.user_logins_id_seq'::regclass),
        user_id          integer                     NOT NULL,
        ip               inet                        NOT NULL DEFAULT '0.0.0.0'::inet,
-       ts               timestamp(6) without time zone NOT NULL DEFAULT now(),
+       ts               timestamp(6) with time zone NOT NULL DEFAULT now(),
        token            character varying(255)      NOT NULL,
-       token_expiration timestamp(6) without time zone NOT NULL,
+       token_expiration timestamp(6) with time zone NOT NULL,
        CONSTRAINT user_logins_pkey PRIMARY KEY (id),
        CONSTRAINT user_logins_fk1 FOREIGN KEY (user_id)
        REFERENCES foglamp.users (id) MATCH SIMPLE

--- a/scripts/plugins/storage/sqlite/init.sql
+++ b/scripts/plugins/storage/sqlite/init.sql
@@ -392,7 +392,7 @@ CREATE TABLE foglamp.users (
        pwd               character varying(255) ,
        public_key        character varying(255) ,
        enabled           boolean                NOT NULL DEFAULT 't',
-       pwd_last_changed  DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW')),
+       pwd_last_changed  DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
        access_method     smallint               NOT NULL DEFAULT 0,
           CONSTRAINT users_fk1 FOREIGN KEY (role_id)
           REFERENCES roles (id) MATCH SIMPLE
@@ -411,7 +411,7 @@ CREATE TABLE foglamp.user_logins (
        id               INTEGER   PRIMARY KEY AUTOINCREMENT,
        user_id          integer   NOT NULL,
        ip               inet      NOT NULL DEFAULT '0.0.0.0',
-       ts               DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW')),
+       ts               DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
        token            character varying(255)      NOT NULL,
        token_expiration DATETIME NOT NULL,
        CONSTRAINT user_logins_fk1 FOREIGN KEY (user_id)

--- a/tests/unit/python/foglamp/services/core/test_user_model.py
+++ b/tests/unit/python/foglamp/services/core/test_user_model.py
@@ -274,7 +274,7 @@ class TestUserModel:
         async def mock_get_category_item():
             return {"value": "0"}
 
-        pwd_result = {'count': 1, 'rows': [{'role_id': '2', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '2', 'pwd_last_changed': '2018-03-30 12:32:08.216159+05:30'}]}
+        pwd_result = {'count': 1, 'rows': [{'role_id': '2', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '2', 'pwd_last_changed': '2018-03-30 12:32:08.216159'}]}
         payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
@@ -294,7 +294,7 @@ class TestUserModel:
         async def mock_get_category_item():
             return {"value": "30"}
 
-        pwd_result = {'count': 1, 'rows': [{'role_id': '2', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '2', 'pwd_last_changed': '2018-01-30 12:32:08.216159+05:30'}]}
+        pwd_result = {'count': 1, 'rows': [{'role_id': '2', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '2', 'pwd_last_changed': '2018-01-30 12:32:08.216159'}]}
         payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
@@ -309,8 +309,8 @@ class TestUserModel:
             mock_get_cat_patch.assert_called_once_with('rest_api', 'passwordChange')
 
     @pytest.mark.parametrize("user_data", [
-        ({'count': 1, 'rows': [{'role_id': '1', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '1', 'is_admin': True, 'pwd_last_changed': '2018-03-30 12:32:08.216159+05:30'}]}),
-        ({'count': 1, 'rows': [{'role_id': '2', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '2', 'is_admin': False, 'pwd_last_changed': '2018-03-29 05:05:08.216159+05:30'}]})
+        ({'count': 1, 'rows': [{'role_id': '1', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '1', 'is_admin': True, 'pwd_last_changed': '2018-03-30 12:32:08.216159'}]}),
+        ({'count': 1, 'rows': [{'role_id': '2', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '2', 'is_admin': False, 'pwd_last_changed': '2018-03-29 05:05:08.216159'}]})
     ])
     async def test_login(self, user_data):
         async def mock_get_category_item():
@@ -342,7 +342,7 @@ class TestUserModel:
         async def mock_get_category_item():
             return {"value": "0"}
 
-        pwd_result = {'count': 1, 'rows': [{'role_id': '1', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '1', 'pwd_last_changed': '2018-03-30 12:32:08.216159+05:30'}]}
+        pwd_result = {'count': 1, 'rows': [{'role_id': '1', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '1', 'pwd_last_changed': '2018-03-30 12:32:08.216159'}]}
         expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'delete'}
         payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
@@ -406,7 +406,7 @@ class TestUserModel:
             query_tbl_patch.assert_called_once_with('user_logins', payload)
 
     def test_validate_token(self):
-        valid_token_result = {'rows': [{"token_expiration": "2017-03-14 15:09:19.800648+05:30"}], 'count': 1}
+        valid_token_result = {'rows': [{"token_expiration": "2017-03-14 15:09:19.800648"}], 'count': 1}
         storage_client_mock = MagicMock(StorageClient)
         payload = '{"return": ["token_expiration"], "where": {"column": "token", "condition": "=", "value": "foglamp"}}'
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):

--- a/tests/unit/python/foglamp/services/core/test_user_model.py
+++ b/tests/unit/python/foglamp/services/core/test_user_model.py
@@ -257,7 +257,7 @@ class TestUserModel:
         async def mock_get_category_item():
             return {"value": "0"}
 
-        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "admin", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
+        payload = '{"return": ["pwd", "id", "role_id", {"column": "pwd_last_changed", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias": "pwd_last_changed"}], "where": {"column": "uname", "condition": "=", "value": "admin", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat_patch:
@@ -275,7 +275,7 @@ class TestUserModel:
             return {"value": "0"}
 
         pwd_result = {'count': 1, 'rows': [{'role_id': '2', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '2', 'pwd_last_changed': '2018-03-30 12:32:08.216159'}]}
-        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
+        payload = '{"return": ["pwd", "id", "role_id", {"column": "pwd_last_changed", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias": "pwd_last_changed"}], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat_patch:
@@ -295,7 +295,7 @@ class TestUserModel:
             return {"value": "30"}
 
         pwd_result = {'count': 1, 'rows': [{'role_id': '2', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '2', 'pwd_last_changed': '2018-01-30 12:32:08.216159'}]}
-        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
+        payload = '{"return": ["pwd", "id", "role_id", {"column": "pwd_last_changed", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias": "pwd_last_changed"}], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat_patch:
@@ -316,7 +316,7 @@ class TestUserModel:
         async def mock_get_category_item():
             return {"value": "0"}
 
-        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
+        payload = '{"return": ["pwd", "id", "role_id", {"column": "pwd_last_changed", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias": "pwd_last_changed"}], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat_patch:
@@ -344,7 +344,7 @@ class TestUserModel:
 
         pwd_result = {'count': 1, 'rows': [{'role_id': '1', 'pwd': '3759bf3302f5481e8c9cc9472c6088ac', 'id': '1', 'pwd_last_changed': '2018-03-30 12:32:08.216159'}]}
         expected = {'message': 'Something went wrong', 'retryable': False, 'entryPoint': 'delete'}
-        payload = '{"return": ["pwd", "id", "role_id", "pwd_last_changed"], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
+        payload = '{"return": ["pwd", "id", "role_id", {"column": "pwd_last_changed", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias": "pwd_last_changed"}], "where": {"column": "uname", "condition": "=", "value": "user", "and": {"column": "enabled", "condition": "=", "value": "t"}}}'
         storage_client_mock = MagicMock(StorageClient)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat_patch:
@@ -395,7 +395,7 @@ class TestUserModel:
 
     def test_invalid_token(self):
         storage_client_mock = MagicMock(StorageClient)
-        payload = '{"return": ["token_expiration"], "where": {"column": "token", "condition": "=", "value": "blah"}}'
+        payload = '{"return": [{"column": "token_expiration", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias": "token_expiration"}], "where": {"column": "token", "condition": "=", "value": "blah"}}'
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value={'rows': [], 'count': 0}) as query_tbl_patch:
                 with pytest.raises(Exception) as excinfo:


### PR DESCRIPTION
- [x] python tests -- all pass [=== 49 passed, 1 skipped in 0.61 seconds ===]
- [x] schema changes without +00.00 for sqlite storage plugins (removed only for auth specific stuff)
- [x] authentication is working with both plugins against this branch (manually verified)


**NOTE**: We need some deep testing to make sure authentication work would not be affected.