### PR TITLE
FOGL-1389 - Added feature to enable/disable schedule by schedule update vide PUT

### DIFF
--- a/python/foglamp/services/core/api/scheduler.py
+++ b/python/foglamp/services/core/api/scheduler.py
@@ -141,7 +141,7 @@ def _extract_args(data, curr_value):
             'schedule_enabled'] if curr_value else 'True'
         _schedule['schedule_enabled'] = 'True' if _schedule['schedule_enabled'] else 'False'
 
-        _schedule['enabled_changed'] = data.get('enabled') if 'enabled' in data else None
+        _schedule['is_enabled_modified'] = data.get('enabled') if 'enabled' in data else None
     except ValueError as ex:
         raise web.HTTPBadRequest(reason=str(ex))
 
@@ -261,7 +261,7 @@ async def _execute_add_update_schedule(data, curr_value=None):
     schedule.enabled = True if _schedule.get('schedule_enabled') == 'True' else False
 
     # Save schedule
-    await server.Server.scheduler.save_schedule(schedule, _schedule['enabled_changed'])
+    await server.Server.scheduler.save_schedule(schedule, _schedule['is_enabled_modified'])
 
     updated_schedule_id = schedule.schedule_id
 

--- a/python/foglamp/services/core/api/scheduler.py
+++ b/python/foglamp/services/core/api/scheduler.py
@@ -140,6 +140,8 @@ def _extract_args(data, curr_value):
         _schedule['schedule_enabled'] = data.get('enabled') if 'enabled' in data else curr_value[
             'schedule_enabled'] if curr_value else 'True'
         _schedule['schedule_enabled'] = 'True' if _schedule['schedule_enabled'] else 'False'
+
+        _schedule['enabled_changed'] = data.get('enabled') if 'enabled' in data else None
     except ValueError as ex:
         raise web.HTTPBadRequest(reason=str(ex))
 
@@ -259,7 +261,7 @@ async def _execute_add_update_schedule(data, curr_value=None):
     schedule.enabled = True if _schedule.get('schedule_enabled') == 'True' else False
 
     # Save schedule
-    await server.Server.scheduler.save_schedule(schedule)
+    await server.Server.scheduler.save_schedule(schedule, _schedule['enabled_changed'])
 
     updated_schedule_id = schedule.schedule_id
 

--- a/python/foglamp/services/core/api/scheduler.py
+++ b/python/foglamp/services/core/api/scheduler.py
@@ -135,13 +135,20 @@ def _extract_args(data, curr_value):
 
         _schedule['schedule_exclusive'] = data.get('exclusive') if 'exclusive' in data else curr_value[
             'schedule_exclusive'] if curr_value else 'True'
-        _schedule['schedule_exclusive'] = 'True' if _schedule['schedule_exclusive'] else 'False'
+        _schedule['schedule_exclusive'] = 'True' if (
+            (type(_schedule['schedule_exclusive']) is str and _schedule['schedule_exclusive'].lower() in ['t', 'true']) or (
+            (type(_schedule['schedule_exclusive']) is bool and _schedule['schedule_exclusive'] is True))) else 'False'
 
         _schedule['schedule_enabled'] = data.get('enabled') if 'enabled' in data else curr_value[
             'schedule_enabled'] if curr_value else 'True'
-        _schedule['schedule_enabled'] = 'True' if _schedule['schedule_enabled'] else 'False'
+        _schedule['schedule_enabled'] = 'True' if (
+            (type(_schedule['schedule_enabled']) is str and _schedule['schedule_enabled'].lower() in ['t', 'true']) or (
+            (type(_schedule['schedule_enabled']) is bool and _schedule['schedule_enabled'] is True))) else 'False'
 
-        _schedule['is_enabled_modified'] = data.get('enabled') if 'enabled' in data else None
+        _schedule['is_enabled_modified'] = None
+        if 'enabled' in data:
+            _schedule['is_enabled_modified'] = True if _schedule['schedule_enabled'] == 'True' else False
+
     except ValueError as ex:
         raise web.HTTPBadRequest(reason=str(ex))
 

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -90,9 +90,11 @@ async def add_service(request):
         if not service_type in ['south', 'north']:
             raise web.HTTPBadRequest(reason='Only north and south types are supported.')
         if enabled is not None:
-            if enabled not in ['t', 'f', 'true', 'false']:
+            if enabled not in ['t', 'f', 'true', 'false', 0, 1]:
                 raise web.HTTPBadRequest(reason='Only "t", "f", "true", "false" are allowed for value of enabled.')
-        is_enabled = True if enabled.lower() in ['t', 'true'] else False
+        is_enabled = True if ((type(enabled) is str and enabled.lower() in ['t', 'true']) or (
+            (type(enabled) is bool and enabled is True))) else False
+
 
         storage = connect.get_storage()
 

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -92,7 +92,7 @@ async def add_service(request):
         if enabled is not None:
             if enabled not in ['t', 'f', 'true', 'false']:
                 raise web.HTTPBadRequest(reason='Only "t", "f", "true", "false" are allowed for value of enabled.')
