### PR TITLE
FOGL-1440 - Update Configuration Manager and its tests to use async storage client - A

### DIFF
--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -41,7 +41,7 @@ async def get_categories(request):
             curl -X GET http://localhost:8081/foglamp/category
     """
     # TODO: make it optimized and elegant
-    cf_mgr = ConfigurationManager(connect.get_storage())
+    cf_mgr = ConfigurationManager(connect.get_storage_async())
     categories = await cf_mgr.get_all_category_names()
     categories_json = [{"key": c[0], "description": c[1]} for c in categories]
 
@@ -62,7 +62,7 @@ async def get_category(request):
     category_name = request.match_info.get('category_name', None)
 
     # TODO: make it optimized and elegant
-    cf_mgr = ConfigurationManager(connect.get_storage())
+    cf_mgr = ConfigurationManager(connect.get_storage_async())
     category = await cf_mgr.get_category_all_items(category_name)
 
     if category is None:
@@ -83,7 +83,7 @@ async def create_category(request):
             curl -d '{"key": "TEST", "description": "description", "value": {"info": {"description": "Test", "type": "boolean", "default": "true"}}}' -X POST http://localhost:8081/foglamp/category
     """
     try:
-        cf_mgr = ConfigurationManager(connect.get_storage())
+        cf_mgr = ConfigurationManager(connect.get_storage_async())
         data = await request.json()
         if not isinstance(data, dict):
             raise ValueError('Data payload must be a dictionary')
@@ -135,7 +135,7 @@ async def get_category_item(request):
     config_item = request.match_info.get('config_item', None)
 
     # TODO: make it optimized and elegant
-    cf_mgr = ConfigurationManager(connect.get_storage())
+    cf_mgr = ConfigurationManager(connect.get_storage_async())
     category_item = await cf_mgr.get_category_item(category_name, config_item)
 
     if category_item is None:
@@ -164,7 +164,7 @@ async def set_configuration_item(request):
 
     data = await request.json()
     # TODO: make it optimized and elegant
-    cf_mgr = ConfigurationManager(connect.get_storage())
+    cf_mgr = ConfigurationManager(connect.get_storage_async())
 
     try:
         value = data['value']
@@ -200,7 +200,7 @@ async def add_configuration_item(request):
     new_config_item = request.match_info.get('config_item', None)
 
     try:
-        storage_client = connect.get_storage()
+        storage_client = connect.get_storage_async()
         cf_mgr = ConfigurationManager(storage_client)
 
         data = await request.json()
@@ -270,7 +270,7 @@ async def delete_configuration_item_value(request):
     config_item = request.match_info.get('config_item', None)
 
     # TODO: make it optimized and elegant
-    cf_mgr = ConfigurationManager(connect.get_storage())
+    cf_mgr = ConfigurationManager(connect.get_storage_async())
     try:
         category_item = await cf_mgr.get_category_item(category_name, config_item)
         if category_item is None:

--- a/python/foglamp/services/core/connect.py
+++ b/python/foglamp/services/core/connect.py
@@ -6,8 +6,8 @@
 
 
 from foglamp.services.core.service_registry.service_registry import ServiceRegistry
-from foglamp.common.storage_client.storage_client import StorageClient
-from foglamp.common.storage_client.storage_client import ReadingsStorageClient
+from foglamp.common.storage_client.storage_client import StorageClient, StorageClientAsync
+from foglamp.common.storage_client.storage_client import ReadingsStorageClient, ReadingsStorageClientAsync
 from foglamp.common import logger
 
 __author__ = "Ashish Jabble"
@@ -34,6 +34,19 @@ def get_storage():
         raise
     return _storage
 
+def get_storage_async():
+    """ Storage Object """
+    try:
+        services = ServiceRegistry.get(name="FogLAMP Storage")
+        storage_svc = services[0]
+        _storage = StorageClientAsync(core_management_host=None, core_management_port=None,
+                                 svc=storage_svc)
+        # _logger.info(type(_storage))
+    except Exception as ex:
+        _logger.exception(str(ex))
+        raise
+    return _storage
+
 # TODO: Needs refactoring or better way to allow global discovery in core process
 def get_readings():
     """ Storage Object """
