### PR TITLE
FOGL-1315 - Fixed event loop running issue at foglamp stop

### DIFF
--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -50,6 +50,7 @@ async def ping(request):
         category_item = await cfg_mgr.get_category_item('rest_api', 'allowPing')
         allow_ping = True if category_item['value'].lower() == 'true' else False
         if request.is_auth_optional is False and allow_ping is False:
+            _logger.exception("Permission denied for Ping when Auth is mandatory: {}".format(str(e)))
             raise web.HTTPForbidden
 
     def get_stats(k):

--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -102,7 +102,9 @@ def do_shutdown(request):
     _logger.info("Executing controlled shutdown")
     try:
         loop = request.loop
-        loop.run_until_complete(server.Server.shutdown(request))
+        asyncio.ensure_future(server.Server.shutdown(request), loop=loop)
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
     except RuntimeError as e:
         _logger.exception("Error while stopping FogLAMP server: {}".format(str(e)))
         raise


### PR DESCRIPTION
Test Suite result:
`============================================= 1149 passed, 13 skipped in 51.32 seconds =============================================
`

syslog output:
```
May  9 16:09:06 nerd51-ThinkPad FogLAMP Storage[14951] INFO: script.plugin.storage.sqlite: SQLite 3 database '/home/asinha/Development/FogLAMP/data/foglamp.db' ready.
May  9 16:09:06 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: start core
May  9 16:09:06 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Management API started on http://0.0.0.0:43502
May  9 16:09:06 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: start storage, from directory /home/asinha/Development/FogLAMP/scripts
May  9 16:09:06 nerd51-ThinkPad FogLAMP Storage[14975]: Connected to SQLite3 database: /home/asinha/Development/FogLAMP/data/foglamp.db
May  9 16:09:06 nerd51-ThinkPad FogLAMP message repeated 4 times: [ Storage[14975]: Connected to SQLite3 database: /home/asinha/Development/FogLAMP/data/foglamp.db]
May  9 16:09:07 nerd51-ThinkPad FogLAMP[14968] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=5832428f-ef7b-4960-9712-6427dd3bbf6b: <FogLAMP Storage, type=Storage, protocol=http, address=localhost, service port=43071, management port=41449, status=1>
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: start scheduler
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Starting
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Starting Scheduler: Management port received is 43502
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'purge' to start at 2018-05-09 17:09:11.490874
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collection' to start at 2018-05-09 16:09:26.490874
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'certificate checker' to start at 2018-05-09 17:05:00
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'HTTP listener south' to start at 2018-05-09 16:09:11.490874
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'COAP listener south' to start at 2018-05-09 16:09:11.490874
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'CC2650 async south' to start at 2018-05-09 16:09:11.490874
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Services monitoring started ...
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'COAP listener south' process 'COAP' task 7c62672b-78d6-4fb8-9578-dd89f413d89b pid 15014, 1 running tasks#012['services/south', '--port=43502', '--address=127.0.0.1', '--name=COAP']
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'CC2650 async south' process 'CC2650ASYN' task 893c1b69-c3b3-4eea-932a-77e94c30f1ef pid 15016, 2 running tasks#012['services/south', '--port=43502', '--address=127.0.0.1', '--name=CC2650ASYN']
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'HTTP listener south' process 'HTTP_SOUTH' task 668a5c49-e2e3-4080-8825-e433dcdfedce pid 15019, 3 running tasks#012['services/south', '--port=43502', '--address=127.0.0.1', '--name=HTTP_SOUTH']
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 14.914904356002808 seconds
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Announce management API service
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: PID [14968] written in [/home/asinha/Development/FogLAMP/data/var/run/foglamp.core.pid]
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: REST API Server started on http://0.0.0.0:8081
May  9 16:09:11 nerd51-ThinkPad FogLAMP[14968] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=9fe85ca6-3af5-4c9a-b537-5a4abe72aa12: <FogLAMP Core, type=Core, protocol=http, address=0.0.0.0, service port=8081, management port=43502, status=1>
May  9 16:09:12 nerd51-ThinkPad FogLAMP[14968] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=10083efe-5441-4fb9-b93d-e3227399c6e1: <CC2650ASYN, type=Southbound, protocol=http, address=127.0.0.1, service port=38110, management port=38110, status=1>
May  9 16:09:12 nerd51-ThinkPad FogLAMP[14968] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May  9 16:09:12 nerd51-ThinkPad FogLAMP [14924] INFO: script.foglamp: FogLAMP started.
May  9 16:09:12 nerd51-ThinkPad FogLAMP[14968] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=e9ddf74c-afcd-445c-9449-cf46b5840ba7: <HTTP_SOUTH, type=Southbound, protocol=http, address=127.0.0.1, service port=39035, management port=39035, status=1>
May  9 16:09:12 nerd51-ThinkPad FogLAMP[14968] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=e96af76e-2915-452c-b505-506c2be24b65: <COAP, type=Southbound, protocol=http, address=127.0.0.1, service port=35112, management port=35112, status=1>
May  9 16:09:12 nerd51-ThinkPad FogLAMP[15015] INFO: coap_listen: foglamp.plugins.south.coap_listen.coap_listen: CoAP listener started on port 5683 with uri sensor-values
May  9 16:09:22 nerd51-ThinkPad FogLAMP[15017] ERROR: sensortag_cc2650: foglamp.plugins.south.common.sensortag_cc2650: SensorTagCC2650 B0:91:22:EA:79:04 connection failure. Timeout=10 seconds.#012Traceback (most recent call last):#012  File "/home/asinha/.local/lib/python3.5/site-packages/pexpect/expect.py", line 97, in expect_loop#012    incoming = spawn.read_nonblocking(spawn.maxread, timeout)#012  File "/home/asinha/.local/lib/python3.5/site-packages/pexpect/pty_spawn.py", line 452, in read_nonblocking#012    raise TIMEOUT('Timeout exceeded.')#012pexpect.exceptions.TIMEOUT: Timeout exceeded.#012#012During handling of the above exception, another exception occurred:#012#012Traceback (most recent call last):#012  File "/home/asinha/Development/FogLAMP/python/foglamp/plugins/south/common/sensortag_cc2650.py", line 159, in __init__#012    self.con.expect('.*Connection successful.*\[LE\]>', timeout=int(timeout))#012  File "/home/asinha/.local/lib/python3.5/site-packages/pexpect/spawnbase.py", line 315, in expect#012    timeout, searchwindowsize, async)#012  File "/home/asinha/.local/lib/python3.5/site-packages/pexpect/spawnbase.py", line 339, in expect_list#012    return exp.expect_loop(timeout)#012  File "/home/asinha/.local/lib/python3.5/site-packages/pexpect/expect.py", line 104, in expect_loop#012    return self.timeout(e)#012  File "/home/asinha/.local/lib/python3.5/site-packages/pexpect/expect.py", line 68, in timeout#012    raise TIMEOUT(msg)#012pexpect.exceptions.TIMEOUT: Timeout exceeded.#012<pexpect.pty_spawn.spawn object at 0x7fbf07401898>#012command: /usr/bin/gatttool#012args: ['/usr/bin/gatttool', '-b', 'B0:91:22:EA:79:04', '--interactive']#012searcher: None#012buffer (last 100 chars): b' connect\r\nAttempting to connect to B0:91:22:EA:79:04\r\n[B0:91:22:EA:79:04][LE]> '#012before (last 100 chars): b' connect\r\nAttempting to connect to B0:91:22:EA:79:04\r\n[B0:91:22:EA:79:04][LE]> '#012after: <class 'pexpect.exceptions.TIMEOUT'>#012match: None#012match_index: None#012exitstatus: None#012flag_eof: False#012pid: 15049#012child_fd: 27#012closed: False#012timeout: 30#012delimiter: <class 'pexpect.exceptions.EOF'>#012logfile: None#012logfile_read: None#012logfile_send: None#012maxread: 2000#012ignorecase: False#012searchwindowsize: None#012delaybeforesend: 0.05#012delayafterclose: 0.1#012delayafterterminate: 0.1
May  9 16:09:26 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collection' process 'stats collector' task 72585bc7-66d0-4448-8724-faa11ecc6951 pid 15056, 4 running tasks#012['tasks/statistics', '--port=43502', '--address=127.0.0.1', '--name=stats collector']
May  9 16:09:26 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 3333.3636949062347 seconds
May  9 16:09:32 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collection' process 'stats collector' task 72585bc7-66d0-4448-8724-faa11ecc6951 pid 15056 exit 0, 3 running tasks#012['tasks/statistics']
May  9 16:09:32 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collection' to start at 2018-05-09 16:09:41.490874
May  9 16:09:32 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 8.889835119247437 seconds
May  9 16:09:41 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collection' process 'stats collector' task df592a65-7f61-4542-b254-737c19750822 pid 15069, 4 running tasks#012['tasks/statistics', '--port=43502', '--address=127.0.0.1', '--name=stats collector']
May  9 16:09:41 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 3318.3982989788055 seconds
May  9 16:09:43 nerd51-ThinkPad FogLAMP[14968] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May  9 16:09:43 nerd51-ThinkPad FogLAMP[14968] INFO: middleware: foglamp.common.web.middleware: Received PUT request for /foglamp/shutdown
May  9 16:09:45 nerd51-ThinkPad FogLAMP[14968] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May  9 16:09:45 nerd51-ThinkPad FogLAMP[14968] INFO: common: foglamp.services.core.api.common: Executing controlled shutdown
May  9 16:09:45 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Processing stop request
May  9 16:09:45 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Stopping process: Schedule 'stats collection' process 'stats collector' task df592a65-7f61-4542-b254-737c19750822 pid 15069#012['tasks/statistics']
May  9 16:09:45 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collection' process 'stats collector' task df592a65-7f61-4542-b254-737c19750822 pid 15069 exit -15, 3 running tasks#012['tasks/statistics']
May  9 16:09:45 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Tasks will no longer execute for schedule 'stats collection'
May  9 16:09:46 nerd51-ThinkPad FogLAMP[14968] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May  9 16:09:50 nerd51-ThinkPad FogLAMP[14968] message repeated 4 times: [ INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping]
May  9 16:09:50 nerd51-ThinkPad FogLAMP[14968] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Stopped
May  9 16:09:50 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Shutting down the Southbound service HTTP_SOUTH ...
May  9 16:09:50 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Shutting down the Southbound service COAP ...
May  9 16:09:50 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Shutting down the Southbound service CC2650ASYN ...
May  9 16:09:50 nerd51-ThinkPad FogLAMP[15017] INFO: cc2650async: foglamp.plugins.south.cc2650async.cc2650async: CC2650 async plugin shut down.
May  9 16:09:50 nerd51-ThinkPad FogLAMP[15015] INFO: coap_listen: foglamp.plugins.south.coap_listen.coap_listen: Stopping South COAP plugin...
May  9 16:09:50 nerd51-ThinkPad FogLAMP[15020] INFO: http_south: foglamp.plugins.south.http_south.http_south: Stopping South HTTP plugin.
May  9 16:09:51 nerd51-ThinkPad FogLAMP[15015] INFO: coap_listen: foglamp.plugins.south.coap_listen.coap_listen: COAP plugin shut down.
May  9 16:09:51 nerd51-ThinkPad FogLAMP[15020] INFO: http_south: foglamp.plugins.south.http_south.http_south: South HTTP plugin shut down.
May  9 16:09:51 nerd51-ThinkPad FogLAMP[14968] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May  9 16:09:55 nerd51-ThinkPad FogLAMP[14968] message repeated 4 times: [ INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping]
May  9 16:10:01 nerd51-ThinkPad FogLAMP[14968] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Stopped service instance id=10083efe-5441-4fb9-b93d-e3227399c6e1: <CC2650ASYN, type=Southbound, protocol=http, address=127.0.0.1, service port=38110, management port=38110, status=2>
May  9 16:10:01 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Successfully shut down the Southbound service CC2650ASYN.
May  9 16:10:06 nerd51-ThinkPad FogLAMP[14968] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Stopped service instance id=e9ddf74c-afcd-445c-9449-cf46b5840ba7: <HTTP_SOUTH, type=Southbound, protocol=http, address=127.0.0.1, service port=39035, management port=39035, status=2>
May  9 16:10:07 nerd51-ThinkPad FogLAMP[14968] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May  9 16:10:12 nerd51-ThinkPad FogLAMP[14968] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Stopped service instance id=e96af76e-2915-452c-b505-506c2be24b65: <COAP, type=Southbound, protocol=http, address=127.0.0.1, service port=35112, management port=35112, status=2>
May  9 16:10:13 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Successfully shut down the Southbound service HTTP_SOUTH.
May  9 16:10:13 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Successfully shut down the Southbound service COAP.
May  9 16:10:13 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Services monitoring stopped.
May  9 16:10:13 nerd51-ThinkPad FogLAMP[14968] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May  9 16:10:13 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Rest server stopped.
May  9 16:10:13 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Shutting down the Storage service FogLAMP Storage ...
May  9 16:10:13 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Successfully shut down the Storage service FogLAMP Storage.
May  9 16:10:13 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: FogLAMP PID file [/home/asinha/Development/FogLAMP/data/var/run/foglamp.core.pid] removed.
May  9 16:10:13 nerd51-ThinkPad FogLAMP[14968] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Stopped service instance id=5832428f-ef7b-4960-9712-6427dd3bbf6b: <FogLAMP Storage, type=Storage, protocol=http, address=localhost, service port=43071, management port=41449, status=2>
May  9 16:10:15 nerd51-ThinkPad FogLAMP[14968] INFO: server: foglamp.services.core.server: Stopping the FogLAMP Core event loop. Good Bye!
May  9 16:10:16 nerd51-ThinkPad FogLAMP [15071] INFO: script.foglamp: FogLAMP stopped.

```