### PR TITLE
Fogl 1290: Extend unit tests for OMF

### DIFF
--- a/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
+++ b/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
@@ -365,6 +365,118 @@ class TestOmfNorthPlugin:
         assert num_sent == expected_num_sent
 
     @pytest.mark.parametrize(
+        "p_data_origin, "
+        "p_stream_id, "
+        "expected_data_to_send, ",
+        [
+                # Case 1 - Two integer values
+                (
+                    # Origin
+                    {
+                        "id": 10,
+                        "asset_code": "test_asset_code_1",
+                        "read_key": "ef6e1368-4182-11e8-842f-0ed5f89f718b",
+                        "reading": {"humidity": 11, "temperature": 38},
+                        "user_ts": '2018-04-20 09:38:50.163164+00'
+                    },
+
+                    # p_stream_id
+                    "0001measurement_""test_asset_code_1",
+
+                    # Expected transformation
+                    [
+                        {
+                            "containerid": "0001measurement_""test_asset_code_1",
+                            "values": [
+                                {
+                                    "Time": "2018-04-20T09:38:50.163164Z",
+                                    "humidity": 11,
+                                    "temperature": 38
+                                }
+                            ]
+                        }
+                    ]
+                ),
+                # Case 2 - String
+                (
+                    # Origin
+                    {
+                        "id": 11,
+                        "asset_code": "test_asset_code_2",
+                        "read_key": "ef6e1368-4182-11e8-842f-0ed5f89f718b",
+                        "reading": {"tick": "tock"},
+                        "user_ts": '2018-04-20 09:38:50.163164+00'
+                    },
+
+                    # p_stream_id
+                    "0001measurement_""test_asset_code_2",
+
+                    # Expected transformation
+                    [
+                        {
+                            "containerid": "0001measurement_""test_asset_code_2",
+                            "values": [
+                                {
+                                    "Time": "2018-04-20T09:38:50.163164Z",
+                                    "tick": "tock"
+                                }
+                            ]
+                        }
+                    ]
+                ),
+
+                # Case 3 - Number 957.2
+                (
+                    # Origin
+                    {
+                        "id": 12,
+                        "asset_code": "test_asset_code_3",
+                        "read_key": "ef6e1368-4182-11e8-842f-0ed5f89f718b",
+                        "reading": {"pressure": 957.2},
+                        "user_ts": '2018-04-20 09:38:50.163164+00'
+                    },
+
+                    # p_stream_id
+                    "0001measurement_""test_asset_code_3",
+
+                    # Expected transformation
+                    [
+
+                        {
+                            "containerid": "0001measurement_""test_asset_code_3",
+                            "values": [
+                                {
+                                    "Time": "2018-04-20T09:38:50.163164Z",
+                                    "pressure": 957.2
+                                }
+                            ]
+                        }
+                    ]
+                )
+
+        ]
+    )
+    def test_transform_in_memory_row(
+                                        self,
+                                        p_data_origin,
+                                        p_stream_id,
+                                        expected_data_to_send
+    ):
+        """Tests the in memory transformations of a single row - _transform_in_memory_row"""
+
+        sending_process_instance = []
+        config = []
+        config_omf_types = []
+        logger = MagicMock()
+        generated_data_to_send = []
+
+        omf_north = omf.OmfNorthPlugin(sending_process_instance, config, config_omf_types, logger)
+
+        omf_north._transform_in_memory_row(generated_data_to_send, p_data_origin, p_stream_id)
+
+        assert generated_data_to_send == expected_data_to_send
+
+    @pytest.mark.parametrize(
         "p_creation_type, "
         "p_data_origin, "
         "p_asset_codes_already_created, "
@@ -433,7 +545,6 @@ class TestOmfNorthPlugin:
         config = []
         config_omf_types = []
         logger = MagicMock()
-        generated_data_to_send = []
 
         config_category_name = "SEND_PR"
         type_id = "0001"
@@ -955,7 +1066,6 @@ class TestOmfNorthPlugin:
                                         expected_link_data
     ):
 
-
         sending_process_instance = []
         config = []
         config_omf_types = []
@@ -977,4 +1087,3 @@ class TestOmfNorthPlugin:
         patched_send_to_picromf.assert_any_call("Container", expected_container)
         patched_send_to_picromf.assert_any_call("Data", expected_static_data)
         patched_send_to_picromf.assert_any_call("Data", expected_link_data)
-

--- a/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
+++ b/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
@@ -955,6 +955,7 @@ class TestOmfNorthPlugin:
                                         expected_link_data
     ):
 
+
         sending_process_instance = []
         config = []
         config_omf_types = []

