### PR TITLE
FOGL-1265 delete configuration response fixes

### DIFF
--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -272,7 +272,11 @@ async def delete_configuration_item_value(request):
     # TODO: make it optimized and elegant
     cf_mgr = ConfigurationManager(connect.get_storage())
     try:
-        await cf_mgr.set_category_item_value_entry(category_name, config_item, '')
+        category_item = await cf_mgr.get_category_item(category_name, config_item)
+        if category_item is None:
+            raise ValueError
+
+        await cf_mgr.set_category_item_value_entry(category_name, config_item, category_item['default'])
     except ValueError:
         raise web.HTTPNotFound(reason="No detail found for the category_name: {} and config_item: {}".format(category_name, config_item))
 

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -165,8 +165,19 @@ class TestConfiguration:
                 patch_get_cat_item.assert_called_once_with(category_name, item_name)
             patch_set_entry.assert_called_once_with(category_name, item_name, payload['value'])
 
+    async def test_set_config_item_exception(self, client, category_name='rest_api', item_name='http_port'):
+        payload = {"value": '8082'}
+        storage_client_mock = MagicMock(StorageClient)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+            with patch.object(c_mgr, 'set_category_item_value_entry', side_effect=ValueError) as patch_set_entry:
+                resp = await client.put('/foglamp/category/{}/{}'.format(category_name, item_name), data=json.dumps(payload))
+                assert 404 == resp.status
+                assert "No detail found for the category_name: {} and config_item: {}".format(category_name, item_name) == resp.reason
+            patch_set_entry.assert_called_once_with(category_name, item_name, payload['value'])
+
     async def test_delete_config_item(self, client, category_name='rest_api', item_name='http_port'):
-        result = {'value': '', 'type': 'integer', 'default': '8081',
+        result = {'value': '8081', 'type': 'integer', 'default': '8081',
                   'description': 'The port to accept HTTP connections on'}
 
         async def async_mock_set_item():
@@ -178,30 +189,55 @@ class TestConfiguration:
         storage_client_mock = MagicMock(StorageClient)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
-            with patch.object(c_mgr, 'set_category_item_value_entry', return_value=async_mock_set_item()) as patch_set_entry:
-                with patch.object(c_mgr, 'get_category_item', return_value=async_mock()) as patch_get_cat_item:
+            with patch.object(c_mgr, 'get_category_item', side_effect=[async_mock(), async_mock()]) as patch_get_cat_item:
+                with patch.object(c_mgr, 'set_category_item_value_entry', return_value=async_mock_set_item()) as patch_set_entry:
                     resp = await client.delete('/foglamp/category/{}/{}/value'.format(category_name, item_name))
                     assert 200 == resp.status
                     r = await resp.text()
                     json_response = json.loads(r)
                     assert result == json_response
-                patch_get_cat_item.assert_called_once_with(category_name, item_name)
-            patch_set_entry.assert_called_once_with(category_name, item_name, '')
+                patch_set_entry.assert_called_once_with(category_name, item_name, result['default'])
+            assert 2 == patch_get_cat_item.call_count
+            args, kwargs = patch_get_cat_item.call_args
+            assert category_name == args[0]
+            assert item_name == args[1]
 
-    async def test_delete_config_item_not_found(self, client, category_name='rest_api', item_name='http_port'):
+    async def test_delete_config_item_not_found_before_set_config(self, client, category_name='rest_api', item_name='http_port'):
         async def async_mock():
             return None
 
         storage_client_mock = MagicMock(StorageClient)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(connect, 'get_storage', return_value=storage_client_mock):
-            with patch.object(c_mgr, 'set_category_item_value_entry', return_value=async_mock()) as patch_set_entry:
-                with patch.object(c_mgr, 'get_category_item', return_value=async_mock()) as patch_get_cat_item:
+            with patch.object(c_mgr, 'get_category_item', return_value=async_mock()) as patch_get_cat_item:
+                resp = await client.delete('/foglamp/category/{}/{}/value'.format(category_name, item_name))
+                assert 404 == resp.status
+                assert "No detail found for the category_name: {} and config_item: {}".format(category_name, item_name) == resp.reason
+            assert 1 == patch_get_cat_item.call_count
+            args, kwargs = patch_get_cat_item.call_args
+            assert category_name == args[0]
+            assert item_name == args[1]
+
+    async def test_delete_config_not_found_after_set_config(self, client, category_name='rest_api', item_name='http_port'):
+        result = {'value': '8081', 'type': 'integer', 'default': '8081',
+                  'description': 'The port to accept HTTP connections on'}
+
+        async def async_mock(return_value):
+            return return_value
+
+        storage_client_mock = MagicMock(StorageClient)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+            with patch.object(c_mgr, 'get_category_item', side_effect=[async_mock(result), async_mock(None)]) as patch_get_cat_item:
+                with patch.object(c_mgr, 'set_category_item_value_entry', return_value=async_mock(None)) as patch_set_entry:
                     resp = await client.delete('/foglamp/category/{}/{}/value'.format(category_name, item_name))
                     assert 404 == resp.status
                     assert "No detail found for the category_name: {} and config_item: {}".format(category_name, item_name) == resp.reason
-                patch_get_cat_item.assert_called_once_with(category_name, item_name)
-            patch_set_entry.assert_called_once_with(category_name, item_name, '')
+                patch_set_entry.assert_called_once_with(category_name, item_name, result['default'])
+            assert 2 == patch_get_cat_item.call_count
+            args, kwargs = patch_get_cat_item.call_args
+            assert category_name == args[0]
+            assert item_name == args[1]
 
     @pytest.mark.parametrize("payload, message", [
         ("blah", "Data payload must be a dictionary"),


### PR DESCRIPTION
1) curl -X GET http://localhost:8081/foglamp/category/rest_api/authentication 
```
{
  "description": "To make the authentication mandatory or optional for API calls",
  "type": "string",
  "default": "optional",
  "value": "optional"
}
```

2) curl -X PUT -H "Content-Type: application/json" -d '{"value": "mandatory"}' http://localhost:8081/foglamp/category/rest_api/authentication
```
{
  "description": "To make the authentication mandatory or optional for API calls",
  "type": "string",
  "default": "optional",
  "value": "mandatory"
}
```
3) curl -X DELETE http://localhost:8081/foglamp/category/rest_api/authentication/value 
```
{
  "description": "To make the authentication mandatory or optional for API calls",
  "type": "string",
  "default": "optional",
  "value": "optional"
}
```

**Tests O/P** - No regression with this change and code coverage for this file to now **100%**

`== 1000 passed, 13 skipped in 64.15 seconds ==`