### PR TITLE
FOGL-1411: Reinstall aiohttp dependency in test

### DIFF
--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -11,5 +11,5 @@ aiopg==0.13.0
 SQLAlchemy==1.1.10
 asyncpg==0.12.0
 
-# Duplicate requirement
+# Downgrade aiohttp to 2.3.8 (dependency of pytest-aiohttp) due to issue with aiohttp 3.3.1
 aiohttp==2.3.8

--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -10,3 +10,6 @@ pytest-aiohttp==0.3.0
 aiopg==0.13.0
 SQLAlchemy==1.1.10
 asyncpg==0.12.0
+
+# Duplicate requirement
+aiohttp==2.3.8


### PR DESCRIPTION
This pull will reinstall the aiohttp dependency (2.3.8) after test-dependencies are installed.

This is required since pytest-aiohttp installs the latest version of aiohttp 3.3.1 which causes the issue:
```
E   RuntimeError: Added route will never be executed, method OPTIONS is already registered
```
while running any api test