### PR TITLE
FOGL-1287 schedule repeat interval fixed for stats and schedule

### DIFF
--- a/python/foglamp/services/core/api/statistics.py
+++ b/python/foglamp/services/core/api/statistics.py
@@ -69,17 +69,18 @@ async def get_statistics_history(request):
         if 'days' in time_str:
             interval_split = time_str.split('days')
             interval_days = interval_split[0].strip()
-            interval_time = interval_split[1].strip()
+            interval_time = interval_split[1]
         elif 'day' in time_str:
             interval_split = time_str.split('day')
             interval_days = interval_split[0].strip()
-            interval_time = interval_split[1].strip()
+            interval_time = interval_split[1]
         else:
             interval_days = 0
             interval_time = time_str
         s_days = int(interval_days)
         if not interval_time:
             interval_time = "00:00:00"
+        interval_time = interval_time.replace(",", "").strip()
         s_interval = datetime.datetime.strptime(interval_time, "%H:%M:%S")
         interval = datetime.timedelta(days=s_days, hours=s_interval.hour, minutes=s_interval.minute, seconds=s_interval.second)
         interval_in_secs = interval.total_seconds()

--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -654,17 +654,18 @@ class Scheduler(object):
                 if 'days' in row.get('schedule_interval'):
                     interval_split = row.get('schedule_interval').split('days')
                     interval_days = interval_split[0].strip()
-                    interval_time = interval_split[1].strip()
+                    interval_time = interval_split[1]
                 elif 'day' in row.get('schedule_interval'):
                     interval_split = row.get('schedule_interval').split('day')
                     interval_days = interval_split[0].strip()
-                    interval_time = interval_split[1].strip()
+                    interval_time = interval_split[1]
                 else:
                     interval_days = 0
                     interval_time = row.get('schedule_interval')
                 s_days = int(interval_days)
                 if not interval_time:
                     interval_time = "00:00:00"
+                interval_time = interval_time.replace(",", "").strip()
                 s_interval = datetime.datetime.strptime(interval_time, "%H:%M:%S")
                 interval = datetime.timedelta(days=s_days, hours=s_interval.hour, minutes=s_interval.minute,
                                               seconds=s_interval.second)

--- a/tests/unit/python/foglamp/services/core/api/test_statistics_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_statistics_api.py
@@ -61,15 +61,29 @@ class TestStatistics:
 
     @pytest.mark.parametrize("interval, schedule_interval", [
         (60, "00:01:00"),
+        (100, "0:01:40"),
+        (3660, "1:01:00"),
+        (3660, "01:01:00"),
+        (86400, "1 day"),
         (86500, "1 day, 00:01:40"),
         (86500, "1 day 00:01:40"),
         (86400, "1 day 0:00:00"),
+        (86400, "1 day, 0:00:00"),
         (172800, "2 days"),
         (172900, "2 days, 0:01:40"),
-        (100, "0 days, 0:01:40"),
+        (179999, "2 days, 01:59:59"),
+        (179940, "2 days 01:59:00"),
+        (176459, "2 days 1:00:59"),
         (0, "0 days"),
         (0, "0 days, 00:00:00"),
-        (1, "0 days, 00:00:01")
+        (0, "0 days 00:00:00"),
+        (3601, "0 days, 1:00:01"),
+        (100, "0 days 0:01:40"),
+        (864000, "10 days"),
+        (867600, "10 days, 01:00:00"),
+        (864000, "10 days 00:00:00"),
+        (864000, "10 days, 0:00:00"),
+        (867600, "10 days 1:00:00")
     ])
     async def test_get_statistics_history(self, client, interval, schedule_interval):
         output = {"interval": interval, 'statistics': [{"READINGS": 1, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:24.321589"},

--- a/tests/unit/python/foglamp/services/core/api/test_statistics_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_statistics_api.py
@@ -61,8 +61,15 @@ class TestStatistics:
 
     @pytest.mark.parametrize("interval, schedule_interval", [
         (60, "00:01:00"),
+        (86500, "1 day, 00:01:40"),
         (86500, "1 day 00:01:40"),
-        (172800, "2 days")
+        (86400, "1 day 0:00:00"),
+        (172800, "2 days"),
+        (172900, "2 days, 0:01:40"),
+        (100, "0 days, 0:01:40"),
+        (0, "0 days"),
+        (0, "0 days, 00:00:00"),
+        (1, "0 days, 00:00:01")
     ])
     async def test_get_statistics_history(self, client, interval, schedule_interval):
         output = {"interval": interval, 'statistics': [{"READINGS": 1, "BUFFERED": 10, "history_ts": "2018-02-20 13:16:24.321589"},


### PR DESCRIPTION
Fix works with both storage engines
- [x] postgres
- [x] sqlite

**Tests O/P**
`=== 1093 passed, 13 skipped in 56.61 seconds ===`