@@ -41,6 +54,19 @@ def get_readings():
         services = ServiceRegistry.get(name="FogLAMP Storage")
         storage_svc = services[0]
         _readings = ReadingsStorageClient(core_mgt_host=None, core_mgt_port=None,
+                                 svc=storage_svc)
+        # _logger.info(type(_storage))
+    except Exception as ex:
+        _logger.exception(str(ex))
+        raise
+    return _readings
+
+def get_readings():
+    """ Storage Object """
+    try:
+        services = ServiceRegistry.get(name="FogLAMP Storage")
+        storage_svc = services[0]
+        _readings = ReadingsStorageClientAsync(core_mgt_host=None, core_mgt_port=None,
                                  svc=storage_svc)
         # _logger.info(type(_storage))
     except Exception as ex:

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -12,7 +12,7 @@ import pytest
 
 from foglamp.services.core import routes
 from foglamp.services.core import connect
-from foglamp.common.storage_client.storage_client import StorageClient
+from foglamp.common.storage_client.storage_client import StorageClientAsync
 from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.common.audit_logger import AuditLogger
 
@@ -39,9 +39,9 @@ class TestConfiguration:
 
         result = {'categories': [{'key': 'rest_api', 'description': 'User REST API'},
                                  {'key': 'service', 'description': 'Service configuration'}]}
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_all_category_names', return_value=async_mock()) as patch_get_all_items:
                 resp = await client.get('/foglamp/category')
                 assert 200 == resp.status
@@ -54,9 +54,9 @@ class TestConfiguration:
         async def async_mock():
             return None
 
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock()) as patch_get_all_items:
                 resp = await client.get('/foglamp/category/{}'.format(category_name))
                 assert 404 == resp.status
@@ -72,9 +72,9 @@ class TestConfiguration:
         async def async_mock():
             return result
 
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock()) as patch_get_all_items:
                 resp = await client.get('/foglamp/category/{}'.format(category_name))
                 assert 200 == resp.status
@@ -87,9 +87,9 @@ class TestConfiguration:
         async def async_mock():
             return None
 
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=async_mock()) as patch_get_cat_item:
                 resp = await client.get('/foglamp/category/{}/{}'.format(category_name, item_name))
                 assert 404 == resp.status
@@ -103,9 +103,9 @@ class TestConfiguration:
         async def async_mock():
             return result
 
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=async_mock()) as patch_get_cat_item:
                 resp = await client.get('/foglamp/category/{}/{}'.format(category_name, item_name))
                 assert 200 == resp.status
@@ -125,9 +125,9 @@ class TestConfiguration:
         async def async_mock():
             return result
 
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'set_category_item_value_entry', return_value=async_mock_set_item()) as patch_set_entry:
                 with patch.object(c_mgr, 'get_category_item', return_value=async_mock()) as patch_get_cat_item:
                     resp = await client.put('/foglamp/category/{}/{}'.format(category_name, item_name),
@@ -141,8 +141,8 @@ class TestConfiguration:
 
     async def test_set_config_item_bad_request(self, client, category_name='rest_api', item_name='http_port'):
         payload = {"valu": '8082'}
-        storage_client_mock = MagicMock(StorageClient)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        storage_client_mock = MagicMock(StorageClientAsync)
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             resp = await client.put('/foglamp/category/{}/{}'.format(category_name, item_name),
                                     data=json.dumps(payload))
             assert 400 == resp.status
@@ -153,9 +153,9 @@ class TestConfiguration:
             return None
 
         payload = {"value": '8082'}
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'set_category_item_value_entry', return_value=async_mock()) as patch_set_entry:
                 with patch.object(c_mgr, 'get_category_item', return_value=async_mock()) as patch_get_cat_item:
                     resp = await client.put('/foglamp/category/{}/{}'.format(category_name, item_name),
@@ -167,9 +167,9 @@ class TestConfiguration:
 
     async def test_set_config_item_exception(self, client, category_name='rest_api', item_name='http_port'):
         payload = {"value": '8082'}
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'set_category_item_value_entry', side_effect=ValueError) as patch_set_entry:
                 resp = await client.put('/foglamp/category/{}/{}'.format(category_name, item_name), data=json.dumps(payload))
                 assert 404 == resp.status
