### PR TITLE
FOGL-1255 payload builder fixes to ignore timezone for back up endpoints

### DIFF
--- a/python/foglamp/plugins/storage/postgres/backup_restore/backup_postgres.py
+++ b/python/foglamp/plugins/storage/postgres/backup_restore/backup_postgres.py
@@ -122,19 +122,14 @@ class Backup(object):
         Raises:
         """
 
+        ts = '{"column": "ts", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "ts"}'
         if status is None:
-            payload = payload_builder.PayloadBuilder() \
-                .LIMIT(limit) \
-                .SKIP(skip) \
-                .ORDER_BY(['ts', sort_order]) \
-                .payload()
+            payload = payload_builder.PayloadBuilder().SELECT("id", "status", ts, "file_name", "type") \
+                      .LIMIT(limit).SKIP(skip).ORDER_BY(['ts', sort_order]).payload()
         else:
-            payload = payload_builder.PayloadBuilder() \
-                .WHERE(['status', '=', status]) \
-                .LIMIT(limit) \
-                .SKIP(skip) \
-                .ORDER_BY(['ts', sort_order]) \
-                .payload()
+            payload = payload_builder.PayloadBuilder().SELECT("id", "status", ts, "file_name", "type")\
+                      .WHERE(['status', '=', status]).LIMIT(limit).SKIP(skip)\
+                      .ORDER_BY(['ts', sort_order]).payload()
 
         backups_from_storage = self._storage.query_tbl_with_payload(self._backup_lib.STORAGE_TABLE_BACKUPS, payload)
 

--- a/python/foglamp/plugins/storage/postgres/backup_restore/lib.py
+++ b/python/foglamp/plugins/storage/postgres/backup_restore/lib.py
@@ -676,10 +676,9 @@ class BackupRestoreLib(object):
             exceptions.DoesNotExist
             exceptions.NotUniqueBackup
         """
-
-        payload = payload_builder.PayloadBuilder() \
-            .WHERE(['id', '=', backup_id]) \
-            .payload()
+        ts = '{"column": "ts", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias" : "ts"}'
+        payload = payload_builder.PayloadBuilder().SELECT("id", "status", ts, "file_name", "type")\
+                  .WHERE(['id', '=', backup_id]).payload()
 
         backup_from_storage = self._storage.query_tbl_with_payload(self.STORAGE_TABLE_BACKUPS, payload)
 


### PR DESCRIPTION
https://scaledb.atlassian.net/browse/FOGL-1255

**Tests O/P** - No regression with this change
`== 998 passed, 13 skipped in 55.02 seconds ==`


1) curl -X GET http://localhost:8081/foglamp/backup/1
```
{
  "status": "COMPLETED",
  "id": 1,
  "date": "2018-04-19 15:49:53.499"
}
```
2) curl -X GET http://localhost:8081/foglamp/backup
```
{
  "backups": [
    {
      "id": 2,
      "date": "2018-04-19 15:59:24.925",
      "status": "RESTORED"
    },
    {
      "id": 1,
      "date": "2018-04-19 15:49:53.499",
      "status": "COMPLETED"
    }
  ]
}
```
3) curl -X GET http://localhost:8081/foglamp/backup?status=completed
```
{
  "backups": [
    {
      "id": 1,
      "date": "2018-04-19 15:49:53.499",
      "status": "COMPLETED"
    }
  ]
}
```
4) curl -X DELETE http://localhost:8081/foglamp/backup/2
```
{
  "message": "Backup deleted successfully"
}
```
5) curl -X POST http://localhost:8081/foglamp/backup
```
{
  "status": "running"
}
```
6) curl -X PUT http://localhost:8081/foglamp/backup/1/restore
```
{
  "status": "running"
}
```