### PR TITLE
FOGL-1282: Fix of test_plugin_transform_in_memory_data unit test for OMF

### DIFF
--- a/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
+++ b/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
@@ -129,6 +129,7 @@ class TestOMF:
 
     @pytest.mark.parametrize(
         "p_data_origin, "
+        "type_id, "
         "expected_data_to_send, "
         "expected_is_data_available, "
         "expected_new_position, "
@@ -145,10 +146,11 @@ class TestOMF:
                                             "user_ts": '2018-04-20 09:38:50.163164+00'
                                         }
                                     ],
+                                    "0001",
                                     # Transformed
                                     [
                                         {
-                                            "containerid": "measurement_test_asset_code",
+                                            "containerid": "0001measurement_test_asset_code",
                                             "values": [
                                                 {
                                                     "Time": "2018-04-20T09:38:50.163164Z",
@@ -172,10 +174,11 @@ class TestOMF:
                                                 "user_ts": '2018-04-20 09:38:50.163164+00'
                                             }
                                         ],
+                                        "0001",
                                         # Transformed
                                         [
                                             {
-                                                "containerid": "measurement_test_asset_code",
+                                                "containerid": "0001measurement_test_asset_code",
                                                 "values": [
                                                     {
                                                         "Time": "2018-04-20T09:38:50.163164Z",
@@ -206,10 +209,11 @@ class TestOMF:
                                                 "user_ts": '2018-04-20 09:38:50.163164+00'
                                             }
                                         ],
+                                        "0001",
                                         # Transformed
                                         [
                                             {
-                                                "containerid": "measurement_test_asset_code",
+                                                "containerid": "0001measurement_test_asset_code",
                                                 "values": [
                                                     {
                                                         "Time": "2018-04-20T09:38:50.163164Z",
@@ -218,7 +222,7 @@ class TestOMF:
                                                 ]
                                             },
                                             {
-                                                "containerid": "measurement_test_asset_code",
+                                                "containerid": "0001measurement_test_asset_code",
                                                 "values": [
                                                     {
                                                         "Time": "2018-04-20T09:38:50.163164Z",
@@ -235,6 +239,7 @@ class TestOMF:
         ])
     def test_plugin_transform_in_memory_data(self,
                                              p_data_origin,
+                                             type_id,
                                              expected_data_to_send,
                                              expected_is_data_available,
                                              expected_new_position,
@@ -248,6 +253,8 @@ class TestOMF:
         generated_data_to_send = []
 
         omf_north = omf.OmfNorthPlugin(sending_process_instance, config, config_omf_types, logger)
+
+        omf._config_omf_types = {"type-id": {"value": type_id}}
 
         is_data_available, new_position, num_sent = omf_north.transform_in_memory_data(generated_data_to_send,
                                                                                        p_data_origin)


### PR DESCRIPTION
test_plugin_transform_in_memory_data  fixed, 
it was no more working after FOGL-1277