### PR TITLE
FOGL-1255 -Payload builder fixes for timestamp fields; ignored tz

### DIFF
--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -163,7 +163,8 @@ class ConfigurationManager(ConfigurationManagerSingleton):
 
     async def _read_all_category_names(self):
         # SELECT configuration.key, configuration.description, configuration.value, configuration.ts FROM configuration
-        payload = PayloadBuilder().SELECT(("key", "description", "value", "ts")).payload()
+        ts = '{"column": "ts", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "timestamp"}'
+        payload = PayloadBuilder().SELECT(("key", "description", "value", ts)).payload()
         results = self._storage.query_tbl_with_payload('configuration', payload)
 
         category_info = []

--- a/python/foglamp/services/core/api/audit.py
+++ b/python/foglamp/services/core/api/audit.py
@@ -188,7 +188,8 @@ async def get_audit_entries(request):
     try:
         # HACK: This way when we can more future we do not get an exponential
         # explosion of if statements
-        payload = PayloadBuilder().WHERE(['1', '=', 1])
+        ts = '{"column": "ts", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "timestamp"}'
+        payload = PayloadBuilder().SELECT("code", "level", "log", ts).WHERE(['1', '=', 1])
         if source is not None:
             payload.AND_WHERE(['code', '=', source])
 
@@ -225,7 +226,7 @@ async def get_audit_entries(request):
             severity_level = int(row["level"])
             r["severity"] = Severity(severity_level).name if severity_level in (0, 1, 2, 4) else "UNKNOWN"
             r["source"] = row["code"]
-            r["timestamp"] = row["ts"]
+            r["timestamp"] = row["timestamp"]
 
             res.append(r)
 

--- a/python/foglamp/services/core/api/scheduler.py
+++ b/python/foglamp/services/core/api/scheduler.py
@@ -681,8 +681,10 @@ async def get_tasks_latest(request):
 
               curl -X GET  http://localhost:8081/foglamp/task/latest?name=xxx
     """
+    start_ts = '{"column": "start_time", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "start_time"}'
+    end_ts = '{"column": "end_time", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "end_time"}'
     payload = PayloadBuilder().SELECT(
-        ("id", "process_name", "state", "start_time", "end_time", "reason", "pid", "exit_code")) \
+        ("id", "process_name", "state", start_ts, end_ts, "reason", "pid", "exit_code")) \
         .ORDER_BY(["process_name", "asc"], ["start_time", "desc"]).payload()
 
     if 'name' in request.query and request.query['name'] != '':

--- a/python/foglamp/services/core/api/statistics.py
+++ b/python/foglamp/services/core/api/statistics.py
@@ -69,8 +69,8 @@ async def get_statistics_history(request):
         interval_in_secs = sum([a * b for a, b in zip(ftr, map(int, time_str.split(':')))])
     else:
         raise web.HTTPNotFound(reason="No stats collector schedule found")
-
-    stats_history_chain_payload = PayloadBuilder().SELECT(("history_ts", "key", "value")).ORDER_BY(['history_ts', 'desc']).chain_payload()
+    history_ts = '{"column": "history_ts", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "history_ts"}'
+    stats_history_chain_payload = PayloadBuilder().SELECT((history_ts, "key", "value")).ORDER_BY(['history_ts', 'desc']).chain_payload()
     if 'limit' in request.query and request.query['limit'] != '':
         try:
             limit = int(request.query['limit'])

--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -1416,7 +1416,10 @@ class Scheduler(object):
 
     async def get_task(self, task_id: uuid.UUID) -> Task:
         """Retrieves a task given its id"""
-        query_payload = PayloadBuilder().WHERE(["id", "=", str(task_id)]).payload()
+        start_ts = '{"column": "start_time", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "start_time"}'
+        end_ts = '{"column": "end_time", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "end_time"}'
+        query_payload = PayloadBuilder().SELECT("id", "process_name", "state", start_ts, end_ts, "reason", "exit_code")\
+            .WHERE(["id", "=", str(task_id)]).payload()
 
         try:
             self._logger.debug('Database command: %s', query_payload)
@@ -1450,8 +1453,9 @@ class Scheduler(object):
                 A tuple of Task attributes to sort by.
                 Defaults to ("start_time", "desc")
         """
-
-        chain_payload = PayloadBuilder().LIMIT(limit).chain_payload()
+        start_ts = '{"column": "start_time", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "start_time"}'
+        end_ts = '{"column": "end_time", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "end_time"}'
+        chain_payload = PayloadBuilder().SELECT("id", "process_name", "state", start_ts, end_ts, "reason", "exit_code").LIMIT(limit).chain_payload()
         if offset:
             chain_payload = PayloadBuilder(chain_payload).OFFSET(offset).chain_payload()
         if where:

