### PR TITLE
FOGL-1353 - python/foglamp/common/statistics.py should use async storage client

### DIFF
--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -9,11 +9,11 @@
 from abc import ABC, abstractmethod
 import argparse
 import time
-from foglamp.common.storage_client.storage_client import ReadingsStorageClient, StorageClient
+from foglamp.common.storage_client.storage_client import StorageClient, ReadingsStorageClient, StorageClientAsync, ReadingsStorageClientAsync
 from foglamp.common import logger
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient
 
-__author__ = "Ashwin Gopalakrishnan"
+__author__ = "Ashwin Gopalakrishnan, Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
@@ -60,9 +60,15 @@ class FoglampProcess(ABC):
     _readings_storage = None
     """ foglamp.common.storage_client.storage_client.ReadingsStorageClient """
 
+    _readings_storage_async = None
+    """ foglamp.common.storage_client.storage_client.ReadingsStorageClient """
+
     _storage = None
     """ foglamp.common.storage_client.storage_client.StorageClient """
     
+    _storage_async = None
+    """ async foglamp.common.storage_client.storage_client.StorageClient """
+
     _start_time = None
     """ time at which this python process started """
 
@@ -90,8 +96,12 @@ class FoglampProcess(ABC):
             raise ValueError("--name is not specified")
 
         self._core_microservice_management_client = MicroserviceManagementClient(self._core_management_host,self._core_management_port)
+
         self._readings_storage = ReadingsStorageClient(self._core_management_host, self._core_management_port)
         self._storage = StorageClient(self._core_management_host, self._core_management_port)
+
+        self._readings_storage_async = ReadingsStorageClientAsync(self._core_management_host, self._core_management_port)
+        self._storage_async = StorageClientAsync(self._core_management_host, self._core_management_port)
 
     # pure virtual method run() to be implemented by child class
     @abstractmethod

--- a/python/foglamp/common/statistics.py
+++ b/python/foglamp/common/statistics.py
@@ -5,18 +5,22 @@
 # FOGLAMP_END
 
 from foglamp.common import logger
-
 from foglamp.common.storage_client.payload_builder import PayloadBuilder
-from foglamp.common.storage_client.storage_client import StorageClient
+from foglamp.common.storage_client.storage_client import StorageClientAsync
 
 
-__author__ = "Ashwin Gopalakrishnan, Ashish Jabble, Mark Riddoch"
+__author__ = "Ashwin Gopalakrishnan, Ashish Jabble, Mark Riddoch, Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 
 _logger = logger.setup(__name__)
+
+async def create_statistics(storage=None):
+    stat = Statistics(storage)
+    await stat._init()
+    return stat
 
 
 class Statistics(object):
@@ -35,11 +39,13 @@ class Statistics(object):
     def __init__(self, storage=None):
         self.__dict__ = self._shared_state
         if self._storage is None:
-            if not isinstance(storage, StorageClient):
-                raise TypeError('Must be a valid Storage object')
+            if not isinstance(storage, StorageClientAsync):
+                raise TypeError('Must be a valid Async Storage object')
             self._storage = storage
+
+    async def _init(self):
         if self._registered_keys is None:
