### PR TITLE
FOGL-1274 - When enabled, Sending process tasks do not start again

### DIFF
--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -1302,6 +1302,11 @@ class Scheduler(object):
             raise RuntimeError('Update failed: %s', update_payload)
         await asyncio.sleep(1)
 
+        # Reset schedule_execution.next_start_time
+        schedule_row = self._schedules[schedule_id]
+        now = self.current_time if self.current_time else time.time()
+        self._schedule_first_task(schedule_row, now)
+
         # Start schedule
         await self.queue_task(schedule_id)
 


### PR DESCRIPTION
The code has been tested OK for:
a) When the schedule is already enabled at the start of the foglamp server
b) When the schedule is disabled at the start of the foglamp server and is enabled afterwards
c) (a) + schedule is disabled + enabled keeping the foglamp server running
d) (b) + schedule is enabled + disabled + enabled keeping the foglamp server running

Test result:
`==================================================== 998 passed, 13 skipped in 46.43 seconds ====================================================
`
