### PR TITLE
FOGL-1284 value error fixes when repeat interval is more than 1 day

### DIFF
--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -663,6 +663,8 @@ class Scheduler(object):
                     interval_days = 0
                     interval_time = row.get('schedule_interval')
                 s_days = int(interval_days)
+                if not interval_time:
+                    interval_time = "00:00:00"
                 s_interval = datetime.datetime.strptime(interval_time, "%H:%M:%S")
                 interval = datetime.timedelta(days=s_days, hours=s_interval.hour, minutes=s_interval.minute,
                                               seconds=s_interval.second)


### PR DESCRIPTION
Fixed items:
- [x] time format fixes when more than 1 day while fetching stats history 
- [x] same fixed for get schedules (This will reproduce after foglamp stop becoz schedules work as per memory) 
- [x] postgres - :heavy_check_mark: 
- [ ] sqlite - blocked due to [FOGl-1287](https://scaledb.atlassian.net/browse/FOGL-1287)

**Tests O/P** - No regression found

```
=== 1002 passed, 34 skipped in 55.53 seconds ===
```

**Code Coverage :** **100%** 
`70 statements   70 run 0 missing 0 excluded`