-            self._load_keys()
+            await self._load_keys()
 
     async def update(self, key, value_increment):
         """ UPDATE the value column only of a statistics row based on key
@@ -62,7 +68,7 @@ class Statistics(object):
                 .WHERE(["key", "=", key])\
                 .EXPR(["value", "+", value_increment])\
                 .payload()
-            self._storage.update_tbl("statistics", payload)
+            await self._storage.update_tbl("statistics", payload)
         except Exception as ex:
             _logger.exception(
                 'Unable to update statistics value based on statistics_key %s and value_increment %d, error %s'
@@ -85,7 +91,7 @@ class Statistics(object):
                     .WHERE(["key", "=", key]) \
                     .EXPR(["value", "+", value_increment]) \
                     .payload()
-                result = self._storage.update_tbl("statistics", payload)
+                result = await self._storage.update_tbl("statistics", payload)
                 if result["response"] != "updated":
                     raise KeyError
             # If key was not present, add the key and with value = value_increment
@@ -102,23 +108,23 @@ class Statistics(object):
         if key in self._registered_keys:
             return
         if len(self._registered_keys) == 0:
-            self._load_keys()
+            await self._load_keys()
         try:
             payload = PayloadBuilder().INSERT(key=key, description=description, value=0, previous_value=0).payload()
-            self._storage.insert_into_tbl("statistics", payload)
+            await self._storage.insert_into_tbl("statistics", payload)
             self._registered_keys.append(key)
         except Exception as ex:
             """ The error may be because the key has been created in another process, reload keys """
-            self._load_keys()
+            await self._load_keys()
             if key not in self._registered_keys:
                 _logger.exception('Unable to create new statistic %s, error %s', key, str(ex))
                 raise
 
-    def _load_keys(self):
+    async def _load_keys(self):
         self._registered_keys = []
         try:
             payload = PayloadBuilder().SELECT("key").payload()
-            results = self._storage.query_tbl_with_payload('statistics', payload)
+            results = await self._storage.query_tbl_with_payload('statistics', payload)
             for row in results['rows']:
                 self._registered_keys.append(row['key'])
         except Exception as ex:

--- a/python/foglamp/services/south/ingest.py
+++ b/python/foglamp/services/south/ingest.py
@@ -13,11 +13,12 @@ import uuid
 from typing import List, Union
 import json
 from foglamp.common import logger
-from foglamp.common.statistics import Statistics
-from foglamp.common.storage_client.storage_client import ReadingsStorageClient, StorageClient
+from foglamp.common import statistics
+from foglamp.common.storage_client.storage_client import ReadingsStorageClient, ReadingsStorageClientAsync, \
+                                                         StorageClient, StorageClientAsync
 from foglamp.common.storage_client.exceptions import StorageServerError
 
-__author__ = "Terris Linenbach"
+__author__ = "Terris Linenbach, Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
@@ -44,6 +45,9 @@ class Ingest(object):
 
     readings_storage = None  # type: Readings
     storage = None  # type: Storage
+
+    readings_storage_async = None  # type: Readings
+    storage_async = None  # type: Storage
 
     _readings_stats = 0  # type: int
     """Number of readings accepted before statistics were written to storage"""
@@ -206,6 +210,9 @@ class Ingest(object):
 
         cls.readings_storage = ReadingsStorageClient(cls._core_management_host, cls._core_management_port)
         cls.storage = StorageClient(cls._core_management_host, cls._core_management_port)
+
+        cls.readings_storage_async = ReadingsStorageClientAsync(cls._core_management_host, cls._core_management_port)
+        cls.storage_async = StorageClientAsync(cls._core_management_host, cls._core_management_port)
 
         await cls._read_config()
 
@@ -425,7 +432,7 @@ class Ingest(object):
         """Periodically commits collected readings statistics"""
         _LOGGER.info('South statistics writer started')
 
-        stats = Statistics(cls.storage)
+        stats = await statistics.create_statistics(cls.storage_async)
 
         # Register static statistics
         await stats.register('READINGS', 'The number of readings received by FogLAMP since startup')
@@ -452,7 +459,7 @@ class Ingest(object):
             cls._readings_stats = 0
 
             try:
-                await stats.update('READINGS', readings)
+                asyncio.ensure_future(stats.update('READINGS', readings))
             except Exception as ex:
                 cls._readings_stats += readings
                 _LOGGER.exception('An error occurred while writing readings statistics, %s', str(ex))
@@ -461,7 +468,7 @@ class Ingest(object):
             cls._discarded_readings_stats = 0
 
             try:
-                await stats.update('DISCARDED', readings)
+                asyncio.ensure_future(stats.update('DISCARDED', readings))
             except Exception as ex:
                 cls._discarded_readings_stats += readings
                 _LOGGER.exception('An error occurred while writing discarded statistics, Error: %s', str(ex))
@@ -471,7 +478,7 @@ class Ingest(object):
                 description = 'The number of readings received by FogLAMP since startup for sensor {}'.format(key)
                 await stats.register(key, description)
             try:
-                await stats.add_update(cls._sensor_stats)
+                asyncio.ensure_future(stats.add_update(cls._sensor_stats))
                 cls._sensor_stats = {}
             except Exception as ex:
                 _LOGGER.exception('An error occurred while writing sensor statistics, Error: %s', str(ex))

--- a/python/foglamp/tasks/north/sending_process.py
+++ b/python/foglamp/tasks/north/sending_process.py
@@ -32,7 +32,7 @@ from foglamp.common.storage_client.storage_client import StorageClient, Readings
 from foglamp.common import logger
 from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.common.storage_client import payload_builder
-from foglamp.common.statistics import Statistics
+from foglamp.common import statistics
 from foglamp.common.jqfilter import JQFilter
 from foglamp.common.audit_logger import AuditLogger
 
@@ -985,7 +985,8 @@ class SendingProcess:
         """
         try:
             key = 'SENT_' + str(stream_id)