@@ -186,9 +186,9 @@ class TestConfiguration:
         async def async_mock():
             return result
 
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', side_effect=[async_mock(), async_mock()]) as patch_get_cat_item:
                 with patch.object(c_mgr, 'set_category_item_value_entry', return_value=async_mock_set_item()) as patch_set_entry:
                     resp = await client.delete('/foglamp/category/{}/{}/value'.format(category_name, item_name))
@@ -206,9 +206,9 @@ class TestConfiguration:
         async def async_mock():
             return None
 
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=async_mock()) as patch_get_cat_item:
                 resp = await client.delete('/foglamp/category/{}/{}/value'.format(category_name, item_name))
                 assert 404 == resp.status
@@ -225,9 +225,9 @@ class TestConfiguration:
         async def async_mock(return_value):
             return return_value
 
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', side_effect=[async_mock(result), async_mock(None)]) as patch_get_cat_item:
                 with patch.object(c_mgr, 'set_category_item_value_entry', return_value=async_mock(None)) as patch_set_entry:
                     resp = await client.delete('/foglamp/category/{}/{}/value'.format(category_name, item_name))
@@ -250,8 +250,8 @@ class TestConfiguration:
         ({"description": "desc", "value": "val"}, "\"'key' param required to create a category\""),
     ])
     async def test_create_category_bad_request(self, client, payload, message):
-        storage_client_mock = MagicMock(StorageClient)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        storage_client_mock = MagicMock(StorageClientAsync)
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             resp = await client.post('/foglamp/category', data=json.dumps(payload))
             assert 400 == resp.status
             assert message == resp.reason
@@ -266,9 +266,9 @@ class TestConfiguration:
         async def async_mock():
             return info
 
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'create_category', return_value=async_mock_create_cat()) as patch_create_cat:
                 with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock()) as patch_cat_all_item:
                     resp = await client.post('/foglamp/category', data=json.dumps(payload))
@@ -284,9 +284,9 @@ class TestConfiguration:
         info = {'info': {'type': 'boolean', 'value': 'False', 'description': 'Test', 'default': 'False'}}
         payload = {"key": name, "description": desc, "value": info, "keep_original_items": "bla"}
 
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             resp = await client.post('/foglamp/category', data=json.dumps(payload))
             assert 400 == resp.status
             assert "keep_original_items should be boolean true | false" == resp.reason
@@ -301,9 +301,9 @@ class TestConfiguration:
         async def async_mock():
             return None
 
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'create_category', return_value=async_mock_create_cat()) as patch_create_cat:
                 with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock()) as patch_cat_all_item:
                     resp = await client.post('/foglamp/category', data=json.dumps(payload))
@@ -316,7 +316,7 @@ class TestConfiguration:
     async def test_create_category_http_exception(self, client, name="test_cat", desc="Test desc"):
         info = {'info': {'type': 'boolean', 'value': 'False', 'description': 'Test', 'default': 'False'}}
         payload = {"key": name, "description": desc, "value": info}
-        with patch.object(connect, 'get_storage', side_effect=Exception):
+        with patch.object(connect, 'get_storage_async', side_effect=Exception):
             resp = await client.post('/foglamp/category', data=json.dumps(payload))
             assert 500 == resp.status
             assert 'Internal Server Error' == resp.reason
@@ -335,8 +335,8 @@ class TestConfiguration:
         ({"description": "1", "type": "integer"}, "entry_val must be a string for item_name info and entry_name value")
     ])
     async def test_validate_data_for_add_config_item(self, client, payload, message):
-        storage_client_mock = MagicMock(StorageClient)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        storage_client_mock = MagicMock(StorageClientAsync)
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             resp = await client.post('/foglamp/category/{}/{}'.format("cat", "info"), data=json.dumps(payload))
             assert 400 == resp.status
             assert message == resp.reason