-        enabled_changed = True if enabled.lower() in ['t', 'true'] else False
+        is_enabled = True if enabled.lower() in ['t', 'true'] else False
 
         storage = connect.get_storage()
 
@@ -142,7 +142,7 @@ async def add_service(request):
         schedule.exclusive = True
         schedule.enabled = False
         # Save schedule
-        await server.Server.scheduler.save_schedule(schedule, )
+        await server.Server.scheduler.save_schedule(schedule, is_enabled)
         schedule = await server.Server.scheduler.get_schedule_by_name(name)
         return web.json_response({'name': name, 'id': str(schedule.schedule_id)})
 

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -79,6 +79,8 @@ async def add_service(request):
         name = data.get('name', None)
         plugin = data.get('plugin', None)
         service_type = data.get('type', None)
+        enabled = data.get('enabled', None)
+
         if name is None:
             raise web.HTTPBadRequest(reason='Missing name property in payload.')
         if plugin is None:
@@ -87,6 +89,10 @@ async def add_service(request):
             raise web.HTTPBadRequest(reason='Missing type property in payload.')
         if not service_type in ['south', 'north']:
             raise web.HTTPBadRequest(reason='Only north and south types are supported.')
+        if enabled is not None:
+            if enabled not in ['t', 'f', 'true', 'false']:
+                raise web.HTTPBadRequest(reason='Only "t", "f", "true", "false" are allowed for value of enabled.')
+        enabled_changed = True if enabled.lower() in ['t', 'true'] else False
 
         storage = connect.get_storage()
 
@@ -136,7 +142,7 @@ async def add_service(request):
         schedule.exclusive = True
         schedule.enabled = False
         # Save schedule
-        await server.Server.scheduler.save_schedule(schedule)
+        await server.Server.scheduler.save_schedule(schedule, )
         schedule = await server.Server.scheduler.get_schedule_by_name(name)
         return web.json_response({'name': name, 'id': str(schedule.schedule_id)})
 

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -125,7 +125,7 @@ async def add_service(request):
         category_desc = '{} service configuration'.format(name)
         config_mgr = ConfigurationManager(storage)
         await config_mgr.create_category(category_name=name, category_description=category_desc,
-                                     category_value=new_category, keep_original_items=False)
+                                     category_value=new_category, keep_original_items=True)
 
         # Check that the process is not already registered
         payload = PayloadBuilder().SELECT("schedule_name").WHERE(['schedule_name', '=', name]).payload()

--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -1078,6 +1078,11 @@ class Scheduler(object):
         if schedule.repeat is not None and schedule.repeat != datetime.timedelta(0):
             repeat_seconds = schedule.repeat.total_seconds()
 