--- a/tests/unit/python/foglamp/common/test_configuration_manager.py
+++ b/tests/unit/python/foglamp/common/test_configuration_manager.py
@@ -915,13 +915,10 @@ class TestConfigurationManager:
 
     @pytest.mark.asyncio
     async def test__read_all_category_names_1_row(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClient)
         storage_client_mock.query_tbl_with_payload.return_value = {
             'rows': [{'key': 'key1', 'description': 'description1'}]}
+        ts = '{"column": "ts", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "timestamp"}'
         c_mgr = ConfigurationManager(storage_client_mock)
 
         with patch.object(PayloadBuilder, '__init__', return_value=None) as pbinitpatch:
@@ -929,7 +926,7 @@ class TestConfigurationManager:
                 with patch.object(PayloadBuilder, 'payload', return_value=None) as pbpayloadpatch:
                     ret_val = await c_mgr._read_all_category_names()
         pbselectpatch.assert_called_once_with(
-            ("key", "description", "value", "ts"))
+            ("key", "description", "value", ts))
         pbpayloadpatch.assert_called_once_with()
         storage_client_mock.query_tbl_with_payload.assert_called_once_with(
             'configuration', None)
@@ -937,21 +934,18 @@ class TestConfigurationManager:
 
     @pytest.mark.asyncio
     async def test__read_all_category_names_2_row(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClient)
         storage_client_mock.query_tbl_with_payload.return_value = {'rows': [
             {'key': 'key1', 'description': 'description1'}, {'key': 'key2', 'description': 'description2'}]}
         c_mgr = ConfigurationManager(storage_client_mock)
+        ts = '{"column": "ts", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "timestamp"}'
 
         with patch.object(PayloadBuilder, '__init__', return_value=None) as pbinitpatch:
             with patch.object(PayloadBuilder, 'SELECT', return_value=PayloadBuilder) as pbselectpatch:
                 with patch.object(PayloadBuilder, 'payload', return_value=None) as pbpayloadpatch:
                     ret_val = await c_mgr._read_all_category_names()
         pbselectpatch.assert_called_once_with(
-            ("key", "description", "value", "ts"))
+            ("key", "description", "value", ts))
         pbpayloadpatch.assert_called_once_with()
         storage_client_mock.query_tbl_with_payload.assert_called_once_with(
             'configuration', None)
@@ -959,20 +953,17 @@ class TestConfigurationManager:
 
     @pytest.mark.asyncio
     async def test__read_all_category_names_0_row(self, reset_singleton):
-
-        async def async_mock(return_value):
-            return return_value
-
         storage_client_mock = MagicMock(spec=StorageClient)
         storage_client_mock.query_tbl_with_payload.return_value = {'rows': []}
         c_mgr = ConfigurationManager(storage_client_mock)
+        ts = '{"column": "ts", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "timestamp"}'
 
         with patch.object(PayloadBuilder, '__init__', return_value=None) as pbinitpatch:
             with patch.object(PayloadBuilder, 'SELECT', return_value=PayloadBuilder) as pbselectpatch:
                 with patch.object(PayloadBuilder, 'payload', return_value=None) as pbpayloadpatch:
                     ret_val = await c_mgr._read_all_category_names()
         pbselectpatch.assert_called_once_with(
-            ("key", "description", "value", "ts"))
+            ("key", "description", "value", ts))
         pbpayloadpatch.assert_called_once_with()
         storage_client_mock.query_tbl_with_payload.assert_called_once_with(
             'configuration', None)

