### PR TITLE
FOGL-1313 - Fixed timestamp in Sensortag plugins to store local timezone instead of UTC timezone

### DIFF
--- a/extras/python/fogbench/__main__.py
+++ b/extras/python/fogbench/__main__.py
@@ -82,6 +82,13 @@ _num_iterated = 0
 # TODO: have its own sys/ console logger
 # _logger = logger.setup(__name__)
 
+def local_timestamp():
+    """
+    :return: str - current time stamp with microseconds and machine timezone info
+    :example '2018-05-08 14:06:40.517313+05:30'
+    """
+    return str(datetime.now(timezone.utc).astimezone())
+
 
 def read_templates():
     templates = []
@@ -143,7 +150,7 @@ def _prepare_sensor_reading(data, supported_format_types):
         sensor_value_object = dict()
         sensor_value_object["asset"] = d['name']
         sensor_value_object["readings"] = x_sensor_values
-        sensor_value_object["timestamp"] = "{!s}".format(datetime.now(tz=timezone.utc))
+        sensor_value_object["timestamp"] = "{!s}".format(local_timestamp())
         sensor_value_object["key"] = str(uuid.uuid4())
         # print(json.dumps(sensor_value_object))
         ord_dict = collections.OrderedDict(sorted(sensor_value_object.items()))
@@ -347,6 +354,7 @@ read_out_file(_file=sample_file, _keep=keep_the_file, _iterations=arg_iterations
               send_to=arg_payload_protocol)
 get_statistics(_stats_type=arg_stats_type, _out_file=statistics_file)
 
+# TODO: Change below per local_timestamp() values
 """ Expected output from given template
 { 
   "timestamp"     : "2017-08-04T06:59:57.503Z",

--- a/python/foglamp/plugins/common/utils.py
+++ b/python/foglamp/plugins/common/utils.py
@@ -7,6 +7,7 @@
 """Common Utilities"""
 
 from foglamp.common import logger
+import datetime
 
 __author__ = "Amarendra Kumar Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -26,3 +27,11 @@ def get_diff(old, new):
         else:
             diff.append(key)
     return diff
+
+
+def local_timestamp():
+    """
+    :return: str - current time stamp with microseconds and machine timezone info
+    :example '2018-05-08 14:06:40.517313+05:30'
+    """
+    return str(datetime.datetime.now(datetime.timezone.utc).astimezone())

--- a/python/foglamp/plugins/south/cc2650async/cc2650async.py
+++ b/python/foglamp/plugins/south/cc2650async/cc2650async.py
@@ -124,7 +124,7 @@ def plugin_start(handle):
     async def save_data():
         if 'tag' not in handle:
             return
-        time_stamp = str(datetime.datetime.now(tz=datetime.timezone.utc))
+        time_stamp = utils.local_timestamp()
         data = {
             'asset': 'TI Sensortag CC2650',
             'timestamp': time_stamp,
@@ -162,7 +162,7 @@ def plugin_start(handle):
             # debug_cnt = 0  # Used only for debugging. debug_cnt should be set to 0 in production.
             cnt = 0
             while tag.is_connected:
-                time_stamp = str(datetime.datetime.now(tz=datetime.timezone.utc))
+                time_stamp = utils.local_timestamp()
                 try:
                     pattern_index = tag.con.expect('Notification handle = .*? \r', timeout=4)
                     # Re-initialize attempt_count on success

--- a/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
+++ b/python/foglamp/plugins/south/cc2650poll/cc2650poll.py
@@ -129,7 +129,7 @@ def plugin_poll(handle):
     if 'tag' not in handle:
         raise RuntimeError
 
-    time_stamp = str(datetime.datetime.now(tz=datetime.timezone.utc))
+    time_stamp = utils.local_timestamp()
     data = list()
     bluetooth_adr = handle['bluetoothAddress']['value']
     tag = handle['tag']


### PR DESCRIPTION
Fixed Sensortag CC2650 Async and Poll plugins to send timestamp data with local timezone info instead of UTC timezone. COAP and HTTP_SOUTH include timestamp data from source hence plugins need no such modification.

Tested OK with both Postgres and Sqlite DBs.

Test suite result:
`============================================= 1149 passed, 13 skipped in 50.74 seconds =============================================
`