### PR TITLE
Fogl-1118 - Removed log entries from python unit tests

### DIFF
--- a/tests/unit/python/foglamp/services/common/microservice_management/test_instance.py
+++ b/tests/unit/python/foglamp/services/common/microservice_management/test_instance.py
@@ -5,7 +5,9 @@
 # FOGLAMP_END
 
 import uuid
+from unittest.mock import patch
 import pytest
+
 from foglamp.services.core.service_registry.service_registry import ServiceRegistry as Service
 from foglamp.services.core.service_registry.exceptions import *
 from foglamp.common.service_record import ServiceRecord
@@ -18,7 +20,7 @@ __version__ = "${VERSION}"
 
 
 @pytest.allure.feature("unit")
-@pytest.allure.story("service-registry instance")
+@pytest.allure.story("services", "common", "microservice_management")
 class TestInstance:
     def setup_method(self):
         Service._registry = []
@@ -27,26 +29,37 @@ class TestInstance:
         Service._registry = []
 
     async def test_register(self):
-        idx = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
-        assert str(uuid.UUID(idx, version=4)) == idx
+        with patch.object(Service._logger, 'info') as log_info:
+            idx = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
+            assert str(uuid.UUID(idx, version=4)) == idx
+        assert 1 == log_info.call_count
 
     async def test_duplicate_name_registration(self):
-        idx1 = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
-        assert str(uuid.UUID(idx1, version=4)) == idx1
+        with patch.object(Service._logger, 'info') as log_info:
+            idx1 = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
+            assert str(uuid.UUID(idx1, version=4)) == idx1
+        assert 1 == log_info.call_count
+
         with pytest.raises(AlreadyExistsWithTheSameName) as excinfo:
             Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
         assert str(excinfo).endswith('AlreadyExistsWithTheSameName')
 
     async def test_duplicate_address_port_registration(self):
-        idx1 = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
-        assert str(uuid.UUID(idx1, version=4)) == idx1
+        with patch.object(Service._logger, 'info') as log_info:
+            idx1 = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
+            assert str(uuid.UUID(idx1, version=4)) == idx1
+        assert 1 == log_info.call_count
+
         with pytest.raises(AlreadyExistsWithTheSameAddressAndPort) as excinfo:
             Service.register("StorageService2", "Storage", "127.0.0.1", 9999, 1998)
         assert str(excinfo).endswith('AlreadyExistsWithTheSameAddressAndPort')
 
     async def test_duplicate_address_and_mgt_port_registration(self):
-        idx1 = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
-        assert str(uuid.UUID(idx1, version=4)) == idx1
+        with patch.object(Service._logger, 'info') as log_info:
+            idx1 = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
+            assert str(uuid.UUID(idx1, version=4)) == idx1
+        assert 1 == log_info.call_count
+
         with pytest.raises(AlreadyExistsWithTheSameAddressAndManagementPort) as excinfo:
             Service.register("StorageService2", "Storage", "127.0.0.1", 9998, 1999)
         assert str(excinfo).endswith('AlreadyExistsWithTheSameAddressAndManagementPort')
@@ -68,55 +81,63 @@ class TestInstance:
 
     async def test_unregister(self, mocker):
         # register a service
-        idx = Service.register("StorageService2", "Storage", "127.0.0.1", 8888, 1888)
-        assert str(uuid.UUID(idx, version=4)) == idx
+        with patch.object(Service._logger, 'info') as log_info:
+            idx = Service.register("StorageService2", "Storage", "127.0.0.1", 8888, 1888)
+            assert str(uuid.UUID(idx, version=4)) == idx
+        assert 1 == log_info.call_count
 
         mocker.patch.object(InterestRegistry, '__init__', return_value=None)
         mocker.patch.object(InterestRegistry, 'get', return_value=list())
 
         # deregister the same
-        t = Service.unregister(idx)
-        assert idx == t
+        with patch.object(Service._logger, 'info') as log_info2:
+            t = Service.unregister(idx)
+            assert idx == t
+        assert 1 == log_info2.call_count
 
         s = Service.get(idx)
         assert s[0]._status == 2  # Unregistered
 
     async def test_get(self):
-        s = Service.register("StorageService", "Storage", "localhost", 8881, 1888)
-        c = Service.register("CoreService", "Core", "localhost", 7771, 1777)
-        d = Service.register("SouthService", "Southbound", "127.0.0.1", 9991, 1999, "https")
+        with patch.object(Service._logger, 'info') as log_info:
+            s = Service.register("StorageService", "Storage", "localhost", 8881, 1888)
+            c = Service.register("CoreService", "Core", "localhost", 7771, 1777)
+            d = Service.register("SouthService", "Southbound", "127.0.0.1", 9991, 1999, "https")
+        assert 3 == log_info.call_count
 
-        l = Service.get()
-        assert 3 == len(l)
+        _service = Service.get()
+        assert 3 == len(_service)
 
-        assert s == l[0]._id
-        assert "StorageService" == l[0]._name
-        assert "Storage" == l[0]._type
-        assert "localhost" == l[0]._address
-        assert 8881 == int(l[0]._port)
-        assert 1888 == int(l[0]._management_port)
+        assert s == _service[0]._id
+        assert "StorageService" == _service[0]._name
+        assert "Storage" == _service[0]._type
+        assert "localhost" == _service[0]._address
+        assert 8881 == int(_service[0]._port)
+        assert 1888 == int(_service[0]._management_port)
         # validates default set to HTTP
-        assert "http" == l[0]._protocol
+        assert "http" == _service[0]._protocol
 
-        assert c == l[1]._id
-        assert "CoreService" == l[1]._name
-        assert "Core" == l[1]._type
-        assert "localhost" == l[1]._address
-        assert 7771 == int(l[1]._port)
-        assert 1777 == int(l[1]._management_port)
+        assert c == _service[1]._id
+        assert "CoreService" == _service[1]._name
+        assert "Core" == _service[1]._type
+        assert "localhost" == _service[1]._address
+        assert 7771 == int(_service[1]._port)
+        assert 1777 == int(_service[1]._management_port)
         # validates default set to HTTP
-        assert "http" == l[1]._protocol
+        assert "http" == _service[1]._protocol
 