--- a/tests/unit/python/foglamp/services/core/api/test_audit.py
+++ b/tests/unit/python/foglamp/services/core/api/test_audit.py
@@ -93,13 +93,13 @@ class TestAudit:
             log_code_patch.assert_called_once_with('log_codes')
 
     @pytest.mark.parametrize("request_params, payload", [
-        ('', '{"where": {"column": "1", "condition": "=", "value": 1}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}'),
-        ('?source=PURGE', '{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "code", "condition": "=", "value": "PURGE"}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}'),
-        ('?skip=1', '{"where": {"column": "1", "condition": "=", "value": 1}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20, "skip": 1}'),
-        ('?severity=failure', '{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "level", "condition": "=", "value": 1}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}'),
-        ('?severity=FAILURE&limit=1', '{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "level", "condition": "=", "value": 1}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 1}'),
-        ('?severity=INFORMATION&limit=1&skip=1', '{"where": {"column": "1", "condition": "=", "value": 1, "and": {"column": "level", "condition": "=", "value": 4}}, "sort": {"column": "ts", "direction": "desc"}, "limit": 1, "skip": 1}'),
-        ('?source=&severity=&limit=&skip=', '{"where": {"column": "1", "condition": "=", "value": 1}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}')
+        ('', {"return": ["code", "level", "log", {"column": "ts", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias": "timestamp"}], "where": {"column": "1", "condition": "=", "value": 1}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}),
+        ('?source=PURGE', {'return': ['code', 'level', 'log', {'format': 'YYYY-MM-DD HH24:MI:SS.MS', 'column': 'ts', 'alias': 'timestamp'}], 'where': {'value': 1, 'and': {'value': 'PURGE', 'column': 'code', 'condition': '='}, 'column': '1', 'condition': '='}, 'sort': {'direction': 'desc', 'column': 'ts'}, 'limit': 20}),
+        ('?skip=1', {'where': {'value': 1, 'column': '1', 'condition': '='}, 'limit': 20, 'return': ['code', 'level', 'log', {'column': 'ts', 'format': 'YYYY-MM-DD HH24:MI:SS.MS', 'alias': 'timestamp'}], 'skip': 1, 'sort': {'direction': 'desc', 'column': 'ts'}}),
+        ('?severity=failure', {'where': {'and': {'value': 1, 'column': 'level', 'condition': '='}, 'value': 1, 'column': '1', 'condition': '='}, 'limit': 20, 'return': ['code', 'level', 'log', {'column': 'ts', 'format': 'YYYY-MM-DD HH24:MI:SS.MS', 'alias': 'timestamp'}], 'sort': {'direction': 'desc', 'column': 'ts'}}),
+        ('?severity=FAILURE&limit=1', {'limit': 1, 'sort': {'direction': 'desc', 'column': 'ts'}, 'return': ['code', 'level', 'log', {'column': 'ts', 'format': 'YYYY-MM-DD HH24:MI:SS.MS', 'alias': 'timestamp'}], 'where': {'value': 1, 'condition': '=', 'and': {'value': 1, 'condition': '=', 'column': 'level'}, 'column': '1'}}),
+        ('?severity=INFORMATION&limit=1&skip=1', {'limit': 1, 'sort': {'direction': 'desc', 'column': 'ts'}, 'return': ['code', 'level', 'log', {'column': 'ts', 'format': 'YYYY-MM-DD HH24:MI:SS.MS', 'alias': 'timestamp'}], 'skip': 1, 'where': {'value': 1, 'condition': '=', 'and': {'value': 4, 'condition': '=', 'column': 'level'}, 'column': '1'}}),
+        ('?source=&severity=&limit=&skip=', {'limit': 20, 'sort': {'direction': 'desc', 'column': 'ts'}, 'return': ['code', 'level', 'log', {'column': 'ts', 'format': 'YYYY-MM-DD HH24:MI:SS.MS', 'alias': 'timestamp'}], 'where': {'value': 1, 'condition': '=', 'column': '1'}})
     ])
     async def test_get_audit_with_params(self, client, request_params, payload, get_log_codes):
         storage_client_mock = MagicMock(StorageClient)
@@ -107,7 +107,7 @@ class TestAudit:
                                       "start_time": "2018-01-30 18:39:48.1517317788", "rowsRemoved": 0,
                                       "unsentRowsRemoved": 0, "rowsRetained": 0},
                               "code": "PURGE", "level": "4", "id": 2,
-                              "ts": "2018-01-30 18:39:48.796263+05:30", 'count': 1}]}
+                              "timestamp": "2018-01-30 18:39:48.796263", 'count': 1}]}
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
             with patch.object(storage_client_mock, 'query_tbl', return_value=get_log_codes):
                 with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=response) as log_code_patch:
@@ -117,7 +117,10 @@ class TestAudit:
                     json_response = json.loads(result)
                     assert 1 == json_response['totalCount']
                     assert 1 == len(json_response['audit'])
