### PR TITLE
Tests fixed which failed due to 1405d

### DIFF
--- a/tests/unit/python/foglamp/services/south/test_ingest.py
+++ b/tests/unit/python/foglamp/services/south/test_ingest.py
@@ -12,6 +12,7 @@ import pytest
 from unittest.mock import MagicMock
 from foglamp.services.south.ingest import *
 from foglamp.services.south import ingest
+from foglamp.common.storage_client.storage_client import StorageClientAsync, ReadingsStorageClientAsync
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient
 
 
@@ -156,7 +157,7 @@ class TestIngest:
         mocker.patch.object(Ingest, "_insert_readings", return_value=mock_coro())
 
         # WHEN
-        await Ingest.start(core_mgt_host=None, core_mgt_port=None, parent=parent_service)
+        await Ingest.start(parent=parent_service)
 
         # THEN
         assert 1 == create_cfg.call_count
@@ -166,7 +167,6 @@ class TestIngest:
         assert Ingest._readings_list_size == int(Ingest._readings_buffer_size / (
             Ingest._max_concurrent_readings_inserts))
         assert Ingest._last_insert_time is 0
-        assert Ingest._max_concurrent_readings_inserts == len(Ingest._insert_readings_tasks)
         assert Ingest._max_concurrent_readings_inserts == len(Ingest._insert_readings_wait_tasks)
         assert Ingest._max_concurrent_readings_inserts == len(Ingest._readings_list_batch_size_reached)
         assert Ingest._max_concurrent_readings_inserts == len(Ingest._readings_list_not_empty)
@@ -187,7 +187,7 @@ class TestIngest:
         mocker.patch.object(Ingest, "_insert_readings", return_value=mock_coro())
 
         # WHEN
-        await Ingest.start(core_mgt_host=None, core_mgt_port=None, parent=parent_service)
+        await Ingest.start(parent=parent_service)
         await asyncio.sleep(1)
         await Ingest.stop()
 
@@ -286,7 +286,7 @@ class TestIngest:
         # THEN
         assert retval is False
         assert 1 == log_warning.call_count
-        log_warning.assert_called_with('The ingest service is unavailable')
+        log_warning.assert_called_with('The ingest service is unavailable %s', 0)
 
     @pytest.mark.asyncio
     async def test_add_readings_all_ok(self, mocker):

--- a/tests/unit/python/foglamp/services/south/test_services_south_server.py
+++ b/tests/unit/python/foglamp/services/south/test_services_south_server.py
@@ -141,8 +141,7 @@ class TestServicesSouthServer:
 
         # THEN
         assert 1 == ingest_start.call_count
-        ingest_start_params = None, None, south_server
-        ingest_start.assert_called_with(*ingest_start_params)
+        ingest_start.assert_called_with(south_server)
         assert 1 == log_info.call_count
         assert 0 == log_exception.call_count
         assert south_server._task_main.done() is True
@@ -228,8 +227,7 @@ class TestServicesSouthServer:
 
         # THEN
         assert 1 == ingest_start.call_count
-        ingest_start_params = None, None, south_server
-        ingest_start.assert_called_with(*ingest_start_params)
+        ingest_start.assert_called_with(south_server)
         assert 1 == log_info.call_count
         assert 1 == log_exception.call_count
         assert south_server._task_main.done() is False  # because of exception occurred


### PR DESCRIPTION
Test result:
```
tests/unit/python/foglamp/plugins/north/ocs/test_ocs.py ......FF..FFF                                                                     [ 30%]
tests/unit/python/foglamp/plugins/north/omf/test_omf.py .....F..FFFFFFFFFFFFFFFF.........F......                                          [ 33%]
======================================= 23 failed, 1201 passed, 33 skipped, 11 warnings in 97.72 seconds ========================================
```
