### PR TITLE
FOGL-1450 - fixed a warnings highlighted by the OMF unit tests

### DIFF
--- a/C/plugins/storage/sqlitememory/CMakeLists.txt
+++ b/C/plugins/storage/sqlitememory/CMakeLists.txt
@@ -27,6 +27,3 @@ target_link_libraries(${PROJECT_NAME} -lsqlite3)
 
 # Install library
 install(TARGETS ${PROJECT_NAME} DESTINATION foglamp/plugins/storage/${PROJECT_NAME})
-
-# Install init.sql
-install(FILES ${CMAKE_SOURCE_DIR}/scripts/plugins/storage/${PROJECT_NAME}/init.sql DESTINATION foglamp/plugins/storage/${PROJECT_NAME})

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-#.PHONY: generate_selfcertificate
-
 ###############################################################################
 ################################### COMMANDS ##################################
 ###############################################################################
@@ -153,6 +151,7 @@ schema_check : apply_version
 # Destination may be overridden by use of the DESTDIR=<location> directive
 # This first does a make to build anything needed for the installation.
 install : $(INSTALL_DIR) \
+    generate_selfcertificate \
 	schema_check \
 	foglamp_version_file_install \
 	c_install \

--- a/python/foglamp/plugins/north/ocs/ocs.py
+++ b/python/foglamp/plugins/north/ocs/ocs.py
@@ -419,7 +419,7 @@ async def plugin_send(data, raw_data, stream_id):
             except Exception as ex:
                 # Forces the recreation of PIServer's objects on the first error occurred
                 if _recreate_omf_objects:
-                    ocs_north.deleted_omf_types_already_created(config_category_name, type_id)
+                    await ocs_north.deleted_omf_types_already_created(config_category_name, type_id)
                     _recreate_omf_objects = False
                     _logger.debug("{0} - Forces objects recreation ".format("plugin_send"))
                 raise ex


### PR DESCRIPTION
FOGL-1450 - fixed a warnings highlighted by the OMF unit tests, the problem was in the code itself not in the unit test.

```
test_ocs.py::TestOCS::test_plugin_shutdown PASSED                        [ 75%]
test_ocs.py::TestOCS::test_plugin_reconfigure PASSED                     [ 83%]
test_ocs.py::TestOCSNorthPlugin::test_create_omf_type_automatic[p_test_data0-0001-p_static_data0-pressure_typename-expected_omf_type0] PASSED [ 91%]
test_ocs.py::TestOCSNorthPlugin::test_create_omf_type_automatic[p_test_data1-0002-p_static_data1-luxometer_typename-expected_omf_type1] PASSED [100%]

========================== 12 passed in 0.13 seconds ===========================
Process finished with exit code 0
```

```
  File "/home/foglamp/.local/lib/python3.5/site-packages/aiohttp/web_response.py", line 89, in set_status
    self._status = int(status)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
================================== 23 failed, 1197 passed, 35 skipped in 99.17 seconds ===================================

real    1m40.108s
user    0m33.840s
sys     0m1.248s
foglamp@ubuntu:~/Development/FogLAMP/tests/unit/python/foglamp$


```