-                log_code_patch.assert_called_with('log', payload)
+                args, kwargs = log_code_patch.call_args
+                assert 'log' == args[0]
+                p = json.loads(args[1])
+                assert payload == p
 
     @pytest.mark.parametrize("request_params, response_code, response_message", [
         ('?source=BLA', 400, "BLA is not a valid source"),

--- a/tests/unit/python/foglamp/services/core/api/test_statistics_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_statistics_api.py
@@ -60,9 +60,9 @@ class TestStatistics:
                 assert "Internal Server Error" == resp.reason
 
     async def test_get_statistics_history(self, client):
-        output = {"interval": 60, 'statistics': [{"READINGS": 1, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:24.321589+05:30"},
-                                                 {"READINGS": 0, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:09.321589+05:30"}]}
-        p1 = {'return': ['history_ts', 'key', 'value'], 'sort': {'direction': 'desc', 'column': 'history_ts'}}
+        output = {"interval": 60, 'statistics': [{"READINGS": 1, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:24.321589"},
+                                                 {"READINGS": 0, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:09.321589"}]}
+        p1 = {"return": [{"alias": "history_ts", "column": "history_ts", "format": "YYYY-MM-DD HH24:MI:SS.MS"}, "key", "value"], "sort": {"column": "history_ts", "direction": "desc"}}
         p2 = {"return": ["schedule_interval"],
               "where": {"column": "process_name", "condition": "=", "value": "stats collector"}}
 
@@ -72,10 +72,10 @@ class TestStatistics:
 
             if table == 'statistics_history':
                 assert p1 == json.loads(payload)
-                return {"rows": [{"key": "READINGS", "value": 1, "history_ts": "2018-02-20 13:16:24.321589+05:30"},
-                                 {"key": "BUFFERED", "value": 10, "history_ts": "2018-02-20 13:16:24.321589+05:30"},
-                                 {"key": "READINGS", "value": 0, "history_ts": "2018-02-20 13:16:09.321589+05:30"},
-                                 {"key": "BUFFERED", "value": 10, "history_ts": "2018-02-20 13:16:09.321589+05:30"}]}
+                return {"rows": [{"key": "READINGS", "value": 1, "history_ts": "2018-02-20 13:16:24.321589"},
+                                 {"key": "BUFFERED", "value": 10, "history_ts": "2018-02-20 13:16:24.321589"},
+                                 {"key": "READINGS", "value": 0, "history_ts": "2018-02-20 13:16:09.321589"},
+                                 {"key": "BUFFERED", "value": 10, "history_ts": "2018-02-20 13:16:09.321589"}]}
 
             if table == 'schedules':
                 assert p2 == json.loads(payload)
@@ -92,13 +92,12 @@ class TestStatistics:
         assert 2 == query_patch.call_count
 
     async def test_get_statistics_history_limit(self, client):
-        output = {"interval": 60, 'statistics': [{"READINGS": 1, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:24.321589+05:30"},
-                                                 {"READINGS": 0, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:09.321589+05:30"}]}
+        output = {"interval": 60, 'statistics': [{"READINGS": 1, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:24.321589"},
+                                                 {"READINGS": 0, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:09.321589"}]}
 
         p1 = {"aggregate": {"operation": "count", "column": "*"}}
         # payload limit will be request limit*2 i.e. via p1 query
-        p2 = {'limit': 2, 'sort': {'direction': 'desc', 'column': 'history_ts'},
-              'return': ['history_ts', 'key', 'value']}
+        p2 = {"return": [{"column": "history_ts", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias": "history_ts"}, "key", "value"], "sort": {"column": "history_ts", "direction": "desc"}, "limit": 2}
         p3 = {"return": ["schedule_interval"],
               "where": {"column": "process_name", "condition": "=", "value": "stats collector"}}
 
@@ -112,10 +111,10 @@ class TestStatistics:
 
             if table == 'statistics_history':
                 assert p2 == json.loads(payload)
-                return {"rows": [{"key": "READINGS", "value": 1, "history_ts": "2018-02-20 13:16:24.321589+05:30"},
-                                 {"key": "BUFFERED", "value": 10, "history_ts": "2018-02-20 13:16:24.321589+05:30"},
-                                 {"key": "READINGS", "value": 0, "history_ts": "2018-02-20 13:16:09.321589+05:30"},
-                                 {"key": "BUFFERED", "value": 10, "history_ts": "2018-02-20 13:16:09.321589+05:30"}]}
+                return {"rows": [{"key": "READINGS", "value": 1, "history_ts": "2018-02-20 13:16:24.321589"},
+                                 {"key": "BUFFERED", "value": 10, "history_ts": "2018-02-20 13:16:24.321589"},
+                                 {"key": "READINGS", "value": 0, "history_ts": "2018-02-20 13:16:09.321589"},
+                                 {"key": "BUFFERED", "value": 10, "history_ts": "2018-02-20 13:16:09.321589"}]}
 
             if table == 'schedules':
                 assert p3 == json.loads(payload)


### PR DESCRIPTION
- [x] configuration
- [x] audit
- [x] scheduler tasks
- [x] stats history
- [ ] back up need to fix once https://scaledb.atlassian.net/browse/FOGL-1253 resolved

**Tests O/P**
`=== 951 passed, 12 skipped in 53.02 seconds ===`

**Tested with both storage engines**, No regression