-            _stats = Statistics(self._storage)
+            _stats = await statistics.create_statistics(self._storage_async)
+
             await _stats.update(key, num_sent)
 
         except Exception:

--- a/python/foglamp/tasks/purge/purge.py
+++ b/python/foglamp/tasks/purge/purge.py
@@ -27,14 +27,14 @@ import time
 
 from foglamp.common.audit_logger import AuditLogger
 from foglamp.common.configuration_manager import ConfigurationManager
-from foglamp.common.statistics import Statistics
+from foglamp.common import statistics
 from foglamp.common.storage_client.payload_builder import PayloadBuilder
 from foglamp.common import logger
 from foglamp.common.storage_client.exceptions import *
 from foglamp.common.process import FoglampProcess
 
 
-__author__ = "Ori Shadmon, Vaibhav Singhal, Mark Riddoch"
+__author__ = "Ori Shadmon, Vaibhav Singhal, Mark Riddoch, Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSI Soft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
@@ -71,7 +71,7 @@ class Purge(FoglampProcess):
         self.loop = asyncio.get_event_loop() if loop is None else loop
 
     def write_statistics(self, total_purged, unsent_purged):
-        stats = Statistics(self._storage)
+        stats = self.loop.run_until_complete(statistics.create_statistics(self._storage_async))
         self.loop.run_until_complete(stats.update('PURGED', total_purged))
         self.loop.run_until_complete(stats.update('UNSNPURGED', unsent_purged))
 


### PR DESCRIPTION
Replaces PR #820 which was incorrectly merged.

@ashish-jabble commented on PR #820:
```
After rebasing, I see errors and regression for statistics

ERROR: statistics: foglamp.common.statistics: Unable to update statistics value based on statistics_key DISCARDED and value_increment 0, error None#012Traceback (most recent call last):#012  File "/home/pi/FogLAMP/python/foglamp/common/statistics.py", line 71, in update#012    await self._storage.update_tbl("statistics", payload)#012  File "/home/pi/FogLAMP/python/foglamp/common/storage_client/storage_client.py", line 695, in update_tbl#012    raise ex#012  File "/home/pi/FogLAMP/python/foglamp/common/storage_client/storage_client.py", line 687, in update_tbl#012    async with self._session.put(url, data=data) as resp:#012  File "/home/pi/.local/lib/python3.5/site-packages/aiohttp/client.py", line 690, in __aenter__#012    self._resp = yield from self._coro#012  File "/home/pi/.local/lib/python3.5/site-packages/aiohttp/client.py", line 277, in _request#012    yield from resp.start(conn, read_until_eof)#012  File "/home/pi/.local/lib/python3.5/site-packages/aiohttp/client_reqrep.py", line 624, in start#012    (message, payload) = yield from self._protocol.read()#012  File "/home/pi/.local/lib/python3.5/site-packages/aiohttp/streams.py", line 554, in read#012    yield from self._waiter#012  File "/usr/lib/python3.5/asyncio/futures.py", line 380, in __iter__#012    yield self  # This tells Task to wait for completion.#012  File "/usr/lib/python3.5/asyncio/tasks.py", line 304, in _wakeup#012    future.result()#012  File "/usr/lib/python3.5/asyncio/futures.py", line 293, in result#012    raise self._exception#012aiohttp.client_exceptions.ServerDisconnectedError: None

```