@@ -347,9 +347,9 @@ class TestConfiguration:
 
         category_name = 'blah'
         payload = {"default": "1", "description": "Test description", "type": "integer"}
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock()) as patch_get_all_items:
                 resp = await client.post('/foglamp/category/{}/{}'.format(category_name, "info"), data=json.dumps(payload))
                 assert 404 == resp.status
@@ -362,9 +362,9 @@ class TestConfiguration:
 
         category_name = 'cat'
         payload = {"default": "1", "description": "Test description", "type": "integer"}
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock()) as patch_get_all_items:
                 resp = await client.post('/foglamp/category/{}/{}'.format(category_name, "info"), data=json.dumps(payload))
                 assert 400 == resp.status
@@ -386,9 +386,9 @@ class TestConfiguration:
         new_config_item = 'info1'
         expected = {'rows_affected': 1, "response": "updated"}
         result = {'message': '{} config item has been saved for {} category'.format(new_config_item, category_name)}
-        storage_client_mock = MagicMock(StorageClient)
+        storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        with patch.object(connect, 'get_storage', return_value=storage_client_mock):
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock()) as patch_get_all_items:
                 with patch.object(storage_client_mock, 'update_tbl', return_value=expected) as update_tbl_patch:
                     with patch.object(AuditLogger, '__init__', return_value=None):
@@ -413,7 +413,7 @@ class TestConfiguration:
 
     async def test_unknown_exception_for_add_config_item(self, client):
         data = {"default": "d", "description": "Test description", "type": "boolean"}
-        with patch.object(connect, 'get_storage', side_effect=Exception):
+        with patch.object(connect, 'get_storage_async', side_effect=Exception):
             resp = await client.post('/foglamp/category/{}/{}'.format("blah", "blah"), data=json.dumps(data))
             assert 500 == resp.status
             assert 'Internal Server Error' == resp.reason


### PR DESCRIPTION
This PR updates core configuration files, code + tests, only. Other client code such Scheduler etc will be updated separately. Currently, tests of client code are failing as under:

