### PR TITLE
FOGL-1405d - Refactor ingest.py and south/server.py to improve end to end ingress and egress performance

### DIFF
--- a/python/foglamp/services/south/ingest.py
+++ b/python/foglamp/services/south/ingest.py
@@ -94,13 +94,13 @@ class Ingest(object):
     _write_statistics_frequency_seconds = 5
     """The number of seconds to wait before writing readings-related statistics to storage"""
 
-    _readings_buffer_size = 40960
+    _readings_buffer_size = 4096
     """Maximum number of readings to buffer in memory(_max_concurrent_readings_inserts x _readings_insert_batch_size)"""
 
     _max_concurrent_readings_inserts = 4
     """Maximum number of concurrent processes that send batches of readings to storage. Preferably in multiples of 2."""
 
-    _readings_insert_batch_size = 10240
+    _readings_insert_batch_size = 1024
     """Maximum number of readings in a batch of inserts. Preferably in multiples of 2."""
 
     _readings_insert_batch_timeout_seconds = 1

--- a/python/foglamp/services/south/ingest.py
+++ b/python/foglamp/services/south/ingest.py
@@ -14,7 +14,6 @@ from typing import List, Union
 import json
 from foglamp.common import logger
 from foglamp.common import statistics
-from foglamp.common.storage_client.storage_client import ReadingsStorageClientAsync, StorageClientAsync
 from foglamp.common.storage_client.exceptions import StorageServerError
 
 __author__ = "Terris Linenbach, Amarendra K Sinha"
@@ -38,8 +37,6 @@ class Ingest(object):
 
     # Class attributes
 
-    _core_management_host = ""
-    _core_management_port = 0
     _parent_service = None
 
     readings_storage_async = None  # type: Readings
@@ -97,13 +94,13 @@ class Ingest(object):
     _write_statistics_frequency_seconds = 5
     """The number of seconds to wait before writing readings-related statistics to storage"""
 
-    _readings_buffer_size = 4096
+    _readings_buffer_size = 40960
     """Maximum number of readings to buffer in memory(_max_concurrent_readings_inserts x _readings_insert_batch_size)"""
 
     _max_concurrent_readings_inserts = 4
     """Maximum number of concurrent processes that send batches of readings to storage. Preferably in multiples of 2."""
 
-    _readings_insert_batch_size = 1024
+    _readings_insert_batch_size = 10240
     """Maximum number of readings in a batch of inserts. Preferably in multiples of 2."""
 
     _readings_insert_batch_timeout_seconds = 1
@@ -195,17 +192,15 @@ class Ingest(object):
             config['max_readings_insert_batch_reconnect_wait_seconds']['value'])
 
     @classmethod
-    async def start(cls, core_mgt_host, core_mgt_port, parent):
+    async def start(cls, parent):
         """Starts the server"""
         if cls._started:
             return
 
-        cls._core_management_host = core_mgt_host
-        cls._core_management_port = core_mgt_port
         cls._parent_service = parent
 
-        cls.readings_storage_async = ReadingsStorageClientAsync(cls._core_management_host, cls._core_management_port)
-        cls.storage_async = StorageClientAsync(cls._core_management_host, cls._core_management_port)
+        cls.readings_storage_async = cls._parent_service._readings_storage_async
+        cls.storage_async = cls._parent_service._storage_async
 
         await cls._read_config()
 
@@ -227,7 +222,6 @@ class Ingest(object):
 
         cls._last_insert_time = 0
 
-        cls._insert_readings_tasks = []
         cls._insert_readings_wait_tasks = []
         cls._readings_list_batch_size_reached = []
         cls._readings_list_not_empty = []
@@ -236,10 +230,10 @@ class Ingest(object):
         for _ in range(cls._max_concurrent_readings_inserts):
             cls._readings_lists.append([])
             cls._insert_readings_wait_tasks.append(None)
-            cls._insert_readings_tasks.append(asyncio.ensure_future(cls._insert_readings(_)))
             cls._readings_list_batch_size_reached.append(asyncio.Event())
             cls._readings_list_not_empty.append(asyncio.Event())
 
+        cls._insert_readings_task = asyncio.ensure_future(cls._insert_readings())
         cls._readings_lists_not_full = asyncio.Event()
 
         cls._stop = False
@@ -259,12 +253,11 @@ class Ingest(object):
         for task in cls._insert_readings_wait_tasks:
             if task is not None:
                 task.cancel()
-
-        for task in cls._insert_readings_tasks:
-            try:
-                await task
-            except Exception:
-                _LOGGER.exception('An exception was raised by Ingest._insert_readings')
+        try:
+            await cls._insert_readings_task
+            cls._insert_readings_task = None
+        except Exception:
+            _LOGGER.exception('An exception was raised by Ingest._insert_readings')
 
         cls._insert_readings_wait_tasks = None
         cls._insert_readings_tasks = None
@@ -292,19 +285,27 @@ class Ingest(object):
         cls._discarded_readings_stats += 1
 
     @classmethod
-    async def _insert_readings(cls, list_index):
+    async def _insert_readings(cls):
         """Inserts rows into the readings table
 
         Use ReadingsStorageClientAsync().append(json_payload_of_readings)
         """
         _LOGGER.info('Insert readings loop started')
 
-        readings_list = cls._readings_lists[list_index]
-        min_readings_reached = cls._readings_list_batch_size_reached[list_index]
-        list_not_empty = cls._readings_list_not_empty[list_index]
-        lists_not_full = cls._readings_lists_not_full
+        list_index = 0
 
-        while True:
+        while list_index <= cls._max_concurrent_readings_inserts-1:
+            list_index += 1
+            if list_index > cls._max_concurrent_readings_inserts-1:
+                list_index = 0
+
+            # _LOGGER.debug('Insert readings for list_index: %s', list_index)
+
+            readings_list = cls._readings_lists[list_index]
+            min_readings_reached = cls._readings_list_batch_size_reached[list_index]
+            list_not_empty = cls._readings_list_not_empty[list_index]
+            lists_not_full = cls._readings_lists_not_full
+
             # Wait for enough items in the list to fill a batch
             # for some minimum amount of time
             while not cls._stop:
@@ -489,7 +490,7 @@ class Ingest(object):
                     cls._current_readings_list_index = list_index
                     return True
 
-        _LOGGER.warning('The ingest service is unavailable')
+        _LOGGER.warning('The ingest service is unavailable %s', list_index)
         return False
 
     @classmethod
@@ -584,8 +585,7 @@ class Ingest(object):
 
         list_size = len(readings_list)
 
-        # _LOGGER.debug('Add readings list index: %s size: %s', cls._current_readings_list_index,
-        #               list_size)
+        # _LOGGER.debug('Add readings list index: %s size: %s', cls._current_readings_list_index, list_size)
 
         if list_size == 1:
             cls._readings_list_not_empty[list_index].set()

--- a/python/foglamp/services/south/server.py
+++ b/python/foglamp/services/south/server.py
@@ -135,7 +135,7 @@ class Server(FoglampMicroservice):
 
             self._plugin_handle = self._plugin.plugin_init(config)
 
-            await Ingest.start(self._core_management_host, self._core_management_port, self)
+            await Ingest.start(self)
 
             # Executes the requested plugin type
             if self._plugin_info['mode'] == 'async':


### PR DESCRIPTION
Tests are failing as we need to modify tests to use async storage ([FOGL-1383](https://scaledb.atlassian.net/browse/FOGL-1383)).
`======================================= 39 failed, 1182 passed, 35 skipped, 12 warnings in 97.52 seconds ========================================
`