-        assert d == l[2]._id
-        assert "SouthService" == l[2]._name
-        assert "Southbound" == l[2]._type
-        assert "127.0.0.1" == l[2]._address
-        assert 9991 == int(l[2]._port)
-        assert 1999 == int(l[2]._management_port)
-        assert "https" == l[2]._protocol
+        assert d == _service[2]._id
+        assert "SouthService" == _service[2]._name
+        assert "Southbound" == _service[2]._type
+        assert "127.0.0.1" == _service[2]._address
+        assert 9991 == int(_service[2]._port)
+        assert 1999 == int(_service[2]._management_port)
+        assert "https" == _service[2]._protocol
 
     async def test_get_fail(self):
         with pytest.raises(DoesNotExist) as excinfo:
-            Service.register("StorageService", "Storage", "127.0.0.1", 8888, 9999)
-            Service.get('incorrect_id')
+            with patch.object(Service._logger, 'info') as log_info:
+                Service.register("StorageService", "Storage", "127.0.0.1", 8888, 9999)
+                Service.get('incorrect_id')
+            assert 1 == log_info.call_count
         assert str(excinfo).endswith('DoesNotExist')

--- a/tests/unit/python/foglamp/services/common/microservice_management/test_instance.py
+++ b/tests/unit/python/foglamp/services/common/microservice_management/test_instance.py
@@ -33,12 +33,20 @@ class TestInstance:
             idx = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
             assert str(uuid.UUID(idx, version=4)) == idx
         assert 1 == log_info.call_count
+        args, kwargs = log_info.call_args
+        assert args[0].startswith('Registered service instance id=')
+        assert args[0].endswith(': <StorageService1, type=Storage, protocol=http, address=127.0.0.1, service port=9999,'
+                                ' management port=1999, status=1>')
 
     async def test_duplicate_name_registration(self):
         with patch.object(Service._logger, 'info') as log_info:
             idx1 = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
             assert str(uuid.UUID(idx1, version=4)) == idx1
         assert 1 == log_info.call_count
+        args, kwargs = log_info.call_args
+        assert args[0].startswith('Registered service instance id=')
+        assert args[0].endswith(': <StorageService1, type=Storage, protocol=http, address=127.0.0.1, service port=9999,'
+                                ' management port=1999, status=1>')
 
         with pytest.raises(AlreadyExistsWithTheSameName) as excinfo:
             Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
@@ -49,6 +57,10 @@ class TestInstance:
             idx1 = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
             assert str(uuid.UUID(idx1, version=4)) == idx1
         assert 1 == log_info.call_count
+        args, kwargs = log_info.call_args
+        assert args[0].startswith('Registered service instance id=')
+        assert args[0].endswith(': <StorageService1, type=Storage, protocol=http, address=127.0.0.1, service port=9999,'
+                                ' management port=1999, status=1>')
 
         with pytest.raises(AlreadyExistsWithTheSameAddressAndPort) as excinfo:
             Service.register("StorageService2", "Storage", "127.0.0.1", 9999, 1998)
@@ -59,6 +71,10 @@ class TestInstance:
             idx1 = Service.register("StorageService1", "Storage", "127.0.0.1", 9999, 1999)
             assert str(uuid.UUID(idx1, version=4)) == idx1
         assert 1 == log_info.call_count
+        args, kwargs = log_info.call_args
+        assert args[0].startswith('Registered service instance id=')
+        assert args[0].endswith(': <StorageService1, type=Storage, protocol=http, address=127.0.0.1, service port=9999,'
+                                ' management port=1999, status=1>')
 
         with pytest.raises(AlreadyExistsWithTheSameAddressAndManagementPort) as excinfo:
             Service.register("StorageService2", "Storage", "127.0.0.1", 9998, 1999)
@@ -85,6 +101,10 @@ class TestInstance:
             idx = Service.register("StorageService2", "Storage", "127.0.0.1", 8888, 1888)
             assert str(uuid.UUID(idx, version=4)) == idx
         assert 1 == log_info.call_count
+        arg, kwarg = log_info.call_args
+        assert arg[0].startswith('Registered service instance id=')
+        assert arg[0].endswith(': <StorageService2, type=Storage, protocol=http, address=127.0.0.1, service port=8888,'
+                               ' management port=1888, status=1>')
 
         mocker.patch.object(InterestRegistry, '__init__', return_value=None)
         mocker.patch.object(InterestRegistry, 'get', return_value=list())
@@ -94,6 +114,10 @@ class TestInstance:
             t = Service.unregister(idx)
             assert idx == t
         assert 1 == log_info2.call_count
+        args, kwargs = log_info2.call_args
+        assert args[0].startswith('Stopped service instance id=')
+        assert args[0].endswith(': <StorageService2, type=Storage, protocol=http, address=127.0.0.1, '
+                                'service port=8888, management port=1888, status=2>')
 
         s = Service.get(idx)
         assert s[0]._status == 2  # Unregistered
@@ -140,4 +164,9 @@ class TestInstance:
                 Service.register("StorageService", "Storage", "127.0.0.1", 8888, 9999)
                 Service.get('incorrect_id')
             assert 1 == log_info.call_count
+            args, kwargs = log_info.call_args
+            assert args[0].startswith('Registered service instance id=')
+            assert args[0].endswith(
+                ': <StorageService1, type=Storage, protocol=http, address=127.0.0.1, service port=8888,'
+                ' management port=9999, status=1>')
         assert str(excinfo).endswith('DoesNotExist')

--- a/tests/unit/python/foglamp/services/core/api/test_audit.py
+++ b/tests/unit/python/foglamp/services/core/api/test_audit.py
@@ -7,6 +7,7 @@
 
 import json
 from unittest.mock import MagicMock, patch
+from collections import Counter
 from aiohttp import web
 import pytest
 
@@ -85,11 +86,11 @@ class TestAudit:
                 result = await resp.text()
                 json_response = json.loads(result)
                 codes = [key['code'] for key in json_response['logCode']]
-                actual_code_list = [key['code'] for key in get_log_codes['rows']]
+                expected_code_list = [key['code'] for key in get_log_codes['rows']]
 
                 # verify the default log_codes with their values which are defined in init.sql
                 assert 18 == len(codes)
