### PR TITLE
Fogl 1294: omf north plugin should validate producerToken for empty strings

### DIFF
--- a/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
+++ b/tests/unit/python/foglamp/plugins/north/omf/test_omf.py
@@ -1363,3 +1363,71 @@ class TestOmfNorthPlugin:
         assert generated_omf_type == expected_omf_type
 
         patched_send_to_picromf.assert_any_call("Type", expected_omf_type[expected_typename])
+
+    @pytest.mark.parametrize(
+        "p_key, "
+        "p_value, "
+        "expected, ",
+        [
+            # Good cases
+            ('producerToken', "xxx", "good"),
+
+            # Bad cases
+            ('NO-producerToken', "", "exception"),
+            ('producerToken', "", "exception")
+        ]
+    )
+    def test_validate_configuration(
+                                    self,
+                                    p_key,
+                                    p_value,
+                                    expected):
+        """ Tests the validation of the configurations retrieved from the Configuration Manager
+            handled by _validate_configuration """
+
+        omf._logger = MagicMock()
+
+        data = {p_key: {'value': p_value}}
+
+        if expected == "good":
+            assert not omf._logger.error.called
+
+        elif expected == "exception":
+            with pytest.raises(ValueError):
+                omf._validate_configuration(data)
+
+            assert omf._logger.error.called
+
+    @pytest.mark.parametrize(
+        "p_key, "
+        "p_value, "
+        "expected, ",
+        [
+            # Good cases
+            ('type-id', "xxx", "good"),
+
+            # Bad cases
+            ('NO-type-id', "", "exception"),
+            ('type-id', "", "exception")
+        ]
+    )
+    def test_validate_configuration_omf_type(
+                                    self,
+                                    p_key,
+                                    p_value,
+                                    expected):
+        """ Tests the validation of the configurations retrieved from the Configuration Manager
+            related to the OMF types """
+
+        omf._logger = MagicMock()
+
+        data = {p_key: {'value': p_value}}
+
+        if expected == "good":
+            assert not omf._logger.error.called
+
+        elif expected == "exception":
+            with pytest.raises(ValueError):
+                omf._validate_configuration_omf_type(data)
+
+            assert omf._logger.error.called


### PR DESCRIPTION
 **Single unit test**
``
============================================= test session starts ==============================================
platform linux -- Python 3.5.2, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/foglamp/Development/FogLAMP/tests/unit/python/foglamp/plugins/north/omf, inifile:
plugins: mock-1.6.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 40 items