+        if not is_new_schedule:
+            previous_enabled = self._schedules[schedule.schedule_id].enabled
+        else:
+            previous_enabled = None
+
         schedule_row = self._ScheduleRow(
             id=schedule.schedule_id,
             name=schedule.name,
@@ -1116,23 +1121,19 @@ class Scheduler(object):
             self._schedule_first_task(schedule_row, now)
             self._resume_check_schedules()
 
-        """
-            FOGL-1389 - Enable/Disable schedule vide {"enabled": True/False} updation.
-
-            During update, if a schedule's enabled attribute is not changed then both enable_schedule() and
-            disable_schedule() will return unconditionally without doing any action otherwise suitable action will be
-            invoked. This implies that if we want to properly change any attribute of a running schedule, it must
-            first be disable, attribtue value changed and then it should be restarted. Othrwise schedule will continue
-            to run with unpredictable behaviour.
-
-            For a new schedule, if enabled is set to True, the schedule will be enabled otherwise disable_schedule()
-            will be called and which will return unconditionally without any action.
-        """
         if is_enabled_modified is not None:
+            if previous_enabled is None:  # New Schedule
+                # For a new schedule, if enabled is set to True, the schedule will be enabled.
+                bypass_check = True if schedule.enabled is True else None
+            else:  # Existing Schedule
+                # During update, if a schedule's enabled attribute is not changed then it will return unconditionally
+                # otherwise suitable action will be invoked.
+                bypass_check = True if previous_enabled != schedule.enabled else None
+
             if is_enabled_modified is True:
-                await self.enable_schedule(schedule.schedule_id)
+                await self.enable_schedule(schedule.schedule_id, bypass_check=bypass_check)
             else:
-                await self.disable_schedule(schedule.schedule_id)
+                await self.disable_schedule(schedule.schedule_id, bypass_check=bypass_check)
 
     async def remove_service_from_task_processes(self, service_name):
         """
@@ -1176,7 +1177,7 @@ class Scheduler(object):
         self._logger.exception("Service {} records could not be removed with task id {} type {}".format(service_name, str(task_id), schedule_type))
         return False
 
-    async def disable_schedule(self, schedule_id: uuid.UUID):
+    async def disable_schedule(self, schedule_id: uuid.UUID, bypass_check=None):
         """
         Find running Schedule, Terminate running process, Disable Schedule, Update database
 
@@ -1194,7 +1195,7 @@ class Scheduler(object):
             self._logger.exception("No such Schedule %s", str(schedule_id))
             return False, "No such Schedule"
 
-        if schedule.enabled is False:
+        if bypass_check is None and schedule.enabled is False:
             self._logger.info("Schedule %s already disabled", str(schedule_id))
             return True, "Schedule {} already disabled".format(str(schedule_id))
 
@@ -1277,7 +1278,7 @@ class Scheduler(object):
         await audit.information('SCHCH', {'schedule': sch.toDict()})
         return True, "Schedule successfully disabled"
 
-    async def enable_schedule(self, schedule_id: uuid.UUID):
+    async def enable_schedule(self, schedule_id: uuid.UUID, bypass_check=None):
         """
         Get Schedule, Enable Schedule, Update database, Start Schedule
 
@@ -1293,7 +1294,7 @@ class Scheduler(object):
             self._logger.exception("No such Schedule %s", str(schedule_id))
             return False, "No such Schedule"
 
-        if schedule.enabled is True:
+        if bypass_check is None and schedule.enabled is True:
             self._logger.info("Schedule %s already enabled", str(schedule_id))
             return True, "Schedule is already enabled"
 

--- a/python/foglamp/services/core/scheduler/scheduler.py
+++ b/python/foglamp/services/core/scheduler/scheduler.py
@@ -980,7 +980,7 @@ class Scheduler(object):
 
         return self._schedule_row_to_schedule(found_id, schedule_row)
 
-    async def save_schedule(self, schedule: Schedule, enabled_changed=None):
+    async def save_schedule(self, schedule: Schedule, is_enabled_modified=None):
         """Creates or update a schedule
 
         Args:
@@ -1128,8 +1128,8 @@ class Scheduler(object):
             For a new schedule, if enabled is set to True, the schedule will be enabled otherwise disable_schedule()
             will be called and which will return unconditionally without any action.
         """
-        if enabled_changed is not None:
-            if enabled_changed is True:
+        if is_enabled_modified is not None:
+            if is_enabled_modified is True:
                 await self.enable_schedule(schedule.schedule_id)
             else:
                 await self.disable_schedule(schedule.schedule_id)

--- a/python/foglamp/services/south/server.py
+++ b/python/foglamp/services/south/server.py
@@ -115,7 +115,7 @@ class Server(FoglampMicroservice):
                 "key": category,
                 "description": '{} Device'.format(self._name),
                 "value": default_config,
-                "keep_original_items": False
+                "keep_original_items": True
             })
             self._core_microservice_management_client.create_configuration_category(config_payload)
             config = self._core_microservice_management_client.get_configuration_category(category_name=category)


### PR DESCRIPTION
This PR adds below features:
-  We can now create a new schedule with "enabled" field set to "t" (or "f") and appropriate action (enable schedule in case of "t") will be initiated.
- Similarly, now any schedule can be enabled/disabled vide PUT verb with {"enabled": "t"/"f"} payload.
- Now we can create a configuration key for a service prior to its induction in the foglamp server and it will be added to the service whenever the service is added vide add_service() call. Please refer to below example.

we can create a configuration key "simplesima" even if no simplesima service is added to foglamp.

`curl -d '{"key": "simplesima", "description": "simple simulator A", "value": {"info": {"description": "Test", "type": "boolean", "default": "true"}}}' -X POST http://localhost:8081/foglamp/category`

we can find the key vide:
```
curl -X GET http://localhost:8081/foglamp/category | jq

{
  "categories": [
    ...
    ...
    {
      "description": "simple simulator A",
      "key": "simplesima"
    }
  ]
}
```
and if we examine the simplesima key value in the DB configuration table , we will find it to be:
```
{
	"info": {
		"description": "Test",
		"type": "boolean",
		"value": "true",
		"default": "true"
	}
}
```
Now we add the service simplesima vide:
`curl -X POST http://localhost:8081/foglamp/service -d '{"name": "simplesima", "type": "south", "plugin": "simplesima", "enabled": "t"}'
`

and curl -X GET http://localhost:8081/foglamp/category | jq gives
```
{
  "categories": [
   ...
   ...
    {
      "description": "simplesima service configuration",
      "key": "simplesima"
    }
  ]
}

```

and if we examine the simplesima key value in the DB configuration table , we will find it to be:
```
{
  "plugin": {
    "value": "simplesima",
    "default": "simplesima",
    "description": "Simple Simulator async plugin",
    "type": "string"
  },
  "info": {
    "value": "true",
    "default": "true",
    "description": "Test",
    "type": "boolean"
  },
  "management_host": {
    "value": "127.0.0.1",
    "default": "127.0.0.1",
    "description": "Management host",
    "type": "string"
  }
}
```