-                assert all([a == b for a, b in zip(actual_code_list, codes)])
+                assert Counter(expected_code_list) == Counter(codes)
             log_code_patch.assert_called_once_with('log_codes')
 
     @pytest.mark.parametrize("request_params, payload", [
@@ -140,9 +141,11 @@ class TestAudit:
                 assert response_message == resp.reason
 
     async def test_get_audit_http_exception(self, client):
-        resp = await client.get('/foglamp/audit')
-        assert 500 == resp.status
-        assert 'Internal Server Error' == resp.reason
+        with patch.object(connect, 'get_storage', return_value=Exception) as exc:
+            resp = await client.get('/foglamp/audit')
+            assert 500 == resp.status
+            assert 'Internal Server Error' == resp.reason
+        exc.assert_called_once_with()
 
     async def test_create_audit_entry(self, client):
         request_data = {"source": "LMTR", "severity": "warning", "details": {"message": "Engine oil pressure low"}}

--- a/tests/unit/python/foglamp/services/core/api/test_audit.py
+++ b/tests/unit/python/foglamp/services/core/api/test_audit.py
@@ -141,11 +141,10 @@ class TestAudit:
                 assert response_message == resp.reason
 
     async def test_get_audit_http_exception(self, client):
-        with patch.object(connect, 'get_storage', return_value=Exception) as exc:
+        with patch.object(connect, 'get_storage', return_value=Exception):
             resp = await client.get('/foglamp/audit')
             assert 500 == resp.status
             assert 'Internal Server Error' == resp.reason
-        exc.assert_called_once_with()
 
     async def test_create_audit_entry(self, client):
         request_data = {"source": "LMTR", "severity": "warning", "details": {"message": "Engine oil pressure low"}}

--- a/tests/unit/python/foglamp/services/core/api/test_backup_restore.py
+++ b/tests/unit/python/foglamp/services/core/api/test_backup_restore.py
@@ -90,9 +90,10 @@ class TestBackup:
         assert response_message == resp.reason
 
     async def test_get_backups_exceptions(self, client):
-        resp = await client.get('/foglamp/backup')
-        assert 500 == resp.status
-        assert "Internal Server Error" == resp.reason
+        with patch.object(connect, 'get_storage', return_value=Exception):
+            resp = await client.get('/foglamp/backup')
+            assert 500 == resp.status
+            assert "Internal Server Error" == resp.reason
 
     async def test_create_backup(self, client):
         async def mock_create():
@@ -106,9 +107,11 @@ class TestBackup:
                 assert '{"status": "running_or_failed"}' == await resp.text()
 
     async def test_create_backup_exception(self, client):
-        resp = await client.post('/foglamp/backup')
-        assert 500 == resp.status
-        assert "Internal Server Error" == resp.reason
+        with patch.object(connect, 'get_storage', return_value=Exception):
+            with patch.object(Backup, 'create_backup', return_value=Exception):
+                resp = await client.post('/foglamp/backup')
+                assert 500 == resp.status
+                assert "Internal Server Error" == resp.reason
 
     async def test_get_backup_details(self, client):
         storage_client_mock = MagicMock(StorageClient)

--- a/tests/unit/python/foglamp/services/core/api/test_browser_assets.py
+++ b/tests/unit/python/foglamp/services/core/api/test_browser_assets.py
@@ -135,11 +135,10 @@ class TestBrowserAssets:
 
     @pytest.mark.parametrize("request_url", URLS)
     async def test_http_exception(self, client, request_url):
-        with patch.object(connect, 'get_storage', return_value=Exception) as exc:
+        with patch.object(connect, 'get_storage', return_value=Exception):
             resp = await client.get(request_url)
             assert 500 == resp.status
             assert 'Internal Server Error' == resp.reason
-        exc.assert_called_once_with()
 
     @pytest.mark.parametrize("group_name, payload, result", [
         ('seconds', '{"aggregate": [{"alias": "min", "operation": "min", "json": {"properties": "temperature", "column": "reading"}}, {"alias": "max", "operation": "max", "json": {"properties": "temperature", "column": "reading"}}, {"alias": "average", "operation": "avg", "json": {"properties": "temperature", "column": "reading"}}], "where": {"column": "asset_code", "condition": "=", "value": "fogbench/humidity"}, "group": {"alias": "timestamp", "format": "YYYY-MM-DD HH24:MI:SS", "column": "user_ts"}, "limit": 20, "sort": {"column": "timestamp", "direction": "desc"}}',

--- a/tests/unit/python/foglamp/services/core/api/test_browser_assets.py
+++ b/tests/unit/python/foglamp/services/core/api/test_browser_assets.py
@@ -135,9 +135,11 @@ class TestBrowserAssets:
 
     @pytest.mark.parametrize("request_url", URLS)
     async def test_http_exception(self, client, request_url):
-        resp = await client.get(request_url)
-        assert 500 == resp.status
-        assert 'Internal Server Error' == resp.reason
+        with patch.object(connect, 'get_storage', return_value=Exception) as exc:
+            resp = await client.get(request_url)
+            assert 500 == resp.status
+            assert 'Internal Server Error' == resp.reason
+        exc.assert_called_once_with()
 
     @pytest.mark.parametrize("group_name, payload, result", [
         ('seconds', '{"aggregate": [{"alias": "min", "operation": "min", "json": {"properties": "temperature", "column": "reading"}}, {"alias": "max", "operation": "max", "json": {"properties": "temperature", "column": "reading"}}, {"alias": "average", "operation": "avg", "json": {"properties": "temperature", "column": "reading"}}], "where": {"column": "asset_code", "condition": "=", "value": "fogbench/humidity"}, "group": {"alias": "timestamp", "format": "YYYY-MM-DD HH24:MI:SS", "column": "user_ts"}, "limit": 20, "sort": {"column": "timestamp", "direction": "desc"}}',

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -316,11 +316,10 @@ class TestConfiguration:
     async def test_create_category_http_exception(self, client, name="test_cat", desc="Test desc"):
         info = {'info': {'type': 'boolean', 'value': 'False', 'description': 'Test', 'default': 'False'}}
         payload = {"key": name, "description": desc, "value": info}
-        with patch.object(connect, 'get_storage', side_effect=Exception) as exc:
+        with patch.object(connect, 'get_storage', side_effect=Exception):
             resp = await client.post('/foglamp/category', data=json.dumps(payload))
             assert 500 == resp.status
             assert 'Internal Server Error' == resp.reason
-        exc.assert_called_once_with()
 
     @pytest.mark.parametrize("payload, message", [
         # FIXME: keys order mismatch assertion
@@ -414,8 +413,7 @@ class TestConfiguration:
 
     async def test_unknown_exception_for_add_config_item(self, client):
         data = {"default": "d", "description": "Test description", "type": "boolean"}
-        with patch.object(connect, 'get_storage', side_effect=Exception) as exc:
+        with patch.object(connect, 'get_storage', side_effect=Exception):
             resp = await client.post('/foglamp/category/{}/{}'.format("blah", "blah"), data=json.dumps(data))
             assert 500 == resp.status
             assert 'Internal Server Error' == resp.reason
-        exc.assert_called_once_with()

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -316,9 +316,11 @@ class TestConfiguration:
     async def test_create_category_http_exception(self, client, name="test_cat", desc="Test desc"):
         info = {'info': {'type': 'boolean', 'value': 'False', 'description': 'Test', 'default': 'False'}}
         payload = {"key": name, "description": desc, "value": info}
-        resp = await client.post('/foglamp/category', data=json.dumps(payload))
-        assert 500 == resp.status
-        assert 'Internal Server Error' == resp.reason
+        with patch.object(connect, 'get_storage', side_effect=Exception) as exc:
+            resp = await client.post('/foglamp/category', data=json.dumps(payload))
+            assert 500 == resp.status
+            assert 'Internal Server Error' == resp.reason
+        exc.assert_called_once_with()
 
     @pytest.mark.parametrize("payload, message", [
         # FIXME: keys order mismatch assertion
@@ -370,11 +372,11 @@ class TestConfiguration:
                 assert "'Config item is already in use for {}'".format(category_name) == resp.reason
             patch_get_all_items.assert_called_once_with(category_name)
 
-    @pytest.mark.parametrize("data", [
-        {"default": "true", "description": "Test description", "type": "boolean"},
-        {"default": "true", "description": "Test description", "type": "boolean", "value": "false"}
+    @pytest.mark.parametrize("data, payload", [
+        ({"default": "true", "description": "Test description", "type": "boolean"}, '{"values": {"value": {"info": {"default": "1", "type": "integer", "description": "Test description"}, "info1": {"value": "true", "default": "true", "type": "boolean", "description": "Test description"}}}, "where": {"column": "key", "condition": "=", "value": "cat"}}'),
+        ({"default": "true", "description": "Test description", "type": "boolean", "value": "false"}, '{"values": {"value": {"info": {"default": "1", "type": "integer", "description": "Test description"}, "info1": {"value": "false", "default": "true", "type": "boolean", "description": "Test description"}}}, "where": {"column": "key", "condition": "=", "value": "cat"}}')
     ])
-    async def test_add_config_item(self, client, data):
+    async def test_add_config_item(self, client, data, payload):
         async def async_mock():
             return {"info": {"default": "1", "description": "Test description", "type": "integer"}}
 
@@ -383,7 +385,6 @@ class TestConfiguration:
 
         category_name = 'cat'
         new_config_item = 'info1'
-        payload = '{"values": {"value": {"info1": {"type": "boolean", "description": "Test description", "default": "true", "value": "true"}, "info": {"type": "integer", "description": "Test description", "default": "1"}}}, "where": {"column": "key", "condition": "=", "value": "cat"}}'
         expected = {'rows_affected': 1, "response": "updated"}
         result = {'message': '{} config item has been saved for {} category'.format(new_config_item, category_name)}
         storage_client_mock = MagicMock(StorageClient)
@@ -406,15 +407,15 @@ class TestConfiguration:
                     args, kwargs = audit_info_patch.call_args
                     assert 'CONAD' == args[0]
                     assert audit_details == args[1]
-                # FIXME: payload order assertion
-                args, kwargs = update_tbl_patch.call_args
-                assert args[0] == 'configuration'
-                # assert args[1] in payload
-                # update_tbl_patch.assert_called_once_with('configuration', payload)
+                args1, kwargs1 = update_tbl_patch.call_args
+                assert 'configuration' == args1[0]
+                assert json.loads(payload) == json.loads(args1[1])
             patch_get_all_items.assert_called_once_with(category_name)
 
     async def test_unknown_exception_for_add_config_item(self, client):
         data = {"default": "d", "description": "Test description", "type": "boolean"}
-        resp = await client.post('/foglamp/category/{}/{}'.format("blah", "blah"), data=json.dumps(data))
-        assert 500 == resp.status
-        assert 'Internal Server Error' == resp.reason
+        with patch.object(connect, 'get_storage', side_effect=Exception) as exc:
+            resp = await client.post('/foglamp/category/{}/{}'.format("blah", "blah"), data=json.dumps(data))
+            assert 500 == resp.status
+            assert 'Internal Server Error' == resp.reason
+        exc.assert_called_once_with()

--- a/tests/unit/python/foglamp/services/core/interest_registry/test_change_callback.py
+++ b/tests/unit/python/foglamp/services/core/interest_registry/test_change_callback.py
@@ -1,18 +1,11 @@
+from unittest.mock import MagicMock, patch, Mock, call
 import pytest
-import json
-import asyncio
+
 import aiohttp
-from unittest.mock import MagicMock
-from unittest.mock import patch
-from unittest.mock import Mock
-from unittest.mock import call
 from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.services.core.service_registry.service_registry import ServiceRegistry
 from foglamp.common.storage_client.storage_client import StorageClient
-from foglamp.services.core.service_registry import exceptions as service_registry_exceptions
-from foglamp.services.core.interest_registry.interest_registry import InterestRegistry
-from foglamp.services.core.interest_registry.interest_registry import InterestRegistrySingleton
-from foglamp.services.core.interest_registry import exceptions as interest_registry_exceptions
+from foglamp.services.core.interest_registry.interest_registry import InterestRegistry, InterestRegistrySingleton
 import foglamp.services.core.interest_registry.change_callback as cb
 
 
@@ -25,32 +18,34 @@ __version__ = "${VERSION}"
 @pytest.allure.feature("unit")
 @pytest.allure.story("common", "interest-registry")
 class TestChangeCallback:
-    @pytest.fixture()
-    def reset_state(self):
-        # executed before each test
+
+    def setup_method(self):
         InterestRegistrySingleton._shared_state = {}
-        del ServiceRegistry._registry[:]
-        yield
+        ServiceRegistry._registry = []
+
+    def teardown_method(self):
         InterestRegistrySingleton._shared_state = {}
-        del ServiceRegistry._registry[:]
+        ServiceRegistry._registry = []
 
     @pytest.mark.asyncio
-    async def test_run_good(self, reset_state):
+    async def test_run_good(self):
         storage_client_mock = MagicMock(spec=StorageClient)
         cfg_mgr = ConfigurationManager(storage_client_mock)
 
-        s_id_1 = ServiceRegistry.register(
-            'sname1', 'Storage', 'saddress1', 1, 1, 'http')
-        s_id_2 = ServiceRegistry.register(
-            'sname2', 'Southbound', 'saddress2', 2, 2, 'http')
-        s_id_3 = ServiceRegistry.register(
-            'sname3', 'Southbound', 'saddress3', 3, 3, 'http')
+        with patch.object(ServiceRegistry._logger, 'info') as log_info:
+            s_id_1 = ServiceRegistry.register(
+                'sname1', 'Storage', 'saddress1', 1, 1, 'http')
+            s_id_2 = ServiceRegistry.register(
+                'sname2', 'Southbound', 'saddress2', 2, 2, 'http')
+            s_id_3 = ServiceRegistry.register(
+                'sname3', 'Southbound', 'saddress3', 3, 3, 'http')
+        assert 3 == log_info.call_count
         i_reg = InterestRegistry(cfg_mgr)
-        id_1_1 = i_reg.register(s_id_1, 'catname1')
-        id_1_2 = i_reg.register(s_id_1, 'catname2')
-        id_2_1 = i_reg.register(s_id_2, 'catname1')
-        id_2_2 = i_reg.register(s_id_2, 'catname2')
-        id_3_3 = i_reg.register(s_id_3, 'catname3')
+        i_reg.register(s_id_1, 'catname1')
+        i_reg.register(s_id_1, 'catname2')
+        i_reg.register(s_id_2, 'catname1')
+        i_reg.register(s_id_2, 'catname2')
+        i_reg.register(s_id_3, 'catname3')
 
         # used to mock client session context manager
         async def async_mock(return_value):
@@ -74,34 +69,34 @@ class TestChangeCallback:
         with patch.object(ConfigurationManager, 'get_category_all_items', return_value=async_mock(None)) as cm_get_patch:
             with patch.object(aiohttp.ClientSession, 'post', return_value=AsyncSessionContextManagerMock()) as post_patch:
                 await cb.run('catname1')
+            post_patch.assert_has_calls([call('http://saddress1:1/foglamp/change', data='{"category": "catname1", "items": null}', headers={'content-type': 'application/json'}),
+                                         call('http://saddress2:2/foglamp/change', data='{"category": "catname1", "items": null}', headers={'content-type': 'application/json'})])
         cm_get_patch.assert_called_once_with('catname1')
-        post_patch.assert_has_calls([call('http://saddress1:1/foglamp/change', data='{"category": "catname1", "items": null}', headers={'content-type': 'application/json'}), call(
-            'http://saddress2:2/foglamp/change', data='{"category": "catname1", "items": null}', headers={'content-type': 'application/json'})])
+
         with patch.object(ConfigurationManager, 'get_category_all_items', return_value=async_mock(None)) as cm_get_patch:
             with patch.object(aiohttp.ClientSession, 'post', return_value=AsyncSessionContextManagerMock()) as post_patch:
                 await cb.run('catname2')
+            post_patch.assert_has_calls([call('http://saddress1:1/foglamp/change', data='{"category": "catname2", "items": null}', headers={'content-type': 'application/json'}),
+                                         call('http://saddress2:2/foglamp/change', data='{"category": "catname2", "items": null}', headers={'content-type': 'application/json'})])
         cm_get_patch.assert_called_once_with('catname2')
-        post_patch.assert_has_calls([call('http://saddress1:1/foglamp/change', data='{"category": "catname2", "items": null}', headers={'content-type': 'application/json'}), call(
-            'http://saddress2:2/foglamp/change', data='{"category": "catname2", "items": null}', headers={'content-type': 'application/json'})])
+
         with patch.object(ConfigurationManager, 'get_category_all_items', return_value=async_mock(None)) as cm_get_patch:
             with patch.object(aiohttp.ClientSession, 'post', return_value=AsyncSessionContextManagerMock()) as post_patch:
                 await cb.run('catname3')
+            post_patch.assert_called_once_with('http://saddress3:3/foglamp/change', data='{"category": "catname3", "items": null}', headers={'content-type': 'application/json'})
         cm_get_patch.assert_called_once_with('catname3')
-        post_patch.assert_called_once_with(
-            'http://saddress3:3/foglamp/change', data='{"category": "catname3", "items": null}', headers={'content-type': 'application/json'})
 
     @pytest.mark.asyncio
-    async def test_run_empty_interests(self, reset_state):
+    async def test_run_empty_interests(self):
         storage_client_mock = MagicMock(spec=StorageClient)
         cfg_mgr = ConfigurationManager(storage_client_mock)
 
-        s_id_1 = ServiceRegistry.register(
-            'sname1', 'Storage', 'saddress1', 1, 1, 'http')
-        s_id_2 = ServiceRegistry.register(
-            'sname2', 'Southbound', 'saddress2', 2, 2, 'http')
-        s_id_3 = ServiceRegistry.register(
-            'sname3', 'Southbound', 'saddress3', 3, 3, 'http')
-        i_reg = InterestRegistry(cfg_mgr)
+        with patch.object(ServiceRegistry._logger, 'info') as log_info:
+            ServiceRegistry.register('sname1', 'Storage', 'saddress1', 1, 1, 'http')
+            ServiceRegistry.register('sname2', 'Southbound', 'saddress2', 2, 2, 'http')
+            ServiceRegistry.register('sname3', 'Southbound', 'saddress3', 3, 3, 'http')
+        assert 3 == log_info.call_count
+        InterestRegistry(cfg_mgr)
 
         # used to mock client session context manager
         async def async_mock(return_value):
@@ -125,24 +120,26 @@ class TestChangeCallback:
         with patch.object(ConfigurationManager, 'get_category_all_items') as cm_get_patch:
             with patch.object(aiohttp.ClientSession, 'post') as post_patch:
                 await cb.run('catname1')
+            post_patch.assert_not_called()
         cm_get_patch.assert_not_called()
-        post_patch.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_run_no_intrests_in_cat(self, reset_state):
+    async def test_run_no_interests_in_cat(self):
         storage_client_mock = MagicMock(spec=StorageClient)
         cfg_mgr = ConfigurationManager(storage_client_mock)
 
-        s_id_1 = ServiceRegistry.register(
-            'sname1', 'Storage', 'saddress1', 1, 1, 'http')
-        s_id_2 = ServiceRegistry.register(
-            'sname2', 'Southbound', 'saddress2', 2, 2, 'http')
-        s_id_3 = ServiceRegistry.register(
-            'sname3', 'Southbound', 'saddress3', 3, 3, 'http')
+        with patch.object(ServiceRegistry._logger, 'info') as log_info:
+            s_id_1 = ServiceRegistry.register(
+                'sname1', 'Storage', 'saddress1', 1, 1, 'http')
+            s_id_2 = ServiceRegistry.register(
+                'sname2', 'Southbound', 'saddress2', 2, 2, 'http')
+            s_id_3 = ServiceRegistry.register(
+                'sname3', 'Southbound', 'saddress3', 3, 3, 'http')
+        assert 3 == log_info.call_count
         i_reg = InterestRegistry(cfg_mgr)
-        id_1_2 = i_reg.register(s_id_1, 'catname2')
-        id_2_2 = i_reg.register(s_id_2, 'catname2')
-        id_3_3 = i_reg.register(s_id_3, 'catname3')
+        i_reg.register(s_id_1, 'catname2')
+        i_reg.register(s_id_2, 'catname2')
+        i_reg.register(s_id_3, 'catname3')
 
         # used to mock client session context manager
         async def async_mock(return_value):
@@ -165,27 +162,30 @@ class TestChangeCallback:
         with patch.object(ConfigurationManager, 'get_category_all_items') as cm_get_patch:
             with patch.object(aiohttp.ClientSession, 'post') as post_patch:
                 await cb.run('catname1')
+            post_patch.assert_not_called()
         cm_get_patch.assert_not_called()
-        post_patch.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_run_missing_service_record(self, reset_state):
+    async def test_run_missing_service_record(self):
         storage_client_mock = MagicMock(spec=StorageClient)
         cfg_mgr = ConfigurationManager(storage_client_mock)
 
-        s_id_1 = ServiceRegistry.register(
-            'sname1', 'Storage', 'saddress1', 1, 1, 'http')
-        s_id_2 = ServiceRegistry.register(
-            'sname2', 'Southbound', 'saddress2', 2, 2, 'http')
-        s_id_3 = ServiceRegistry.register(
-            'sname3', 'Southbound', 'saddress3', 3, 3, 'http')
+        with patch.object(ServiceRegistry._logger, 'info') as log_info:
+            s_id_1 = ServiceRegistry.register(
+                'sname1', 'Storage', 'saddress1', 1, 1, 'http')
+            s_id_2 = ServiceRegistry.register(
+                'sname2', 'Southbound', 'saddress2', 2, 2, 'http')
+            s_id_3 = ServiceRegistry.register(
+                'sname3', 'Southbound', 'saddress3', 3, 3, 'http')
+        assert 3 == log_info.call_count
+
         i_reg = InterestRegistry(cfg_mgr)
-        id_fake_1 = i_reg.register('fakeid', 'catname1')
-        id_1_1 = i_reg.register(s_id_1, 'catname1')
-        id_1_2 = i_reg.register(s_id_1, 'catname2')
-        id_2_1 = i_reg.register(s_id_2, 'catname1')
-        id_2_2 = i_reg.register(s_id_2, 'catname2')
-        id_3_3 = i_reg.register(s_id_3, 'catname3')
+        i_reg.register('fakeid', 'catname1')
+        i_reg.register(s_id_1, 'catname1')
+        i_reg.register(s_id_1, 'catname2')
+        i_reg.register(s_id_2, 'catname1')
+        i_reg.register(s_id_2, 'catname2')
+        i_reg.register(s_id_3, 'catname3')
 
         # used to mock client session context manager
         async def async_mock(return_value):
@@ -210,20 +210,22 @@ class TestChangeCallback:
             with patch.object(aiohttp.ClientSession, 'post', return_value=AsyncSessionContextManagerMock()) as post_patch:
                 with patch.object(cb._LOGGER, 'exception') as exception_patch:
                     await cb.run('catname1')
+                exception_patch.assert_called_once_with(
+                    'Unable to notify microservice with uuid %s as it is not found in the service registry', 'fakeid')
+            post_patch.assert_has_calls([call('http://saddress1:1/foglamp/change', data='{"category": "catname1", "items": null}', headers={'content-type': 'application/json'}),
+                                         call('http://saddress2:2/foglamp/change', data='{"category": "catname1", "items": null}', headers={'content-type': 'application/json'})])
         cm_get_patch.assert_called_once_with('catname1')
-        exception_patch.assert_called_once_with('Unable to notify microservice with uuid %s as it is not found in the service registry', 'fakeid')
-        post_patch.assert_has_calls([call('http://saddress1:1/foglamp/change', data='{"category": "catname1", "items": null}', headers={'content-type': 'application/json'}), call(
-            'http://saddress2:2/foglamp/change', data='{"category": "catname1", "items": null}', headers={'content-type': 'application/json'})])
 
     @pytest.mark.asyncio
-    async def test_run_general_exception(self, reset_state):
+    async def test_run_general_exception(self):
         storage_client_mock = MagicMock(spec=StorageClient)
         cfg_mgr = ConfigurationManager(storage_client_mock)
 
-        s_id_1 = ServiceRegistry.register(
-            'sname1', 'Storage', 'saddress1', 1, 1, 'http')
+        with patch.object(ServiceRegistry._logger, 'info') as log_info:
+            s_id_1 = ServiceRegistry.register('sname1', 'Storage', 'saddress1', 1, 1, 'http')
+        assert 1 == log_info.call_count
         i_reg = InterestRegistry(cfg_mgr)
-        id_1_1 = i_reg.register(s_id_1, 'catname1')
+        i_reg.register(s_id_1, 'catname1')
 
         # used to mock client session context manager
         async def async_mock(return_value):
@@ -243,6 +245,7 @@ class TestChangeCallback:
             with patch.object(aiohttp.ClientSession, 'post', return_value=AsyncSessionContextManagerMock()) as post_patch:
                 with patch.object(cb._LOGGER, 'exception') as exception_patch:
                     await cb.run('catname1')
+                exception_patch.assert_called_once_with(
+                    'Unable to notify microservice with uuid %s due to exception: %s', s_id_1, '')
+            post_patch.assert_has_calls([call('http://saddress1:1/foglamp/change', data='{"category": "catname1", "items": null}', headers={'content-type': 'application/json'})])
         cm_get_patch.assert_called_once_with('catname1')
-        exception_patch.assert_called_once_with('Unable to notify microservice with uuid %s due to exception: %s', s_id_1, '')
-        post_patch.assert_has_calls([call('http://saddress1:1/foglamp/change', data='{"category": "catname1", "items": null}', headers={'content-type': 'application/json'})])

--- a/tests/unit/python/foglamp/services/core/interest_registry/test_change_callback.py
+++ b/tests/unit/python/foglamp/services/core/interest_registry/test_change_callback.py
@@ -224,6 +224,10 @@ class TestChangeCallback:
         with patch.object(ServiceRegistry._logger, 'info') as log_info:
             s_id_1 = ServiceRegistry.register('sname1', 'Storage', 'saddress1', 1, 1, 'http')
         assert 1 == log_info.call_count
+        args, kwargs = log_info.call_args
+        assert args[0].startswith('Registered service instance id=')
+        assert args[0].endswith(': <sname1, type=Storage, protocol=http, address=saddress1, service port=1, management port=1, status=1>')
+
         i_reg = InterestRegistry(cfg_mgr)
         i_reg.register(s_id_1, 'catname1')
 

--- a/tests/unit/python/foglamp/services/core/service_registry/test_service_registry.py
+++ b/tests/unit/python/foglamp/services/core/service_registry/test_service_registry.py
@@ -4,10 +4,8 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-""" Test foglamp/services/core/service_registry/service_registry.py """
-
-import pytest
 from unittest.mock import patch
+import pytest
 
 from foglamp.services.core.service_registry.service_registry import ServiceRegistry
 from foglamp.services.core.service_registry.exceptions import *
@@ -22,115 +20,120 @@ __version__ = "${VERSION}"
 @pytest.allure.story("services", "core", "service-registry")
 class TestServiceRegistry:
 
-    def setup_method(self, method):
+    def setup_method(self):
         ServiceRegistry._registry = list()
 
-    def teardown_method(self, method):
+    def teardown_method(self):
         ServiceRegistry._registry = list()
 
     def test_register(self):
-        with patch.object(ServiceRegistry._logger, 'info') as log_i:
+        with patch.object(ServiceRegistry._logger, 'info') as log_info:
             s_id = ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1234, 4321, 'http')
             assert 36 == len(s_id)  # uuid version 4 len
             assert 1 == len(ServiceRegistry._registry)
-        args, kwargs = log_i.call_args
+        assert 1 == log_info.call_count
+        args, kwargs = log_info.call_args
         assert args[0].startswith('Registered service instance id=')
         assert args[0].endswith(': <A name, type=Storage, protocol=http, address=127.0.0.1, service port=1234,'
                                 ' management port=4321, status=1>')
-        assert 1 == log_i.call_count
 
     def test_register_with_service_port_none(self):
-        with patch.object(ServiceRegistry._logger, 'info') as log_i:
+        with patch.object(ServiceRegistry._logger, 'info') as log_info:
             s_id = ServiceRegistry.register("A name", "Southbound", "127.0.0.1", None, 4321, 'http')
             assert 36 == len(s_id)  # uuid version 4 len
             assert 1 == len(ServiceRegistry._registry)
-        args, kwargs = log_i.call_args
+        assert 1 == log_info.call_count
+        args, kwargs = log_info.call_args
         assert args[0].startswith('Registered service instance id=')
         assert args[0].endswith(': <A name, type=Southbound, protocol=http, address=127.0.0.1, service port=None,'
                                 ' management port=4321, status=1>')
-        assert 1 == log_i.call_count
 
     def test_register_with_same_name(self):
         """raise AlreadyExistsWithTheSameName"""
-
-        ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1, 2, 'http')
-        assert 1 == len(ServiceRegistry._registry)
+        with patch.object(ServiceRegistry._logger, 'info') as log_info1:
+            ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1, 2, 'http')
+            assert 1 == len(ServiceRegistry._registry)
+        assert 1 == log_info1.call_count
 
         with pytest.raises(Exception) as excinfo:
-            with patch.object(ServiceRegistry._logger, 'info') as log_i:
+            with patch.object(ServiceRegistry._logger, 'info') as log_info2:
                 ServiceRegistry.register("A name", "Storage", "127.0.0.2", 3, 4, 'http')
-        assert 0 == log_i.call_count
+                assert 1 == len(ServiceRegistry._registry)
+            assert 0 == log_info2.call_count
         assert excinfo.type is AlreadyExistsWithTheSameName
-        assert 1 == len(ServiceRegistry._registry)
 
     def test_register_with_same_address_and_port(self):
         """raise AlreadyExistsWithTheSameAddressAndPort"""
-        ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1234, 1, 'http')
-        assert 1 == len(ServiceRegistry._registry)
+        with patch.object(ServiceRegistry._logger, 'info') as log_info1:
+            ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1234, 1, 'http')
+            assert 1 == len(ServiceRegistry._registry)
+        assert 1 == log_info1.call_count
 
         with pytest.raises(Exception) as excinfo:
-            with patch.object(ServiceRegistry._logger, 'info') as log_i:
+            with patch.object(ServiceRegistry._logger, 'info') as log_info2:
                 ServiceRegistry.register("B name", "Storage", "127.0.0.1", 1234, 2, 'http')
-        assert 0 == log_i.call_count
+                assert 1 == len(ServiceRegistry._registry)
+            assert 0 == log_info2.call_count
         assert excinfo.type is AlreadyExistsWithTheSameAddressAndPort
-        assert 1 == len(ServiceRegistry._registry)
 
     def test_register_with_same_address_and_mgt_port(self):
         """raise AlreadyExistsWithTheSameAddressAndManagementPort"""
-        ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1, 1234, 'http')
-        assert 1 == len(ServiceRegistry._registry)
+        with patch.object(ServiceRegistry._logger, 'info') as log_info1:
+            ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1, 1234, 'http')
+            assert 1 == len(ServiceRegistry._registry)
+        assert 1 == log_info1.call_count
 
         with pytest.raises(Exception) as excinfo:
-            with patch.object(ServiceRegistry._logger, 'info') as log_i:
+            with patch.object(ServiceRegistry._logger, 'info') as log_info2:
                 ServiceRegistry.register("B name", "Storage", "127.0.0.1", 2, 1234, 'http')
-        assert 0 == log_i.call_count
+                assert 1 == len(ServiceRegistry._registry)
+            assert 0 == log_info2.call_count
         assert excinfo.type is AlreadyExistsWithTheSameAddressAndManagementPort
-        assert 1 == len(ServiceRegistry._registry)
 
     def test_register_with_bad_service_port(self):
         """raise NonNumericPortError"""
         with pytest.raises(Exception) as excinfo:
-            with patch.object(ServiceRegistry._logger, 'info') as log_i:
+            with patch.object(ServiceRegistry._logger, 'info') as log_info:
                 ServiceRegistry.register("B name", "Storage", "127.0.0.1", "s01", 1234, 'http')
-        assert 0 == log_i.call_count
+                assert 1 == len(ServiceRegistry._registry)
+            assert 0 == log_info.call_count
         assert excinfo.type is NonNumericPortError
-        assert 0 == len(ServiceRegistry._registry)
 
     def test_register_with_bad_management_port(self):
         """raise NonNumericPortError"""
         with pytest.raises(Exception) as excinfo:
-            with patch.object(ServiceRegistry._logger, 'info') as log_i:
+            with patch.object(ServiceRegistry._logger, 'info') as log_info:
                 ServiceRegistry.register("B name", "Storage", "127.0.0.1", 1234, "m01", 'http')
-        assert 0 == log_i.call_count
+                assert 0 == len(ServiceRegistry._registry)
+            assert 0 == log_info.call_count
         assert excinfo.type is NonNumericPortError
-        assert 0 == len(ServiceRegistry._registry)
 
-    def test_unregister(selfd, mocker):
+    def test_unregister(self, mocker):
         mocker.patch.object(InterestRegistry, '__init__', return_value=None)
         mocker.patch.object(InterestRegistry, 'get', return_value=list())
 
-        reg_id = ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1234, 4321, 'http')
-        assert 1 == len(ServiceRegistry._registry)
+        with patch.object(ServiceRegistry._logger, 'info') as log_info1:
+            reg_id = ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1234, 4321, 'http')
+            assert 1 == len(ServiceRegistry._registry)
+        assert 1 == log_info1.call_count
 
-        with patch.object(ServiceRegistry._logger, 'info') as log_i:
+        with patch.object(ServiceRegistry._logger, 'info') as log_info2:
             s_id = ServiceRegistry.unregister(reg_id)
             assert 36 == len(s_id)  # uuid version 4 len
             assert 1 == len(ServiceRegistry._registry)
             s = ServiceRegistry.get(idx=s_id)
             assert s[0]._status == 2
-
-        args, kwargs = log_i.call_args
+        assert 1 == log_info2.call_count
+        args, kwargs = log_info2.call_args
         assert args[0].startswith('Stopped service instance id=')
         assert args[0].endswith(': <A name, type=Storage, protocol=http, address=127.0.0.1, service port=1234,'
                                 ' management port=4321, status=2>')
-        assert 1 == log_i.call_count
 
     def test_unregister_non_existing_service_record(self):
         """raise DoesNotExist"""
-
         with pytest.raises(Exception) as excinfo:
-            with patch.object(ServiceRegistry._logger, 'info') as log_i:
+            with patch.object(ServiceRegistry._logger, 'info') as log_info:
                 ServiceRegistry.unregister("blah")
-        assert 0 == log_i.call_count
+                assert 0 == len(ServiceRegistry._registry)
+            assert 0 == log_info.call_count
         assert excinfo.type is DoesNotExist
-

--- a/tests/unit/python/foglamp/services/core/service_registry/test_service_registry.py
+++ b/tests/unit/python/foglamp/services/core/service_registry/test_service_registry.py
@@ -54,6 +54,10 @@ class TestServiceRegistry:
             ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1, 2, 'http')
             assert 1 == len(ServiceRegistry._registry)
         assert 1 == log_info1.call_count
+        args, kwargs = log_info1.call_args
+        assert args[0].startswith('Registered service instance id=')
+        assert args[0].endswith(': <A name, type=Storage, protocol=http, address=127.0.0.1, service port=1,'
+                                ' management port=2, status=1>')
 
         with pytest.raises(Exception) as excinfo:
             with patch.object(ServiceRegistry._logger, 'info') as log_info2:
@@ -68,6 +72,10 @@ class TestServiceRegistry:
             ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1234, 1, 'http')
             assert 1 == len(ServiceRegistry._registry)
         assert 1 == log_info1.call_count
+        args, kwargs = log_info1.call_args
+        assert args[0].startswith('Registered service instance id=')
+        assert args[0].endswith(': <A name, type=Storage, protocol=http, address=127.0.0.1, service port=1234,'
+                                ' management port=1, status=1>')
 
         with pytest.raises(Exception) as excinfo:
             with patch.object(ServiceRegistry._logger, 'info') as log_info2:
@@ -82,6 +90,10 @@ class TestServiceRegistry:
             ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1, 1234, 'http')
             assert 1 == len(ServiceRegistry._registry)
         assert 1 == log_info1.call_count
+        args, kwargs = log_info1.call_args
+        assert args[0].startswith('Registered service instance id=')
+        assert args[0].endswith(': <A name, type=Storage, protocol=http, address=127.0.0.1, service port=1,'
+                                ' management port=1234, status=1>')
 
         with pytest.raises(Exception) as excinfo:
             with patch.object(ServiceRegistry._logger, 'info') as log_info2:
@@ -116,6 +128,10 @@ class TestServiceRegistry:
             reg_id = ServiceRegistry.register("A name", "Storage", "127.0.0.1", 1234, 4321, 'http')
             assert 1 == len(ServiceRegistry._registry)
         assert 1 == log_info1.call_count
+        arg, kwarg = log_info1.call_args
+        assert arg[0].startswith('Registered service instance id=')
+        assert arg[0].endswith(': <A name, type=Storage, protocol=http, address=127.0.0.1, service port=1234,'
+                               ' management port=4321, status=1>')
 
         with patch.object(ServiceRegistry._logger, 'info') as log_info2:
             s_id = ServiceRegistry.unregister(reg_id)


### PR DESCRIPTION
- [x] **tests/unit/python/foglamp/common**
     - [x] test_microservice_management_client.py
     - [x] test_configuration_manager.py
- [x] **tests/unit/python/foglamp/plugins**
- [x] **tests/unit/python/foglamp/services**
- [x] **tests/unit/python/foglamp/tasks**


**NOTE**: 
1) No syslog entries  when we run `pytest` for the python unit tests
2) No regression in tests when we run in suite as well `=== 1195 passed, 13 skipped in 67.32 seconds ==`