### PR TITLE
FOGL-1308:  Apply to OCS the same fix applied to OMF in FOGL-1235

### DIFF
--- a/python/foglamp/plugins/north/ocs/ocs.py
+++ b/python/foglamp/plugins/north/ocs/ocs.py
@@ -204,7 +204,8 @@ def _performance_log(_function):
             print("ERROR - {func} - error details |{error}|".format(
                                                                     func="_performance_log",
                                                                     error=ex), file=sys.stderr)
-
+            raise
+            
     return wrapper
 
 


### PR DESCRIPTION
hiding exceptions because of the _performance_log function