--- a/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
+++ b/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
@@ -360,7 +360,132 @@ class TestOmfNorthPlugin:
         assert new_position == expected_new_position
         assert num_sent == expected_num_sent
 
-    def test_create_omf_objects(self):
-        """ Unit test """
+    @pytest.mark.parametrize(
+        "p_data_origin, "
+        "expected_output ",
+        [
+            # Case 1
+            (
+                # Origin
+                [
+                    {
+                        "id": 10,
+                        "asset_code": "test_asset_code",
+                        "read_key": "ef6e1368-4182-11e8-842f-0ed5f89f718b",
+                        "reading": {"humidity": 10, "temperature": 20},
+                        "user_ts": '2018-04-20 09:38:50.163164+00'
+                    }
+                ]
+                , "# FIXME:"
+            )
+        ]
+    )
+    def test_create_omf_objects(self, p_data_origin, expected_output):
+        # # FIXME:
+        """ Test the creation of the OMF objects """
 
+        sending_process_instance = []
+        config = []
+        config_omf_types = []
+        logger = MagicMock()
+        generated_data_to_send = []
+
+        config_category_name = "# FIXME:"
+        type_id = "0001"
+
+        omf_north = omf.OmfNorthPlugin(sending_process_instance, config, config_omf_types, logger)
+
+        omf_north._config_omf_types = {"type-id": {"value": type_id}}
+        # omf_north.create_omf_objects(p_data_origin, config_category_name, type_id)
+
+        assert True
+
+
+    @pytest.mark.parametrize(
+        "p_test_data, "
+        "expected_output ",
+        [
+            # Case 1
+            (
+                # Origin
+                [
+                    {
+                        "id": 10,
+                        "asset_code": "test_asset_code",
+                        "read_key": "ef6e1368-4182-11e8-842f-0ed5f89f718b",
+                        "reading": {"humidity": 10, "temperature": 20},
+                        "user_ts": '2018-04-20 09:38:50.163164+00'
+                    }
+                ]
+                , "# FIXME:"
+            )
+        ]
+    )
+    def test_create_omf_objects_automatic(self, p_test_data, expected_output):
+        assert True
+
+    @pytest.mark.parametrize(
+        "p_test_data, "
+        "expected_output ",
+        [
+            # Case 1
+            (
+                # Origin
+                [
+                    {
+                        "id": 10,
+                        "asset_code": "test_asset_code",
+                        "read_key": "ef6e1368-4182-11e8-842f-0ed5f89f718b",
+                        "reading": {"humidity": 10, "temperature": 20},
+                        "user_ts": '2018-04-20 09:38:50.163164+00'
+                    }
+                ]
+                , "# FIXME:"
+            )
+        ]
+    )
+    def test_create_omf_type_automatic(self, p_test_data, expected_output):
+        # FIXME:
+
+        sending_process_instance = []
+        config = []
+        config_omf_types = []
+        logger = MagicMock()
+        generated_data_to_send = []
+
+        config_category_name = "# FIXME:"
+        type_id = "0001"
+
+        omf_north = omf.OmfNorthPlugin(sending_process_instance, config, config_omf_types, logger)
+
+        omf_north._config_omf_types = {"type-id": {"value": type_id}}
+
+        omf_north._create_omf_type_automatic(p_test_data)
+
+
+        assert True
+
+
+    @pytest.mark.parametrize(
+        "p_test_data, "
+        "expected_output ",
+        [
+            # Case 1
+            (
+                # Origin
+                [
+                    {
+                        "id": 10,
+                        "asset_code": "test_asset_code",
+                        "read_key": "ef6e1368-4182-11e8-842f-0ed5f89f718b",
+                        "reading": {"humidity": 10, "temperature": 20},
+                        "user_ts": '2018-04-20 09:38:50.163164+00'
+                    }
+                ]
+                , "# FIXME:"
+            )
+        ]
+    )
+    def test_create_omf_object_links(self, p_test_data, expected_output):
+        # FIXME:
         assert True

--- a/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
+++ b/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
@@ -431,16 +431,11 @@ class TestOmfNorthPlugin:
             # Case 1
             (
                 # Origin
-                [
-                    {
-                        "id": 10,
-                        "asset_code": "test_asset_code",
-                        "read_key": "ef6e1368-4182-11e8-842f-0ed5f89f718b",
-                        "reading": {"humidity": 10, "temperature": 20},
-                        "user_ts": '2018-04-20 09:38:50.163164+00'
-                    }
-                ]
+                {"asset_code": "temperature", "asset_data": 10}
+
+                # Expected
                 , "# FIXME:"
+
             )
         ]
     )


