### PR TITLE
FOGL-1288: The fix related to the FOGL‌-1277 required a change to the…

### DIFF
--- a/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
+++ b/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
@@ -23,7 +23,6 @@ import foglamp.tasks.north.sending_process as module_sp
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("plugin", "north", "omf")
-@pytest.mark.skip(reason="ERROR - _performance_log - error details |list indices must be integers or slices, not str| -- FOGL-1285")
 class TestOMF:
     """Unit tests for the omf plugin"""
 
@@ -257,7 +256,7 @@ class TestOMF:
 
         omf_north = omf.OmfNorthPlugin(sending_process_instance, config, config_omf_types, logger)
 
-        omf._config_omf_types = {"type-id": {"value": type_id}}
+        omf_north._config_omf_types = {"type-id": {"value": type_id}}
 
         is_data_available, new_position, num_sent = omf_north.transform_in_memory_data(generated_data_to_send,
                                                                                        p_data_origin)


### PR DESCRIPTION
… test.

{code}

foglamp@ubuntu:~/Development/FogLAMP$ pytest -s -vv /home/foglamp/Development/FogLAMP/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
============================================= test session starts ==============================================
platform linux -- Python 3.5.2, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/foglamp/Development/FogLAMP, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 11 items

tests/unit/python/foglamp/plugins/north/omf/test_omf.py::TestOMF::test_plugin_info PASSED
tests/unit/python/foglamp/plugins/north/omf/test_omf.py::TestOMF::test_plugin_init_good PASSED
tests/unit/python/foglamp/plugins/north/omf/test_omf.py::TestOMF::test_plugin_init_bad[data0] PASSED
tests/unit/python/foglamp/plugins/north/omf/test_omf.py::TestOMF::test_plugin_init_bad[data1] PASSED
tests/unit/python/foglamp/plugins/north/omf/test_omf.py::TestOMF::test_plugin_transform_in_memory_data[p_data_origin0-0001-expected_data_to_send0-True-10-1] PASSED
tests/unit/python/foglamp/plugins/north/omf/test_omf.py::TestOMF::test_plugin_transform_in_memory_data[p_data_origin1-0001-expected_data_to_send1-True-11-1] PASSED
tests/unit/python/foglamp/plugins/north/omf/test_omf.py::TestOMF::test_plugin_transform_in_memory_data[p_data_origin2-0001-expected_data_to_send2-True-20-2] PASSED
tests/unit/python/foglamp/plugins/north/omf/test_omf.py::TestOMF::test_plugin_send_ok PASSED
tests/unit/python/foglamp/plugins/north/omf/test_omf.py::TestOMF::test_plugin_send_bad PASSED
tests/unit/python/foglamp/plugins/north/omf/test_omf.py::TestOMF::test_plugin_shutdown PASSED
tests/unit/python/foglamp/plugins/north/omf/test_omf.py::TestOMF::test_plugin_reconfigure PASSED

========================================== 11 passed in 0.17 seconds ===========================================
foglamp@ubuntu:~/Development/FogLAMP$

{code}