```
tests/unit/python/foglamp/common/test_audit_logger.py ..........                                                                          [  0%]
tests/unit/python/foglamp/common/test_configuration_manager.py ........................................................................   [  6%]
tests/unit/python/foglamp/common/test_jqfilter.py ....                                                                                    [  6%]
tests/unit/python/foglamp/common/test_logger.py .....                                                                                     [  7%]
tests/unit/python/foglamp/common/test_process.py ........                                                                                 [  7%]
tests/unit/python/foglamp/common/test_service_record.py .......                                                                           [  8%]
tests/unit/python/foglamp/common/test_statistics.py ..................                                                                    [  9%]
tests/unit/python/foglamp/common/microservice_management_client/test_microservice_management_client.py .................................. [ 12%]
.....                                                                                                                                     [ 12%]
tests/unit/python/foglamp/common/storage_client/test_payload_builder.py ................................................................. [ 18%]
.s..............                                                                                                                          [ 19%]
tests/unit/python/foglamp/common/storage_client/test_sc_exceptions.py ..........                                                          [ 20%]
tests/unit/python/foglamp/common/storage_client/test_storage_client.py ..............................                                     [ 22%]
tests/unit/python/foglamp/common/storage_client/test_utils.py ..................                                                          [ 24%]
tests/unit/python/foglamp/common/web/test_middleware.py ......                                                                            [ 24%]
tests/unit/python/foglamp/plugins/common/test_plugins_common_utils.py ....                                                                [ 24%]
tests/unit/python/foglamp/plugins/north/common/test_common.py ..................................................                          [ 28%]
tests/unit/python/foglamp/plugins/north/http_north/test_http_north.py .ss....                                                             [ 29%]
tests/unit/python/foglamp/plugins/north/ocs/test_ocs.py ............                                                                      [ 30%]
tests/unit/python/foglamp/plugins/north/omf/test_omf.py ......................................                                            [ 33%]
tests/unit/python/foglamp/plugins/south/cc2650async/test_cc2650async.py ........                                                          [ 34%]
tests/unit/python/foglamp/plugins/south/cc2650poll/test_cc2650poll.py ...........                                                         [ 34%]
tests/unit/python/foglamp/plugins/south/coap_listen/test_coap_listen.py ...........                                                       [ 35%]
tests/unit/python/foglamp/plugins/south/common/test_sensortag_cc2650.py ........................s                                         [ 37%]
tests/unit/python/foglamp/plugins/south/http_south/test_http_south.py ...............                                                     [ 38%]
tests/unit/python/foglamp/services/common/test_avahi.py ......                                                                            [ 39%]
tests/unit/python/foglamp/services/common/test_microservice.py ....                                                                       [ 39%]
tests/unit/python/foglamp/services/common/test_services_common_utils.py ....                                                              [ 40%]
tests/unit/python/foglamp/services/common/microservice_management/test_instance.py ..........                                             [ 40%]
tests/unit/python/foglamp/services/core/test_connect.py ...                                                                               [ 41%]
tests/unit/python/foglamp/services/core/test_main.py .                                                                                    [ 41%]
tests/unit/python/foglamp/services/core/test_server.py sssssssssssssssss..sssss.......FFFFFFFFF.FFF.FF......................              [ 46%]
tests/unit/python/foglamp/services/core/test_user_model.py ...........................FFFFFF.....s...........                             [ 50%]
tests/unit/python/foglamp/services/core/api/test_audit.py ..........................                                                      [ 52%]
tests/unit/python/foglamp/services/core/api/test_auth_mandatory.py ..............................................................         [ 57%]
tests/unit/python/foglamp/services/core/api/test_auth_optional.py ......................................                                  [ 60%]
tests/unit/python/foglamp/services/core/api/test_backup_restore.py ......................................                                 [ 63%]
tests/unit/python/foglamp/services/core/api/test_browser_assets.py ..........................................                             [ 67%]
tests/unit/python/foglamp/services/core/api/test_certificate_store.py ................FF                                                  [ 68%]
tests/unit/python/foglamp/services/core/api/test_common_ping.py FFFFFFFF.                                                                 [ 69%]
tests/unit/python/foglamp/services/core/api/test_configuration.py ....................................                                    [ 72%]
tests/unit/python/foglamp/services/core/api/test_scheduler_api.py ....................................................................... [ 77%]
.......                                                                                                                                   [ 78%]
tests/unit/python/foglamp/services/core/api/test_service.py .........s                                                                    [ 79%]
tests/unit/python/foglamp/services/core/api/test_statistics_api.py ...............................                                        [ 81%]
tests/unit/python/foglamp/services/core/api/test_support.py ................                                                              [ 82%]
tests/unit/python/foglamp/services/core/interest_registry/test_change_callback.py .....                                                   [ 83%]
tests/unit/python/foglamp/services/core/interest_registry/test_interest_registry.py ........                                              [ 83%]
tests/unit/python/foglamp/services/core/scheduler/test_scheduler.py ......s..............s.............s..............s......s            [ 88%]
tests/unit/python/foglamp/services/core/scheduler/test_scheduler_entities.py .........                                                    [ 89%]
tests/unit/python/foglamp/services/core/scheduler/test_scheduler_exceptions.py ......                                                     [ 89%]
tests/unit/python/foglamp/services/core/service_registry/test_exceptions.py .....                                                         [ 90%]
tests/unit/python/foglamp/services/core/service_registry/test_monitor.py .s                                                               [ 90%]
tests/unit/python/foglamp/services/core/service_registry/test_service_registry.py .........                                               [ 90%]
tests/unit/python/foglamp/services/south/test_ingest.py ....ss........                                                                    [ 92%]
tests/unit/python/foglamp/services/south/test_services_south_main.py .                                                                    [ 92%]
tests/unit/python/foglamp/services/south/test_services_south_server.py ...............                                                    [ 93%]
tests/unit/python/foglamp/tasks/north/test_sending_process.py ...........................................................                 [ 98%]
tests/unit/python/foglamp/tasks/purge/test_purge.py ................                                                                      [ 99%]
tests/unit/python/foglamp/tasks/purge/test_purge_main.py .                                                                                [ 99%]
tests/unit/python/foglamp/tasks/statistics/test_statistics_history.py ......                                                              [ 99%]
tests/unit/python/foglamp/tasks/statistics/test_statistics_main.py .                                                                      [100%]
```