test_omf.py::TestOMF::test_plugin_info PASSED                                                            [  2%]
test_omf.py::TestOMF::test_plugin_init_good PASSED                                                       [  5%]
test_omf.py::TestOMF::test_plugin_init_bad[data0] PASSED                                                 [  7%]
test_omf.py::TestOMF::test_plugin_init_bad[data1] PASSED                                                 [ 10%]
test_omf.py::TestOMF::test_plugin_send_ok PASSED                                                         [ 12%]
test_omf.py::TestOMF::test_plugin_send_bad PASSED                                                        [ 15%]
test_omf.py::TestOMF::test_plugin_shutdown PASSED                                                        [ 17%]
test_omf.py::TestOMF::test_plugin_reconfigure PASSED                                                     [ 20%]
test_omf.py::TestOmfNorthPlugin::test_plugin_transform_in_memory_data[p_data_origin0-0001-expected_data_to_send0-True-10-1] PASSED [ 22%]
test_omf.py::TestOmfNorthPlugin::test_plugin_transform_in_memory_data[p_data_origin1-0001-expected_data_to_send1-True-11-1] PASSED [ 25%]
test_omf.py::TestOmfNorthPlugin::test_plugin_transform_in_memory_data[p_data_origin2-0001-expected_data_to_send2-True-20-2] PASSED [ 27%]
test_omf.py::TestOmfNorthPlugin::test_transform_in_memory_row[p_data_origin0-0001measurement_test_asset_code_1-expected_data_to_send0] PASSED [ 30%]
test_omf.py::TestOmfNorthPlugin::test_transform_in_memory_row[p_data_origin1-0001measurement_test_asset_code_2-expected_data_to_send1] PASSED [ 32%]
test_omf.py::TestOmfNorthPlugin::test_transform_in_memory_row[p_data_origin2-0001measurement_test_asset_code_3-expected_data_to_send2] PASSED [ 35%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_objects_test_creation[automatic-p_data_origin0-p_asset_codes_already_created0-p_omf_objects_configuration_based0] PASSED [ 37%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_objects_test_creation[configuration-p_data_origin1-p_asset_codes_already_created1-p_omf_objects_configuration_based1] PASSED [ 40%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_type_automatic[p_test_data0-0001-p_static_data0-pressure_typename-expected_omf_type0] PASSED [ 42%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_type_automatic[p_test_data1-0002-p_static_data1-luxometer_typename-expected_omf_type1] PASSED [ 45%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_type_automatic[p_test_data2-0002-p_static_data2-switch_typename-expected_omf_type2] PASSED [ 47%]
test_omf.py::TestOmfNorthPlugin::test_send_in_memory_data_to_picromf_ok[p_test_data0] PASSED             [ 50%]
test_omf.py::TestOmfNorthPlugin::test_send_in_memory_data_to_picromf_bad[p_test_data0] PASSED            [ 52%]
test_omf.py::TestOmfNorthPlugin::test_send_in_memory_data_to_picromf_data[Type-p_test_data0] PASSED      [ 55%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_object_links[p_asset0-0001-p_static_data0-pressure_typename-p_omf_type0-expected_container0-expected_static_data0-expected_link_data0] PASSED [ 57%]
test_omf.py::TestOmfNorthPlugin::test_retrieve_omf_types_already_created[SEND_PR1-0001-p_data_from_storage0-expected_data0] PASSED [ 60%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_asset_id[asset_code_1 -asset_code_1] PASSED           [ 62%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_asset_id[ asset_code_2 -asset_code_2] PASSED          [ 65%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_asset_id[asset_ code_3-asset_code_3] PASSED           [ 67%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_measurement[0001-asset_code_1 -0001measurement_asset_code_1] PASSED [ 70%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_measurement[0002- asset_code_2 -0002measurement_asset_code_2] PASSED [ 72%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_measurement[0003-asset_ code_3-0003measurement_asset_code_3] PASSED [ 75%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_typename_automatic[asset_code_1 -asset_code_1_typename] PASSED [ 77%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_typename_automatic[ asset_code_2 -asset_code_2_typename] PASSED [ 80%]
test_omf.py::TestOmfNorthPlugin::test_generate_omf_typename_automatic[asset_ code_3-asset_code_3_typename] PASSED [ 82%]
test_omf.py::TestOmfNorthPlugin::test_create_omf_type_configuration_based[0001-p_asset_code_omf_type0-position-expected_omf_type0] PASSED [ 85%]
test_omf.py::TestOmfNorthPlugin::test_validate_configuration[producerToken-xxx-good] PASSED              [ 87%]
test_omf.py::TestOmfNorthPlugin::test_validate_configuration[NO-producerToken--exception] PASSED         [ 90%]
test_omf.py::TestOmfNorthPlugin::test_validate_configuration[producerToken--exception] PASSED            [ 92%]
test_omf.py::TestOmfNorthPlugin::test_validate_configuration_omf_type[type-id-xxx-good] PASSED           [ 95%]
test_omf.py::TestOmfNorthPlugin::test_validate_configuration_omf_type[NO-type-id--exception] PASSED      [ 97%]
test_omf.py::TestOmfNorthPlugin::test_validate_configuration_omf_type[type-id--exception] PASSED         [100%]

========================================== 40 passed in 0.31 seconds ===========================================
foglamp@ubuntu:~/Development/FogLAMP/tests/unit/python/foglamp/plugins/north/omf$
``

**Complete tests set**
``
=================================== 1136 passed, 13 skipped in 84.07 seconds ===================================

real    1m25.677s
user    0m35.748s
sys     0m1.076s
``