### PR TITLE
FOGL-1316 - Foglamp stop error on Raspbian resolved

### DIFF
--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -104,8 +104,6 @@ def do_shutdown(request):
     try:
         loop = request.loop
         asyncio.ensure_future(server.Server.shutdown(request), loop=loop)
-        loop.run_until_complete(loop.shutdown_asyncgens())
-        loop.close()
     except RuntimeError as e:
         _logger.exception("Error while stopping FogLAMP server: {}".format(str(e)))
         raise

--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -50,7 +50,7 @@ async def ping(request):
         category_item = await cfg_mgr.get_category_item('rest_api', 'allowPing')
         allow_ping = True if category_item['value'].lower() == 'true' else False
         if request.is_auth_optional is False and allow_ping is False:
-            _logger.exception("Permission denied for Ping when Auth is mandatory.")
+            _logger.warning("Permission denied for Ping when Auth is mandatory.")
             raise web.HTTPForbidden
 
     def get_stats(k):


### PR DESCRIPTION
Test Suite result:
`============================================= 1149 passed, 13 skipped in 51.50 seconds =============================================
`


Syslog on Raspbian:
```
May 10 08:10:04 raspberrypi_AKS FogLAMP Storage[8261] INFO: script.plugin.storage.sqlite: SQLite 3 database '/home/pi/FogLAMP/data/foglamp.db' ready.
May 10 08:10:06 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: start core
May 10 08:10:06 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Management API started on http://0.0.0.0:40961
May 10 08:10:06 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: start storage, from directory /home/pi/FogLAMP/scripts
May 10 08:10:06 raspberrypi_AKS FogLAMP Storage[8297]: Connected to SQLite3 database: /home/pi/FogLAMP/data/foglamp.db
May 10 08:10:06 raspberrypi_AKS FogLAMP Storage[8297]: Connected to SQLite3 database: /home/pi/FogLAMP/data/foglamp.db
May 10 08:10:06 raspberrypi_AKS FogLAMP Storage[8297]: Connected to SQLite3 database: /home/pi/FogLAMP/data/foglamp.db
May 10 08:10:06 raspberrypi_AKS FogLAMP Storage[8297]: Connected to SQLite3 database: /home/pi/FogLAMP/data/foglamp.db
May 10 08:10:06 raspberrypi_AKS FogLAMP Storage[8297]: Connected to SQLite3 database: /home/pi/FogLAMP/data/foglamp.db
May 10 08:10:07 raspberrypi_AKS FogLAMP[8278] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=f27b5779-6d28-470d-a313-f5ba67500acb: <FogLAMP Storage, type=Storage, protocol=http, address=localhost, service port=41687, management port=34019, status=1>
May 10 08:10:11 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: start scheduler
May 10 08:10:11 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Starting
May 10 08:10:11 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Starting Scheduler: Management port received is 40961
May 10 08:10:11 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'purge' to start at 2018-05-10 09:10:11.900912
May 10 08:10:11 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collection' to start at 2018-05-10 08:10:26.900912
May 10 08:10:11 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'certificate checker' to start at 2018-05-10 09:05:00
May 10 08:10:11 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'HTTP listener south' to start at 2018-05-10 08:10:11.900912
May 10 08:10:11 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'COAP listener south' to start at 2018-05-10 08:10:11.900912
May 10 08:10:12 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Services monitoring started ...
May 10 08:10:12 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'HTTP listener south' process 'HTTP_SOUTH' task 3f577083-ce4d-4f38-95d3-9827aa91033f pid 8330, 1 running tasks#012['services/south', '--port=40961', '--address=127.0.0.1', '--name=HTTP_SOUTH']
May 10 08:10:12 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'COAP listener south' process 'COAP' task aefebc0b-d884-4440-aabe-89fb5e8c9a3e pid 8332, 2 running tasks#012['services/south', '--port=40961', '--address=127.0.0.1', '--name=COAP']
May 10 08:10:12 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 14.78149938583374 seconds
May 10 08:10:12 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Announce management API service
May 10 08:10:12 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: PID [8278] written in [/home/pi/FogLAMP/data/var/run/foglamp.core.pid]
May 10 08:10:12 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: REST API Server started on http://0.0.0.0:8081
May 10 08:10:12 raspberrypi_AKS FogLAMP[8278] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=ac299ba0-8f7d-4866-9230-1004d36fa945: <FogLAMP Core, type=Core, protocol=http, address=0.0.0.0, service port=8081, management port=40961, status=1>
May 10 08:10:13 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:13 raspberrypi_AKS FogLAMP [8234] INFO: script.foglamp: FogLAMP started.
May 10 08:10:14 raspberrypi_AKS FogLAMP[8278] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=e92f7ff7-9430-4148-8020-4bba53267f1f: <COAP, type=Southbound, protocol=http, address=127.0.0.1, service port=42627, management port=42627, status=1>
May 10 08:10:14 raspberrypi_AKS FogLAMP[8278] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=a9aa3401-a888-4050-b03a-1911d787d937: <HTTP_SOUTH, type=Southbound, protocol=http, address=127.0.0.1, service port=36873, management port=36873, status=1>
May 10 08:10:14 raspberrypi_AKS FogLAMP[8333] INFO: coap_listen: foglamp.plugins.south.coap_listen.coap_listen: CoAP listener started on port 5683 with uri sensor-values
May 10 08:10:27 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collection' process 'stats collector' task e1921ffe-38fa-4d4f-ab41-6d37635cfbd6 pid 8365, 3 running tasks#012['tasks/statistics', '--port=40961', '--address=127.0.0.1', '--name=stats collector']
May 10 08:10:27 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 3272.9454867839813 seconds
May 10 08:10:28 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collection' process 'stats collector' task e1921ffe-38fa-4d4f-ab41-6d37635cfbd6 pid 8365 exit 0, 2 running tasks#012['tasks/statistics']
May 10 08:10:28 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collection' to start at 2018-05-10 08:10:41.900912
May 10 08:10:28 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 13.73391318321228 seconds
May 10 08:10:33 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:34 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received PUT request for /foglamp/shutdown
May 10 08:10:35 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:36 raspberrypi_AKS FogLAMP[8278] INFO: common: foglamp.services.core.api.common: Executing controlled shutdown
May 10 08:10:36 raspberrypi_AKS FogLAMP[8278] ERROR: common: foglamp.services.core.api.common: Error while stopping FogLAMP server: Cannot close a running event loop#012Traceback (most recent call last):#012  File "/home/pi/FogLAMP/python/foglamp/services/core/api/common.py", line 107, in do_shutdown#012    loop.close()#012  File "/usr/lib/python3.5/asyncio/unix_events.py", line 63, in close#012    super().close()#012  File "/usr/lib/python3.5/asyncio/selector_events.py", line 107, in close#012    raise RuntimeError("Cannot close a running event loop")#012RuntimeError: Cannot close a running event loop
May 10 08:10:36 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Processing stop request
May 10 08:10:36 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:37 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:39 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:40 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:41 raspberrypi_AKS FogLAMP[8278] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Stopped
May 10 08:10:41 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Shutting down the Southbound service HTTP_SOUTH ...
May 10 08:10:41 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Shutting down the Southbound service COAP ...
May 10 08:10:41 raspberrypi_AKS FogLAMP[8331] INFO: http_south: foglamp.plugins.south.http_south.http_south: Stopping South HTTP plugin.
May 10 08:10:41 raspberrypi_AKS FogLAMP[8331] INFO: http_south: foglamp.plugins.south.http_south.http_south: South HTTP plugin shut down.
May 10 08:10:41 raspberrypi_AKS FogLAMP[8333] INFO: coap_listen: foglamp.plugins.south.coap_listen.coap_listen: Stopping South COAP plugin...
May 10 08:10:41 raspberrypi_AKS FogLAMP[8333] INFO: coap_listen: foglamp.plugins.south.coap_listen.coap_listen: COAP plugin shut down.
May 10 08:10:41 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:43 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:44 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:45 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:51 raspberrypi_AKS FogLAMP[8278] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Stopped service instance id=a9aa3401-a888-4050-b03a-1911d787d937: <HTTP_SOUTH, type=Southbound, protocol=http, address=127.0.0.1, service port=36873, management port=36873, status=2>
May 10 08:10:52 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Successfully shut down the Southbound service HTTP_SOUTH.
May 10 08:10:57 raspberrypi_AKS FogLAMP[8278] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Stopped service instance id=e92f7ff7-9430-4148-8020-4bba53267f1f: <COAP, type=Southbound, protocol=http, address=127.0.0.1, service port=42627, management port=42627, status=2>
May 10 08:10:58 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:59 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Successfully shut down the Southbound service COAP.
May 10 08:10:59 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Services monitoring stopped.
May 10 08:10:59 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Rest server stopped.
May 10 08:10:59 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Shutting down the Storage service FogLAMP Storage ...
May 10 08:10:59 raspberrypi_AKS FogLAMP[8278] INFO: middleware: foglamp.common.web.middleware: Received GET request for /foglamp/ping
May 10 08:10:59 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Successfully shut down the Storage service FogLAMP Storage.
May 10 08:10:59 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: FogLAMP PID file [/home/pi/FogLAMP/data/var/run/foglamp.core.pid] removed.
May 10 08:10:59 raspberrypi_AKS FogLAMP[8278] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Stopped service instance id=f27b5779-6d28-470d-a313-f5ba67500acb: <FogLAMP Storage, type=Storage, protocol=http, address=localhost, service port=41687, management port=34019, status=2>
May 10 08:11:01 raspberrypi_AKS FogLAMP[8278] INFO: server: foglamp.services.core.server: Stopping the FogLAMP Core event loop. Good Bye!
May 10 08:11:03 raspberrypi_AKS FogLAMP [8369] INFO: script.foglamp: FogLAMP stopped.

```