### PR DESCRIPTION
# single execution 
``
foglamp@ubuntu:~/Development/FogLAMP$ cd /home/foglamp/Development/FogLAMP/tests/unit/python/foglamp/plugins/north/omf;\
> python3 -m pytest -v *.py
============================================= test session starts ==============================================
platform linux -- Python 3.5.2, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/foglamp/Development/FogLAMP/tests/unit/python/foglamp/plugins/north/omf, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 34 items

test_omf.py::TestOMF::test_plugin_info PASSED                                                            [  2%]
test_omf.py::TestOMF::test_plugin_init_good PASSED                                                       [  5%]
test_omf.py::TestOMF::test_plugin_init_bad[data0] PASSED                                                 [  8%]
test_omf.py::TestOMF::test_plugin_init_bad[data1] PASSED                                                 [ 11%]
test_omf.py::TestOMF::test_plugin_send_ok PASSED                                                         [ 14%]
test_omf.py::TestOMF::test_plugin_send_bad PASSED                                                        [ 17%]
test_omf.py::TestOMF::test_plugin_shutdown PASSED                                                        [ 20%]
test_omf.py::TestOMF::test_plugin_reconfigure PASSED                                                     [ 23%]
test_omf.py::TestOmfNorthPlugin::test_plugin_transform_in_memory_data[p_data_origin0-0001-expected_data_to_send0-True-10-1] PASSED [ 26%]
test_omf.py::TestOmfNorthPlugin::test_plugin_transform_in_memory_data[p_data_origin1-0001-expected_data_to_send1-True-11-1] PASSED [ 29%]
test_omf.py::TestOmfNorthPlugin::test_plugin_transform_in_memory_data[p_data_origin2-0001-expected_data_to_send2-True-20-2] PASSED [ 32%]
test_omf.py::TestOmfNorthPlugin::test_transform_in_memory_row[p_data_origin0-0001measurement_test_asset_code_1-expected_data_to_send0] PASSED [ 35%]
test_omf.py::TestOmfNorthPlugin::test_transform_in_memory_row[p_data_origin1-0001measurement_test_asset_code_2-expected_data_to_send1] PASSED [ 38%]
test_omf.py::TestOmfNorthPlugin::test_transform_in_memory_row[p_data_origin2-0001measurement_test_asset_code_3-expected_data_to_send2] PASSED [ 41%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_objects_test_creation[automatic-p_data_origin0-p_asset_codes_already_created0-p_omf_objects_configuration_based0] PASSED [ 44%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_objects_test_creation[configuration-p_data_origin1-p_asset_codes_already_created1-p_omf_objects_configuration_based1] PASSED [ 47%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_type_automatic[p_test_data0-0001-p_static_data0-pressure_typename-expected_omf_type0] PASSED [ 50%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_type_automatic[p_test_data1-0002-p_static_data1-luxometer_typename-expected_omf_type1] PASSED [ 52%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_type_automatic[p_test_data2-0002-p_static_data2-switch_typename-expected_omf_type2] PASSED [ 55%]
test_omf.py::TestOmfNorthPlugin::test_send_in_memory_data_to_picromf_ok[p_test_data0] PASSED             [ 58%]
test_omf.py::TestOmfNorthPlugin::test_send_in_memory_data_to_picromf_bad[p_test_data0] PASSED            [ 61%]
test_omf.py::TestOmfNorthPlugin::test_send_in_memory_data_to_picromf_data[Type-p_test_data0] PASSED      [ 64%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_object_links[p_asset0-0001-p_static_data0-pressure_typename-p_omf_type0-expected_container0-expected_static_data0-expected_link_data0] PASSED [ 67%]
test_omf.py::TestOmfNorthPlugin::test_retrieve_omf_types_already_created[SEND_PR1-0001-p_data_from_storage0-expected_data0] PASSED [ 70%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_asset_id[asset_code_1 -asset_code_1] PASSED           [ 73%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_asset_id[ asset_code_2 -asset_code_2] PASSED          [ 76%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_asset_id[asset_ code_3-asset_code_3] PASSED           [ 79%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_measurement[0001-asset_code_1 -0001measurement_asset_code_1] PASSED [ 82%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_measurement[0002- asset_code_2 -0002measurement_asset_code_2] PASSED [ 85%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_measurement[0003-asset_ code_3-0003measurement_asset_code_3] PASSED [ 88%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_typename_automatic[asset_code_1 -asset_code_1_typename] PASSED [ 91%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_typename_automatic[ asset_code_2 -asset_code_2_typename] PASSED [ 94%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_typename_automatic[asset_ code_3-asset_code_3_typename] PASSED [ 97%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_type_configuration_based[0001-p_asset_code_omf_type0-position-expected_omf_type0] PASSED [100%]

========================================== 34 passed in 0.26 seconds ===========================================
foglamp@ubuntu:~/Development/FogLAMP/tests/unit/python/foglamp/plugins/north/omf$

``

# Full tests set - the errors are on other tests
``
plugins/north/omf/test_omf.py::TestOMF::test_plugin_info PASSED          [ 30%]
plugins/north/omf/test_omf.py::TestOMF::test_plugin_init_good PASSED     [ 30%]
plugins/north/omf/test_omf.py::TestOMF::test_plugin_init_bad[data0] PASSED [ 30%]
plugins/north/omf/test_omf.py::TestOMF::test_plugin_init_bad[data1] PASSED [ 30%]
plugins/north/omf/test_omf.py::TestOMF::test_plugin_send_ok PASSED       [ 30%]
plugins/north/omf/test_omf.py::TestOMF::test_plugin_send_bad PASSED      [ 30%]
plugins/north/omf/test_omf.py::TestOMF::test_plugin_shutdown PASSED      [ 30%]
plugins/north/omf/test_omf.py::TestOMF::test_plugin_reconfigure PASSED   [ 30%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_plugin_transform_in_memory_data[p_data_origin0-0001-expected_data_to_send0-True-10-1] PASSED [ 30%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_plugin_transform_in_memory_data[p_data_origin1-0001-expected_data_to_send1-True-11-1] PASSED [ 31%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_plugin_transform_in_memory_data[p_data_origin2-0001-expected_data_to_send2-True-20-2] PASSED [ 31%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_transform_in_memory_row[p_data_origin0-0001measurement_test_asset_code_1-expected_data_to_send0] PASSED [ 31%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_transform_in_memory_row[p_data_origin1-0001measurement_test_asset_code_2-expected_data_to_send1] PASSED [ 31%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_transform_in_memory_row[p_data_origin2-0001measurement_test_asset_code_3-expected_data_to_send2] PASSED [ 31%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_create_omf_objects_test_creation[automatic-p_data_origin0-p_asset_codes_already_created0-p_omf_objects_configuration_based0] PASSED [ 31%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_create_omf_objects_test_creation[configuration-p_data_origin1-p_asset_codes_already_created1-p_omf_objects_configuration_based1] PASSED [ 31%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_create_omf_type_automatic[p_test_data0-0001-p_static_data0-pressure_typename-expected_omf_type0] PASSED [ 31%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_create_omf_type_automatic[p_test_data1-0002-p_static_data1-luxometer_typename-expected_omf_type1] PASSED [ 31%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_create_omf_type_automatic[p_test_data2-0002-p_static_data2-switch_typename-expected_omf_type2] PASSED [ 31%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_send_in_memory_data_to_picromf_ok[p_test_data0] PASSED [ 31%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_send_in_memory_data_to_picromf_bad[p_test_data0] PASSED [ 32%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_send_in_memory_data_to_picromf_data[Type-p_test_data0] PASSED [ 32%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_create_omf_object_links[p_asset0-0001-p_static_data0-pressure_typename-p_omf_type0-expected_container0-expected_static_data0-expected_link_data0] PASSED [ 32%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_retrieve_omf_types_already_created[SEND_PR1-0001-p_data_from_storage0-expected_data0] PASSED [ 32%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_generate_omf_asset_id[asset_code_1 -asset_code_1] PASSED [ 32%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_generate_omf_asset_id[ asset_code_2 -asset_code_2] PASSED [ 32%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_generate_omf_asset_id[asset_ code_3-asset_code_3] PASSED [ 32%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_generate_omf_measurement[0001-asset_code_1 -0001measurement_asset_code_1] PASSED [ 32%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_generate_omf_measurement[0002- asset_code_2 -0002measurement_asset_code_2] PASSED [ 32%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_generate_omf_measurement[0003-asset_ code_3-0003measurement_asset_code_3] PASSED [ 32%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_generate_omf_typename_automatic[asset_code_1 -asset_code_1_typename] PASSED [ 32%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_generate_omf_typename_automatic[ asset_code_2 -asset_code_2_typename] PASSED [ 33%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_generate_omf_typename_automatic[asset_ code_3-asset_code_3_typename] PASSED [ 33%]
plugins/north/omf/test_omf.py::TestOmfNorthPlugin::test_create_omf_type_configuration_based[0001-p_asset_code_omf_type0-position-expected_omf_type0] PASSED [ 33%]

________________________________________________________________________________________________ TestCertificateStore.test_upload[pyloop] ________________________________________________________________________________________________


______________________________________________________________________________________ TestCertificateStore.test_file_upload_with_overwrite[pyloop] ______________________________________________________________________________________


=========================================================================================== 2 failed, 1093 passed, 13 skipped in 55.82 seconds ===========================================================================================


``