### PR TITLE
FOGL-1472 south plugin references fix in doc

### DIFF
--- a/docs/02_foglamp_at_a_glance.rst
+++ b/docs/02_foglamp_at_a_glance.rst
@@ -96,8 +96,8 @@ Details of the Architecture
 - **Southbound Microservice** - A microservice that offers bi-directional communication with data and metadata exchange between the platform and Edge devices, such as sensors, actuators, PLCs or other FogLAMP installations. Smaller systems may have this service installed on board Edge devices.
 
 
-To Know More About the Archicture
----------------------------------
+To Know More About the Architecture
+-----------------------------------
 
 You can know more about the FogLAMP architecture downloading this document or by checking the content of the |Dianomic Website|.
 

--- a/docs/03_getting_started.rst
+++ b/docs/03_getting_started.rst
@@ -49,9 +49,8 @@ This version of FogLAMP requires the following software to be installed in the s
 - **Python 3.5+**
 - **PostgreSQL 9.5+**
 - **SQLite 3.11+**
-- **Bluez 5.37+**
 
-Bluez is the official Bluetooth stack and we have added plugins that are set on by default and use *gatttool* and other components of *bluez*. In the future we will make this package optional, but for the moment you should install it even if you do not intend to use any Bluetooth device. |br| If you intend to download and build FogLAMP from source (as explained in this page), you also need *git*. |br| In this version SQLite is default engine, but we have left libraries to easily switch to PostgreSQL, in case you need it. The PostgreSQL plugin will be moved to a different repository in future versions. Other requirements largely depend on the plugins that run in FogLAMP.
+If you intend to download and build FogLAMP from source (as explained in this page), you also need *git*. |br| In this version SQLite is default engine, but we have left libraries to easily switch to PostgreSQL, in case you need it. The PostgreSQL plugin will be moved to a different repository in future versions. Other requirements largely depend on the plugins that run in FogLAMP.
 
 You may also want to install some utilities to make your life easier when you use or test FogLAMP:
 
@@ -73,14 +72,14 @@ FogLAMP is currently based on C/C++ and Python code. The packages needed to buil
 - autoconf 
 - automake 
 - avahi-daemon
-- bluez
-- build-essential 
+- build-essential
 - cmake
 - g++
 - git
-- libbost-dev
-- libbost-system-dev
-- libbost-thread-dev
+- libboost-dev
+- libboost-system-dev
+- libboost-thread-dev
+- libssl-dev
 - libpq-dev
 - libsqlite3-dev
 - libtool 
@@ -109,7 +108,7 @@ FogLAMP is currently based on C/C++ and Python code. The packages needed to buil
   Building dependency tree
   ...
   $
-  $ sudo apt-get install libtool libboost-dev libboost-system-dev libboost-thread-dev libpq-dev uuid-dev
+  $ sudo apt-get install libtool libboost-dev libboost-system-dev libboost-thread-dev libssl-dev libpq-dev uuid-dev
   Reading package lists... Done
   Building dependency tree
   ...
@@ -120,12 +119,6 @@ FogLAMP is currently based on C/C++ and Python code. The packages needed to buil
   ...
   $
   $ sudo apt-get install postgresql
-  Reading package lists... Done
-  Building dependency tree
-  $
-  ...
-  $
-  $ sudo apt-get install bluez
   Reading package lists... Done
   Building dependency tree
   $
@@ -176,8 +169,8 @@ Selecting the Correct Version
 
 The git repository created on your local machine, creates several branches. More specifically:
 
-- The **master** branch is the latest, stable version. You should use this branch if you are interested in using FogLAMP with the latest features and fixes.
-- The **develop** branch is the current working branch used by our developers. The branch contains the lastest version and features, but it may be unstable and there may be issues in the code. You may consider to use this branch if you are curious to see one of the latest features we are working on, but you should not use this branch in production.
+- The **master** branch is the latest, stable version. You should use this branch if you are interested in using FogLAMP with the last release features and fixes.
+- The **develop** branch is the current working branch used by our developers. The branch contains the latest version and features, but it may be unstable and there may be issues in the code. You may consider to use this branch if you are curious to see one of the latest features we are working on, but you should not use this branch in production.
 - The branches with versions **majorID.minorID**, such as *1.0* or *1.4*, contain the code of that specific version. You may use one of these branches if you need to check the code used in those versions.
 - The branches with name **FOGL-XXXX**, where 'XXXX' is a sequence number, are working branches used by developers and contributors to add features, fix issues, modify and release code and documentation of FogLAMP. Those branches are free for you to see and learn from the work of the contributors.
  
@@ -202,7 +195,7 @@ Once you have cloned the FogLAMP project, in order to check the branches availab
   remotes/origin/master
   $
 
-Assuming you want to use the latest, stable version, use the ``git checkout`` command to select the *master* branch:
+Assuming you want to use the latest released, stable version, use the ``git checkout`` command to select the *master* branch:
 
 .. code-block:: console
 
@@ -229,9 +222,10 @@ Move to the *FogLAMP* project directory, type the ``make`` comand and let the ma
   -- The C compiler identification is GNU 5.4.0
   -- The CXX compiler identification is GNU 5.4.0
   ...
-  Successfully built aiocoap pexpect
-  Installing collected packages: aiocoap, cbor2, six, pyparsing, packaging, async-timeout, multidict, yarl, chardet, aiohttp, typing, aiohttp-cors, cchardet, certifi, idna, urllib3, requests, ptyprocess, pexpect
-  Successfully installed aiocoap aiohttp aiohttp-cors async-timeout cbor2 cchardet certifi chardet-2.3.0 idna multidict packaging pexpect ptyprocess pyparsing requests-2.9.1 six-1.10.0 typing urllib3-1.13.1 yarl
+  pip3 install -Ir python/requirements.txt --user --no-cache-dir
+  ...
+  Installing collected packages: multidict, idna, yarl, async-timeout, chardet, aiohttp, typing, aiohttp-cors, cchardet, pyjwt, six, pyjq
+  Successfully installed aiohttp-2.3.8 aiohttp-cors-0.5.3 async-timeout-3.0.0 cchardet-2.1.1 chardet-3.0.4 idna-2.6 multidict-4.3.1 pyjq-2.1.0 pyjwt-1.6.0 six-1.11.0 typing-3.6.4 yarl-1.2.6
   $
 
 
@@ -263,7 +257,7 @@ The other issue is related to the version of pip (more specifically pip3), the P
   You are using pip version 8.1.1, however version 9.0.1 is available.
   You should consider upgrading via the 'pip install --upgrade pip' command.
 
-In this case, what you need to do is to upgrade the pip software for Python 3:
+In this case, what you need to do is to upgrade the pip software for Python3:
 
 .. code-block:: console
 
@@ -288,7 +282,8 @@ If you are eager to test FogLAMP straight away, you can do so! All you need to d
   $ pwd
   /home/ubuntu/FogLAMP
   $ export FOGLAMP_ROOT=/home/ubuntu/FogLAMP
-  $ scripts/foglamp start
+  $ ./scripts/foglamp start
+  Starting FogLAMP vX.X.....
   FogLAMP started.
   $
 
@@ -297,7 +292,7 @@ You can check the status of FogLAMP with the ``foglamp status`` command. For few
 
 .. code-block:: console
 
-  $ scripts/foglamp status
+  $ ./scripts/foglamp status
   FogLAMP starting.
   $
   $ scripts/foglamp status
@@ -307,8 +302,6 @@ You can check the status of FogLAMP with the ``foglamp status`` command. For few
   FogLAMP does not require authentication.
   === FogLAMP services:
   foglamp.services.core
-  foglamp.services.south --port=40417 --address=127.0.0.1 --name=HTTP_SOUTH
-  foglamp.services.south --port=40417 --address=127.0.0.1 --name=COAP
   === FogLAMP tasks:
   foglamp.tasks.north.sending_process --stream_id 1 --debug_level 1 --port=40417 --address=127.0.0.1 --name=sending process
   foglamp.tasks.north.sending_process --stream_id 2 --debug_level 1 --port=40417 --address=127.0.0.1 --name=statistics to pi
@@ -392,6 +385,7 @@ Easy, you have learnt ``foglamp start`` and ``foglamp status``, simply type ``fo
 .. code-block:: console
 
   $ scripts/foglamp stop
+  Stopping FogLAMP.........
   FogLAMP stopped.
   $
 
@@ -491,10 +485,8 @@ Pre-Requisites
 Pre-requisites on CentOS are similar to the ones on other distributions, but the name of the packages may differ from Debian-based distros. Starting from a minimal installation, this is the list of packages you need to add:
 
 - libtool
-- bluez
-- git
 - cmake
-- bost-devel
+- boost-devel
 - libuuid-devel
 - gmp-devel
 - mpfr-devel
@@ -508,8 +500,6 @@ This is the complete list of the commands to execute and the installed packages 
 .. code-block:: console
 
   sudo yum install libtool
-  sudo yum install bluez
-  sudo yum install git
   sudo yum install cmake
   sudo yum install boost-devel
   sudo yum install libuuid-devel
@@ -524,7 +514,7 @@ This is the complete list of the commands to execute and the installed packages 
 Building and Installing C++ 5.4
 -------------------------------
 
-FogLAMP, requires C++ 5.4, CentOS 7 provides version 4.8. These are the commands to build and install the new GCC environnment:
+FogLAMP, requires C++ 5.4, CentOS 7 provides version 4.8. These are the commands to build and install the new GCC environment:
 
 .. code-block:: console
 
@@ -769,8 +759,6 @@ Check the *core.err* file, but if it is empty and *foglamp status* shows FogLAMP
   FogLAMP does not require authentication.
   === FogLAMP services:
   foglamp.services.core
-  foglamp.services.south --port=38994 --address=127.0.0.1 --name=COAP
-  foglamp.services.south --port=38994 --address=127.0.0.1 --name=HTTP_SOUTH
   === FogLAMP tasks:
   $
   $ cat data/core.err
@@ -779,11 +767,6 @@ Check the *core.err* file, but if it is empty and *foglamp status* shows FogLAMP
   ...
   foglamp   6174     1  1 08:03 pts/0    00:00:00 python3 -m foglamp.services.core
   foglamp   6179     1  0 08:03 ?        00:00:00 /home/foglamp/FogLAMP/services/storage --address=0.0.0.0 --port=34037
-  foglamp   6197  6174  0 08:03 pts/0    00:00:00 /bin/sh services/south --port=34037 --address=127.0.0.1 --name=COAP
-  foglamp   6198  6197  0 08:03 pts/0    00:00:00 python3 -m foglamp.services.south --port=34037 --address=127.0.0.1 --name=COAP
-  foglamp   6199  6174  0 08:03 pts/0    00:00:00 /bin/sh services/south --port=34037 --address=127.0.0.1 --name=HTTP_SOUTH
-  foglamp   6200  6199  0 08:03 pts/0    00:00:00 python3 -m foglamp.services.south --port=34037 --address=127.0.0.1 --name=HTTP_SOUTH
-  foglamp   6212  6174  0 08:04 pts/0    00:00:00 /bin/sh tasks/statistics --port=34037 --address=127.0.0.1 --name=stats collector
   foglamp   6213  6212  0 08:04 pts/0    00:00:00 python3 -m foglamp.tasks.statistics --port=34037 --address=127.0.0.1 --name=stats collector
   ...
   $
@@ -799,8 +782,6 @@ Check the *core.err* file, but if it is empty and *foglamp status* shows FogLAMP
   FogLAMP does not require authentication.
   === FogLAMP services:
   foglamp.services.core
-  foglamp.services.south --port=38994 --address=127.0.0.1 --name=COAP
-  foglamp.services.south --port=38994 --address=127.0.0.1 --name=HTTP_SOUTH
   === FogLAMP tasks:
   $ foglamp stop
   Stopping FogLAMP.............

--- a/docs/03_getting_started.rst
+++ b/docs/03_getting_started.rst
@@ -61,7 +61,7 @@ You may also want to install some utilities to make your life easier when you us
 Building FogLAMP
 ================
 
-In this section we will describe how to build FogLAMP on Ubuntu 16.04.3 LTS (Server or Desktop).  Other Linux distributions, Debian or Red-Hat based, or even other versions of Ubuntu may differ. If you are not familiar with Linux and you do not want to build FogLAMP from the source code, you can download a ready-made Debian package (the list of packages is `here <92_downloads.html>`_).
+In this section we will describe how to build FogLAMP on Ubuntu 16.04 LTS (Server or Desktop). Other Linux distributions, Debian or Red-Hat based, or even other versions of Ubuntu may differ. If you are not familiar with Linux and you do not want to build FogLAMP from the source code, you can download a ready-made Debian package (the list of packages is `here <92_downloads.html>`_).
 
 
 Build Pre-Requisites
@@ -85,9 +85,10 @@ FogLAMP is currently based on C/C++ and Python code. The packages needed to buil
 - libtool 
 - make
 - postgresql
-- python-dbus
-- python-dev
+- python3-dbus
+- python3-dev
 - python3-pip
+- python3-setuptools
 - sqlite3
 - uuid-dev
 
@@ -113,7 +114,7 @@ FogLAMP is currently based on C/C++ and Python code. The packages needed to buil
   Building dependency tree
   ...
   $
-  $ sudo apt-get install python-dev python3-pip python-dbus
+  $ sudo apt-get install python3-dev python3-pip python3-dbus python3-setuptools
   Reading package lists... Done
   Building dependency tree
   ...
@@ -797,5 +798,3 @@ Check the *core.err* file, but if it is empty and *foglamp status* shows FogLAMP
   $ ps -ef | grep foglamp
   ...
   $
-
-

--- a/docs/04_installation.rst
+++ b/docs/04_installation.rst
@@ -92,7 +92,7 @@ These are the main steps of the installation:
 - Create all the necessary destination directories and copy the executables, scripts and configuration files
 - Change the ownership of the *data* directory, if the install user is a superuser (we recommend to run FogLAMP as regular user, i.e. not as superuser).
 
-FogLAMP is now present in */usr/local/foglamp* and ready to start. The start script is in the *bin* directory
+FogLAMP is now present in */usr/local/foglamp* and ready to start. The start script is in the */usr/local/foglamp/bin* directory
 
 .. code-block:: console
 
@@ -261,11 +261,7 @@ You can install FogLAMP as a service following these simple steps:
         CPU: 2.888s
      CGroup: /system.slice/foglamp.service
              ├─1759 python3 -m foglamp.services.core
-             ├─1764 /usr/local/foglamp/services/storage --address=0.0.0.0 --port=46309
-             ├─1814 /bin/sh services/south --port=46309 --address=127.0.0.1 --name=COAP
-             ├─1815 python3 -m foglamp.services.south --port=46309 --address=127.0.0.1 --name=COAP
-             ├─1816 /bin/sh services/south --port=46309 --address=127.0.0.1 --name=HTTP_SOUTH
-             └─1817 python3 -m foglamp.services.south --port=46309 --address=127.0.0.1 --name=HTTP_SOUTH
+             └─1764 /usr/local/foglamp/services/storage --address=0.0.0.0 --port=46309
   $
 
 |br|
@@ -284,7 +280,7 @@ Check the |Downloads page| to find the package to install.
 
 Once you have downloaded the package, install it using the ``apt-get`` command. You can use ``apt-get`` to install a local Debian package and automatically retrieve all the necessary packages that are defined as pre-requisites for FogLAMP.  Note that you may need to install the package as superuser (or by using the ``sudo`` command) and move the package to the apt cache directory first (``/var/cache/apt/archives``).
 
-For example, if you are installing FogLAMP on an Intel x86/64 machine, you can type this command to download the package:
+For example, if you are installing FogLAMP on an Intel x86_64 machine, you can type this command to download the package:
 
 .. code-block:: console
 
@@ -363,11 +359,8 @@ You can also check the service currently running:
       CPU: 2.603s
    CGroup: /system.slice/foglamp.service
            ├─1218 python3 -m foglamp.services.core
-           ├─1226 /usr/local/foglamp/services/storage --address=0.0.0.0 --port=44530
-           ├─1277 /bin/sh services/south --port=44530 --address=127.0.0.1 --name=COAP
-           ├─1278 /bin/sh services/south --port=44530 --address=127.0.0.1 --name=HTTP_SOUTH
-           ├─1279 python3 -m foglamp.services.south --port=44530 --address=127.0.0.1 --name=COAP
-           └─1280 python3 -m foglamp.services.south --port=44530 --address=127.0.0.1 --name=HTTP_SOUTH
+           └─1226 /usr/local/foglamp/services/storage --address=0.0.0.0 --port=44530
+
   ...
   $
 
@@ -383,9 +376,9 @@ Check if FogLAMP is up and running with the ``foglamp`` command:
   FogLAMP does not require authentication.
   === FogLAMP services:
   foglamp.services.core
-  foglamp.services.south --port=46141 --address=127.0.0.1 --name=COAP
-  foglamp.services.south --port=46141 --address=127.0.0.1 --name=HTTP_SOUTH
+  ...
   === FogLAMP tasks:
+  ...
   $
 
 

--- a/docs/04_installation.rst
+++ b/docs/04_installation.rst
@@ -582,5 +582,3 @@ Snap is designed to be self-contained and it does not require any user setting, 
   -rw------- 1 ubuntu ubuntu   121 Dec 11 15:07 postmaster.opts
   -rw------- 1 ubuntu ubuntu   117 Dec 11 15:07 postmaster.pid
   $
-
-

--- a/docs/05_testing.rst
+++ b/docs/05_testing.rst
@@ -85,7 +85,6 @@ When you have a running FogLAMP, check the extra information provided by the ``f
   FogLAMP does not require authentication.
   === FogLAMP services:
   foglamp.services.core
-  foglamp.services.south --port=44180 --address=127.0.0.1 --name=COAP
   === FogLAMP tasks:
   foglamp.tasks.north.sending_process --stream_id 1 --debug_level 1 --port=44180 --address=127.0.0.1 --name=sending process
   foglamp.tasks.north.sending_process --stream_id 2 --debug_level 1 --port=44180 --address=127.0.0.1 --name=statistics to pi
@@ -109,7 +108,7 @@ The following lines provide a list of the modules running in this installation o
 - ``=== FogLAMP services:`` - This block contains the list of microservices running in the FogLAMP plaftorm.
 
   - ``foglamp.services.core`` is the Core microservice itself
-  - ``foglamp.services.south --port=44180 --address=127.0.0.1 --name=COAP`` - This South microservice is a listener of data pushed to FogLAMP via a CoAP protocol
+  - ``foglamp.services.south --port=44180 --address=127.0.0.1 --name=COAP`` - This South microservice is a listener of data pushed to FogLAMP via a CoAP protocol (foglamp-south-coap plugin)
 
 - ``=== FogLAMP tasks:`` - This block contains the list of tasks running in the FogLAMP platform.
 
@@ -161,7 +160,7 @@ The default port for the REST API is 8081. Using curl, try this command:
 
 The ``echo`` at the end of the line is simply used to add an extra new line to the output.
 |br| |br|
-If you are using Postman, select the *GET* method and type ``http://localhost:8081/foglamp/ping`` in the URI line. If you are accessing a remote machine, replace *localhost* with the correct IP address. The output should be something like:
+If you are using Postman, select the *GET* method and type ``http://localhost:8081/foglamp/ping`` in the URI address input. If you are accessing a remote machine, replace *localhost* with the correct IP address. The output should be something like:
 
 |postman_ping|
 
@@ -192,7 +191,7 @@ Regardless of the position or environment, the *fogbench* tool, responds to your
 .. code-block:: console
 
   $ foglamp.fogbench
-  >>> Make sure device service is running & CoAP server is listening on specified host and port
+  >>> Make sure south service is running & CoAP server is listening on specified host and port
   usage: fogbench [-h] [-v] [-k {y,yes,n,no}] -t TEMPLATE [-o OUTPUT]
                   [-I ITERATIONS] [-O OCCURRENCES] [-H HOST] [-P PORT]
                   [-i INTERVAL] [-S {total}]
@@ -204,7 +203,7 @@ Regardless of the position or environment, the *fogbench* tool, responds to your
 .. code-block:: console
 
   $ foglamp.fogbench -h
-  >>> Make sure device service is running & CoAP server is listening on specified host and port
+  >>> Make sure south CoAP plugin service is running & listening on specified host and port
   usage: fogbench [-h] [-v] [-k {y,yes,n,no}] -t TEMPLATE [-o OUTPUT]
                   [-I ITERATIONS] [-O OCCURRENCES] [-H HOST] [-P PORT]
                   [-i INTERVAL] [-S {total}]
@@ -298,7 +297,7 @@ The output of your command should be:
 .. code-block:: console
 
   $ scripts/extras/fogbench -t data/extras/fogbench/fogbench_sensor_coap.template.json
-  >>> Make sure device service is running & CoAP server is listening on specified host and port
+  >>> Make sure south CoAP service is running & listening on specified host and port
   Total Statistics:
 
   Start Time: 2017-12-17 07:17:50.615433
@@ -327,7 +326,7 @@ If you want to stress FogLAMP a bit, you may insert the same data sample several
 .. code-block:: console
 
   $ scripts/extras/fogbench -t data/extras/fogbench/fogbench_sensor_coap.template.json -I 100
-  >>> Make sure device service is running & CoAP server is listening on specified host and port
+  >>> Make sure south CoAP service is running & listening on specified host and port
   Total Statistics:
 
   Start Time: 2017-12-17 07:33:40.568130
@@ -459,12 +458,7 @@ If you are curious to see which categories are available in FogLAMP, simply type
 .. code-block:: console
 
   $ curl -s http://localhost:8081/foglamp/category ; echo
-  { "categories": [ { "key": "CC2650ASYN", "description": "TI SensorTag CC2650 async South Plugin"    },
-                    { "key": "CC2650POLL", "description": "TI SensorTag CC2650 polling South Plugin"  },
-                    { "key": "COAP",       "description": "COAP Device"                               },
-                    { "key": "HTTP_SOUTH", "description": "HTTP_SOUTH Device"                         },
-                    { "key": "POLL",       "description": "South Plugin polling template"             },
-                    { "key": "SCHEDULER",  "description": "Scheduler configuration"                   },
+  { "categories": [ { "key": "SCHEDULER",  "description": "Scheduler configuration"                   },
                     { "key": "SEND_PR_1",  "description": "OMF North Plugin Configuration"            },
                     { "key": "SEND_PR_2",  "description": "OMF North Statistics Plugin Configuration" },
                     { "key": "SEND_PR_3",  "description": "HTTP North Plugin Configuration"           },
@@ -477,6 +471,8 @@ If you are curious to see which categories are available in FogLAMP, simply type
   }
   $
 
+
+For each plugin, you will see corresponding category e.g. for foglamp-south-coap the registered category will be ``{ "key": "COAP", "description": "CoAP Listener South Plugin"}``.
 The configuration for the OMF Translator used to stream the South data is initially disabled, all you can see about the settings is:
 
 .. code-block:: console

--- a/docs/05_testing.rst
+++ b/docs/05_testing.rst
@@ -108,7 +108,7 @@ The following lines provide a list of the modules running in this installation o
 - ``=== FogLAMP services:`` - This block contains the list of microservices running in the FogLAMP plaftorm.
 
   - ``foglamp.services.core`` is the Core microservice itself
-  - ``foglamp.services.south --port=44180 --address=127.0.0.1 --name=COAP`` - This South microservice is a listener of data pushed to FogLAMP via a CoAP protocol (foglamp-south-coap plugin)
+  - ``foglamp.services.south --port=44180 --address=127.0.0.1 --name=COAP`` - This South microservice is a listener of data pushed to FogLAMP via a CoAP protocol
 
 - ``=== FogLAMP tasks:`` - This block contains the list of tasks running in the FogLAMP platform.
 
@@ -191,7 +191,7 @@ Regardless of the position or environment, the *fogbench* tool, responds to your
 .. code-block:: console
 
   $ foglamp.fogbench
-  >>> Make sure south service is running & CoAP server is listening on specified host and port
+  >>> Make sure south CoAP plugin service is running & listening on specified host and port
   usage: fogbench [-h] [-v] [-k {y,yes,n,no}] -t TEMPLATE [-o OUTPUT]
                   [-I ITERATIONS] [-O OCCURRENCES] [-H HOST] [-P PORT]
                   [-i INTERVAL] [-S {total}]
@@ -297,7 +297,7 @@ The output of your command should be:
 .. code-block:: console
 
   $ scripts/extras/fogbench -t data/extras/fogbench/fogbench_sensor_coap.template.json
-  >>> Make sure south CoAP service is running & listening on specified host and port
+  >>> Make sure south CoAP plugin service is running & listening on specified host and port
   Total Statistics:
 
   Start Time: 2017-12-17 07:17:50.615433
@@ -326,7 +326,7 @@ If you want to stress FogLAMP a bit, you may insert the same data sample several
 .. code-block:: console
 
   $ scripts/extras/fogbench -t data/extras/fogbench/fogbench_sensor_coap.template.json -I 100
-  >>> Make sure south CoAP service is running & listening on specified host and port
+  >>> Make sure south CoAP plugin service is running & listening on specified host and port
   Total Statistics:
 
   Start Time: 2017-12-17 07:33:40.568130
@@ -472,7 +472,7 @@ If you are curious to see which categories are available in FogLAMP, simply type
   $
 
 
-For each plugin, you will see corresponding category e.g. for foglamp-south-coap the registered category will be ``{ "key": "COAP", "description": "CoAP Listener South Plugin"}``.
+For each plugin, you will see corresponding category e.g. For foglamp-south-coap the registered category will be ``{ "key": "COAP", "description": "CoAP Listener South Plugin"}``.
 The configuration for the OMF Translator used to stream the South data is initially disabled, all you can see about the settings is:
 
 .. code-block:: console

--- a/docs/06_plugins/01_FogLAMP_plugins.rst
+++ b/docs/06_plugins/01_FogLAMP_plugins.rst
@@ -20,7 +20,7 @@
 
 FogLAMP makes extensive use of plugin components to extend the base functionality of the platform. In particular, plugins are used to extend the set of sensors and actuators that FogLAMP supports, the set of services to which FogLAMP will push accumulated data gathered from those sensors and the mechanism by which FogLAMP buffers data internally.
 
-This chapter presents the plugins available in FogLAMP, how to write and use new plugins to support different sensors, protocols, historians and storage devices. It will guide you through the process and entry points that are required for the various different type of plugin.
+This chapter presents the plugins available for FogLAMP, how to write and use new plugins to support different sensors, protocols, historians and storage devices. It will guide you through the process and entry points that are required for the various different type of plugin.
 
 
 FogLAMP Plugins
@@ -29,7 +29,7 @@ FogLAMP Plugins
 In this version of FogLAMP you have three types of plugins:
 
 - **South Plugins** - They are responsible for communication between FogLAMP and the sensors and actuators they support. Each instance of a FogLAMP South microservice will use a plugin for the actual communication to the sensors or actuators that that instance of the South microservice supports.
-- **North Plugins** - They are responsible for taking reading data passed to them from the South bound task and doing any necessary conversion to the data and providing the protocol to send that converted data to a north-side service.
+- **North Plugins** - They are responsible for taking reading data passed to them from the South bound service and doing any necessary conversion to the data and providing the protocol to send that converted data to a north-side task.
 - **Storage Plugins** - They sit between the Storage microservice and the physical data storage mechanism that stores the FogLAMP configuration and readings data. Storage plugins differ from other plugins in that they interface to a storage system which is written in C/C++ rather than Python, however they share the same common attributes and entry points that the Python based plugins must support.
 
 
@@ -50,22 +50,6 @@ This version of FogLAMP provides the following plugins in the main repository:
 |         |            |            | for data and metadata       | Ubuntu Core: x86, ARM |br| |                                        |
 |         |            |            |                             | Raspbian                   |                                        |
 +---------+------------+------------+-----------------------------+----------------------------+----------------------------------------+
-| South   | COAP       | Enabled    | CoAP Listener               | Ubuntu: x86_64 |br|        |                                        |
-|         |            |            |                             | Ubuntu Core: x86, ARM |br| |                                        |
-|         |            |            |                             | Raspbian                   |                                        |
-+---------+------------+------------+-----------------------------+----------------------------+----------------------------------------+
-| South   | CC2650POLL | Disabled   | TI SensorTag CC2650 |br|    | Ubuntu: x86_64 |br|        | It requires BLE support. |br|          |
-|         |            |            | in polling mode             | Ubuntu Core: x86, ARM |br| | There are issues with Ubuntu Core |br| |
-|         |            |            |                             | Raspbian                   | on ARM, reported |here BT|             |
-+---------+------------+------------+-----------------------------+----------------------------+----------------------------------------+
-| South   | CC2650ASYN | Disabled   | TI SensorTag CC2650 |br|    | Ubuntu: x86_64 |br|        | It requires BLE support. |br|          |
-|         |            |            | asynchronous |br|           | Ubuntu Core: x86, ARM |br| | There are issues with Ubuntu Core |br| |
-|         |            |            | (listening) mode            | Raspbian                   | on ARM, reported |here BT|.            |
-+---------+------------+------------+-----------------------------+----------------------------+----------------------------------------+
-| South   | HTTP_SOUTH | Enabled    | HTTP Listener               | Ubuntu: x86_64 |br|        |                                        |
-|         |            |            |                             | Ubuntu Core: x86, ARM |br| |                                        |
-|         |            |            |                             | Raspbian                   |                                        |
-+---------+------------+------------+-----------------------------+----------------------------+----------------------------------------+
 | North   | OMF        | Disabled   | OSIsoft Message Format |br| | Ubuntu: x86_64 |br|        | It works with PI Connector |br|        |
 |         |            |            | sender to PI Connector |br| | Ubuntu Core: x86, ARM |br| | Relay OMF 1.2.X and 2.2                |
 |         |            |            | Relay OMF                   | Raspbian                   |                                        |
@@ -78,18 +62,34 @@ This version of FogLAMP provides the following plugins in the main repository:
 
 In addition to the plugins in the main repository, these plugins are also available:
 
-+-------+----------------+------------------------------+---------------------------------------+---------------+
-| Type  | Name           | Repository                   | Description                           | Availability  |
-+=======+================+==============================+=======================================+===============+
-| South | dht11pi        | foglamp-south-dht11          | Wired DHT11 Sensor in polling mode    | Respbian      |
-+-------+----------------+------------------------------+---------------------------------------+---------------+
-| South | envirophat     | foglamp-south-envirophat     | Enviro pHAT sensor set                | Raspbian      |
-+-------+----------------+------------------------------+---------------------------------------+---------------+
-| South | openweathermap | foglamp-south-openweathermap | Data pull from the OpenWeatherMap API | Ubuntu x86_64 |
-|       |                |                              |                                       | Raspbian      |
-+-------+----------------+------------------------------+---------------------------------------+---------------+
-| South | pt100          | foglamp-south-pt100          | Wired PT100 temperature sensor        | Raspbian      |
-+-------+----------------+------------------------------+---------------------------------------+---------------+
++-------+----------------+------------------------------+---------------------------------------+---------------+----------------------------------------+
+| Type  | Name           | Repository                   | Description                           | Availability  | Notes                                  |
++=======+================+==============================+=======================================+===============+========================================+
+| South | dht11pi        | foglamp-south-dht11          | Wired DHT11 Sensor in polling mode    | Raspbian      |                                        |
++-------+----------------+------------------------------+---------------------------------------+---------------+----------------------------------------+
+| South | envirophat     | foglamp-south-envirophat     | Enviro pHAT sensor set                | Raspbian                                               |
++-------+----------------+------------------------------+---------------------------------------+---------------+----------------------------------------+
+| South | openweathermap | foglamp-south-openweathermap | Data pull from the OpenWeatherMap API | Ubuntu x86_64 |                                        |
+|       |                |                              |                                       | Raspbian      |                                        |
++-------+----------------+------------------------------+---------------------------------------+---------------+----------------------------------------+
+| South | pt100          | foglamp-south-pt100          | Wired PT100 temperature sensor        | Raspbian      |                                        |
++-------+----------------+------------------------------+---------------------------------------+---------------+----------------------------------------+
+| South | CoAP           | foglamp-south-coap           | CoAP Listener                         | Ubuntu x86_64 |                                        |
+|       |                |                              |                                       | Ubuntu Core   |                                        |
+|       |                |                              |                                       | Raspbian      |                                        |
++-------+----------------+------------------------------+---------------------------------------+---------------+----------------------------------------+
+| South | CC2650POLL     | foglamp-south--cc2650poll    | TI SensorTag CC2650 |br|              | Ubuntu x86_64 | It requires BLE support. |br|          |
+|       |                |                              | in polling mode                       | Ubuntu Core   | There are issues with Ubuntu Core |br| |
+|       |                |                              |                                       | Raspbian      | on ARM, reported |here BT|             |
++-------+----------------+------------------------------+---------------------------------------+---------------+----------------------------------------+
+| South | CC2650ASYN     | foglamp-south-cc2650asyn     | TI SensorTag CC2650 |br|              | Ubuntu x86_64 | It requires BLE support. |br|          |
+|       |                |                              | asynchronous |br|                     | Ubuntu Core   | There are issues with Ubuntu Core |br| |
+|       |                |                              | (listening) mode                      | Raspbian      | on ARM, reported |here BT|             |
++-------+----------------+------------------------------+---------------------------------------+---------------+----------------------------------------+
+| South | HTTP_SOUTH     | foglamp-south-http           | HTTP Listener                         | Ubuntu x86_64 |                                        |
+|       |                |                              |                                       | Ubuntu Core   |                                        |
+|       |                |                              |                                       | Raspbian      |                                        |
++-------+----------------+------------------------------+---------------------------------------+---------------+----------------------------------------+
 
 
 Installing New Plugins
@@ -113,25 +113,17 @@ For example, this is the command to use to install the *OpenWeather* South plugi
        Docs: man:systemd-sysv-generator(8)
      CGroup: /system.slice/foglamp.service
              ├─13741 python3 -m foglamp.services.core
-             ├─13746 /usr/local/foglamp/services/storage --address=0.0.0.0 --port=40138
-             ├─13785 /bin/sh services/south --port=40138 --address=127.0.0.1 --name=COAP
-             ├─13786 python3 -m foglamp.services.south --port=40138 --address=127.0.0.1 --name=COAP
-             ├─13787 /bin/sh services/south --port=40138 --address=127.0.0.1 --name=HTTP_SOUTH
-             └─13788 python3 -m foglamp.services.south --port=40138 --address=127.0.0.1 --name=HTTP_SOUTH
+             └─13746 /usr/local/foglamp/services/storage --address=0.0.0.0 --port=40138
 
   May 16 01:36:09 ubuntu python3[13741]: FogLAMP[13741] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collection' process 'stats coll
                                          ['tasks/statistics', '--port=40138', '--address=127.0.0.1', '--name=stats collector']
-  May 16 01:36:09 ubuntu python3[13741]: FogLAMP[13741] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Sleeping for 1730.0983202457428 seconds
-  May 16 01:36:10 ubuntu python3[13741]: FogLAMP[13741] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collection' process 'stats c
-                                         ['tasks/statistics']
+  ...
   FogLAMP v1.2 running.
   FogLAMP Uptime:  266 seconds.
   FogLAMP records: 0 read, 0 sent, 0 purged.
   FogLAMP does not require authentication.
   === FogLAMP services:
   foglamp.services.core
-  foglamp.services.south --port=40138 --address=127.0.0.1 --name=COAP
-  foglamp.services.south --port=40138 --address=127.0.0.1 --name=HTTP_SOUTH
   === FogLAMP tasks:
   $
   $ sudo cp foglamp-south-openweathermap-1.2-x86_64.deb /var/cache/apt/archives/.
@@ -155,10 +147,7 @@ For example, this is the command to use to install the *OpenWeather* South plugi
   Preparing to unpack .../foglamp-south-openweathermap-1.2-x86_64.deb ...
   Unpacking foglamp-south-openweathermap (1.2) ...
   Setting up foglamp-south-openweathermap (1.2) ...
-  openweathermap plugin installed. Restart FogLAMP to enable the plugin.
-  $
-  $ sudo systemctl stop foglamp.service
-  $ sudo systemctl start foglamp.service
+  openweathermap plugin installed.
   $
   $ foglamp status
   FogLAMP v1.2 running.
@@ -168,10 +157,5 @@ For example, this is the command to use to install the *OpenWeather* South plugi
   === FogLAMP services:
   foglamp.services.core
   foglamp.services.south --port=42066 --address=127.0.0.1 --name=openweathermap
-  foglamp.services.south --port=42066 --address=127.0.0.1 --name=COAP
-  foglamp.services.south --port=42066 --address=127.0.0.1 --name=HTTP_SOUTH
   === FogLAMP tasks:
   $
-
-
-

--- a/docs/06_plugins/02_writing_plugins.rst
+++ b/docs/06_plugins/02_writing_plugins.rst
@@ -47,7 +47,7 @@ A typical Python implementation of this would simply return a fixed dictionary o
           'mode': 'poll',
           'type': 'south',
           'interface': '1.0',
-          'config': DEFAULT_CONFIG
+          'config': _DEFAULT_CONFIG
       }
 
 These are the properties returned by the JSON document:

--- a/docs/06_plugins/02_writing_plugins.rst
+++ b/docs/06_plugins/02_writing_plugins.rst
@@ -8,19 +8,8 @@
 .. Images
 
 .. Links
-.. _here: 05_testing.html#setting-the-omf-translator-plugin
-.. _these steps: 04_installation.html
-
-.. |Getting Started| raw:: html
-
-   <a href="03_getting_started.html#building-foglamp">here</a>
 
 .. Links in new tabs
-
-.. |GPIO| raw:: html
-
-   <a href="https://www.raspberrypi.org/documentation/usage/gpio-plus-and-raspi2/README.md" target="_blank">here</a>
-
 
 .. =============================================
 
@@ -58,7 +47,7 @@ A typical Python implementation of this would simply return a fixed dictionary o
           'mode': 'poll',
           'type': 'south',
           'interface': '1.0',
-          'config': _DEFAULT_CONFIG
+          'config': DEFAULT_CONFIG
       }
 
 These are the properties returned by the JSON document:
@@ -140,7 +129,6 @@ Using a simple example of our sensor reading a GPIO pin, we extract the new pin 
       """
 
       new_handle = new_config['gpiopin']['value']
-
       return new_handle
 
 |br|

--- a/docs/06_plugins/03_01_DHT11.rst
+++ b/docs/06_plugins/03_01_DHT11.rst
@@ -277,19 +277,19 @@ Building FogLAMP and Adding the Plugin
 If you have not built FogLAMP yet, follow the steps described |Getting Started|. After the build, you can optionally install FogLAMP following |these INSTALLATION| steps.
 
 
-- If you have started FogLAMP from the build folder: copy the structure of the *foglamp-south-dht11/python/* directory into the *python* directory:
+- If you have started FogLAMP from the build directory, copy the structure of the *foglamp-south-dht11/python/* directory into the *python* directory:
 
 .. code-block:: console
 
   $ cd ~/FogLAMP
-  $ cp -r ~/foglamp-south-dht11/python/foglamp/plugins/south/dht11 python/foglamp/plugin/south/
+  $ cp -R ~/foglamp-south-dht11/python/foglamp/plugins/south/dht11 python/foglamp/plugin/south/
   $
 
 - If you have installed FogLAMP by executing ``sudo make install``, copy the structure of the *foglamp-south-dht11/python/* directory into the installed *python* directory:
 
 .. code-block:: console
 
-  $ sudo cp -r ~/foglamp-south-dht11/python/foglamp/plugins/south/dht11 /usr/local/foglamp/python/foglamp/plugin/south/
+  $ sudo cp -R ~/foglamp-south-dht11/python/foglamp/plugins/south/dht11 /usr/local/foglamp/python/foglamp/plugin/south/
   $
 
 .. note:: If you have installed FogLAMP using an alternative *DESTDIR*, remember to add the path to the destination directory to the ``cp`` command.

--- a/docs/06_plugins/03_01_DHT11.rst
+++ b/docs/06_plugins/03_01_DHT11.rst
@@ -26,7 +26,7 @@
 
 .. |DHT Repo| raw:: html
 
-   <a href="https://github.com/foglamp/foglamp-south-dht11 target="_blank">FogLAMP DHT11 South Plugin</a>
+   <a href="https://github.com/foglamp/foglamp-south-dht11" target="_blank">FogLAMP DHT11 South Plugin</a>
 
 .. |ADAFruit| raw:: html
 
@@ -301,8 +301,7 @@ If you have not built FogLAMP yet, follow the steps described |Getting Started|.
 
    $ curl -sX POST http://localhost:8081/foglamp/service -d '{"name": "dht11", "type": "south", "plugin": "dht11", "enabled": true}'
 
-.. note:: Each plugin repo has its own debian packaging script and documentation, And that is the recommended way to go! As above method(s) may need explicit action for
-linux and/or python dependencies installation.
+.. note:: Each plugin repo has its own debian packaging script and documentation, And that is the recommended way to go! As above method(s) may need explicit action for linux and/or python dependencies installation.
 
 Using the Plugin
 ~~~~~~~~~~~~~~~~

--- a/docs/06_plugins/03_01_DHT11.rst
+++ b/docs/06_plugins/03_01_DHT11.rst
@@ -11,22 +11,26 @@
    :target: https://s3.amazonaws.com/foglamp/readthedocs/images/06_dht11_tags_in_PI.jpg 
 
 .. Links
-.. _here: 05_testing.html#setting-the-omf-translator-plugin
-.. _these steps: 04_installation.html
+.. |these INSTALLATION| raw:: html
+
+   <a href="04_installation.html">these</a>
 
 .. |Getting Started| raw:: html
 
    <a href="03_getting_started.html#building-foglamp">here</a>
 
 .. Links in new tabs
+.. |setting OMF| raw:: html
+
+   <a href="05_testing.html#setting-the-omf-translator-plugin">here</a>
+
+.. |DHT Repo| raw:: html
+
+   <a href="https://github.com/foglamp/foglamp-south-dht11 target="_blank">FogLAMP DHT11 South Plugin</a>
 
 .. |ADAFruit| raw:: html
 
    <a href="https://github.com/adafruit/Adafruit_Python_DHT" target="_blank">ADAFruit DHT Library</a>
-
-.. |here BT| raw:: html
-
-   <a href="https://bugs.launchpad.net/snappy/+bug/1674509" target="_blank">here</a>
 
 .. |DHT Description| raw:: html
 
@@ -59,7 +63,7 @@
 A South Plugin Example: the DHT11 Sensor
 ----------------------------------------
 
-Let's try to put all the information together and write a plugin. We can continue to use the example of an inexpensive sensor, the DHT11, used to measure temperature and humidity, directly wired to a Raspberry PI. This plugin is also available in the FogLAMP project on GitHub, in the *contrib* folder.
+Let's try to put all the information together and write a plugin. We can continue to use the example of an inexpensive sensor, the DHT11, used to measure temperature and humidity, directly wired to a Raspberry PI. This plugin is available on github, |DHT Repo|.
 
 First, here is a set of links where you can find more information regarding this sensor:
 
@@ -153,7 +157,7 @@ This is the code for the plugin:
       'plugin': {
           'description': 'Python module name of the plugin to load',
           'type':        'string',
-          'default':     'dht11pi'
+          'default':     'dht11'
       },
       'pollInterval': {
           'description': 'The interval between poll calls to the device poll routine expressed in milliseconds.',
@@ -264,97 +268,50 @@ This is the code for the plugin:
       Returns:
       Raises:
       """
-
-
-The configuration
-~~~~~~~~~~~~~~~~~
-
-Since the plugin is still experimental, it works only in a build environment, the snap version will be available in the next release.
-
-The configuration must be set manually in the FogLAMP metadata. in the repository, the file *cmds.sql* in the *contrib/plugins/south/dht11pi* folder must be executed with *psql* (or another PostgreSQL client) to add the configuration to the FogLAMP metadata.
- 
-Let's see the SQL commands:
-
-.. code-block:: sql
-
-  --- Create the South service instannce
-  INSERT INTO foglamp.scheduled_processes ( name, script )
-       VALUES ( 'dht11pi', '["services/south"]');
-
-  --- Add the schedule to start the service at system startup
-  INSERT INTO foglamp.schedules ( id, schedule_name, process_name, schedule_type,schedule_interval, exclusive )
-       VALUES ( '543a59ce-a9ca-11e7-abc4-cec278b6b11a', 'device', 'dht11pi', 1, '0:0', true );
-
-  --- Insert the config needed to load the plugin
-  INSERT INTO foglamp.configuration ( key, description, value )
-       VALUES ( 'dht11pi', 'DHT11 on Raspberry Pi Configuration',
-                '{"plugin" : { "type" : "string", "value" : "dht11pi", "default" : "dht11pi", "description" : "Plugin to load" } }' );
+      pass
 
 
 Building FogLAMP and Adding the Plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you have not built FogLAMP yet, follow the steps described |Getting Started|. After the build, you can optionally install FogLAMP following `these steps`_.
-
-Once the Storage database has been setup, let's update the configurarion to include the new plugin:
-
-.. code-block:: console
-
-  $ psql -d foglamp -f cmds.sql
-  INSERT 0 1
-  INSERT 0 1
-  INSERT 0 1
-  $
+If you have not built FogLAMP yet, follow the steps described |Getting Started|. After the build, you can optionally install FogLAMP following |these INSTALLATION| steps.
 
 
-Now it is time to apply a workaround and include our new plugin. 
-
-- If you intend to start and execute FogLAMP from the build folder: copy the structure of the *contrib* folder into the *python* folder:
+- If you have started FogLAMP from the build folder: copy the structure of the *foglamp-south-dht11/python/* directory into the *python* directory:
 
 .. code-block:: console
 
   $ cd ~/FogLAMP
-  $ cp -R contrib/plugins python/foglamp/.
+  $ cp -r ~/foglamp-south-dht11/python/foglamp/plugins/south/dht11 python/foglamp/plugin/south/
   $
 
-- If you have installed FogLAMP by executing ``sudo make install``, copy the structure of the *contrib* folder into the installed *python* folder:
+- If you have installed FogLAMP by executing ``sudo make install``, copy the structure of the *foglamp-south-dht11/python/* directory into the installed *python* directory:
 
 .. code-block:: console
 
-  $ cd ~/FogLAMP
-  $ sudo cp -R contrib/plugins /usr/local/FogLAMP/python/foglamp/.
+  $ sudo cp -r ~/foglamp-south-dht11/python/foglamp/plugins/south/dht11 /usr/local/foglamp/python/foglamp/plugin/south/
   $
 
 .. note:: If you have installed FogLAMP using an alternative *DESTDIR*, remember to add the path to the destination directory to the ``cp`` command.
 
 
+- Add service
+
+.. code-block:: console
+
+   $ curl -sX POST http://localhost:8081/foglamp/service -d '{"name": "dht11", "type": "south", "plugin": "dht11", "enabled": true}'
+
+.. note:: Each plugin repo has its own debian packaging script and documentation, And that is the recommended way to go! As above method(s) may need explicit action for
+linux and/or python dependencies installation.
+
 Using the Plugin
 ~~~~~~~~~~~~~~~~
 
-Now you are ready to use the DHT11 plugin. If stop and restart FogLAMP if it is already running, or start it now.
-
-- Starting FogLAMP from the build folder:
+Once south plugin is added as an enabled service, You are ready to use the DHT11 plugin.
 
 .. code-block:: console
 
-  $ cd ~/FogLAMP
-  $ export FOGLAMP_ROOT=$HOME/FogLAMP
-  $ scripts/foglamp start
-  Starting FogLAMP................
-  FogLAMP started.
-  $
-
-
-- Starting FogLAMP from the installed folder:
-
-.. code-block:: console
-
-  $ cd /usr/local/FogLAMP
-  $ bin/foglamp start
-  Starting FogLAMP................
-  FogLAMP started.
-  $
-
+   $ curl -X GET http://localhost:8081/foglamp/service | jq
 
 Let's see what we have collected so far:
 
@@ -458,7 +415,7 @@ Clearly we will not see many changes in temperature or humidity, unless we place
   ]
   $
 
-Needless to say, the North plugin will send the buffered data to the PI system using the PI Connector Relay OMF. Do not forget to set the correct IP address for the PI Connector Relay, as it is described `here`_.
+Needless to say, the North plugin will send the buffered data to the PI system using the PI Connector Relay OMF. Do not forget to set the correct IP address for the PI Connector Relay, as it is described |setting OMF|.
 
 |DHT11 in PI|
 

--- a/docs/06_plugins/03_south_plugins.rst
+++ b/docs/06_plugins/03_south_plugins.rst
@@ -7,51 +7,7 @@
 
 .. Images
 
-.. |DHT11 in PI| image:: https://s3.amazonaws.com/foglamp/readthedocs/images/06_dht11_tags_in_PI.jpg
-   :target: https://s3.amazonaws.com/foglamp/readthedocs/images/06_dht11_tags_in_PI.jpg
-
 .. Links
-.. _here: 05_testing.html#setting-the-omf-translator-plugin
-.. _these steps: 04_installation.html
-
-.. |Getting Started| raw:: html
-
-   <a href="03_getting_started.html#building-foglamp">here</a>
-
-.. Links in new tabs
-
-.. |ADAFruit| raw:: html
-
-   <a href="https://github.com/adafruit/Adafruit_Python_DHT" target="_blank">ADAFruit DHT Library</a>
-
-.. |here BT| raw:: html
-
-   <a href="https://bugs.launchpad.net/snappy/+bug/1674509" target="_blank">here</a>
-
-.. |DHT Description| raw:: html
-
-   <a href="http://www.aosong.com/en/products/details.asp?id=109" target="_blank">DHT11 Product Description</a>
-
-.. |DHT Manual| raw:: html
-
-   <a href="https://s3.amazonaws.com/foglamp/docs/v1/Common/plugins/South/DHT11/DHT11.pdf" target="_blank">DHT11 Product Manual</a>
-
-.. |DHT Resistor| raw:: html
-
-   <a href="https://s3.amazonaws.com/foglamp/docs/v1/Common/plugins/South/DHT11/DHT11-with-resistor.jpg" target="_blank">This picture</a>
-
-.. |DHT Wired| raw:: html
-
-   <a href="https://s3.amazonaws.com/foglamp/docs/v1/Common/plugins/South/DHT11/DHT11-RaspPI-wired.jpg" target="_blank">This picture</a>
-
-.. |DHT Pins| raw:: html
-
-   <a href="https://s3.amazonaws.com/foglamp/docs/v1/Common/plugins/South/DHT11/DHT11-RaspPI-pins.jpg" target="_blank">this</a>
-
-.. |GPIO| raw:: html
-
-   <a href="https://www.raspberrypi.org/documentation/usage/gpio-plus-and-raspi2/README.md" target="_blank">here</a>
-
 
 .. =============================================
 
@@ -112,10 +68,10 @@ Using the example of our simple DHT11 device attached to a GPIO pin, the *poll* 
               time_stamp = str(datetime.now(tz=timezone.utc))
               readings =  { 'temperature': temperature , 'humidity' : humidity }
               wrapper = {
-                      'asset':     'dht11',
+                      'asset': 'dht11',
                       'timestamp': time_stamp,
-                       'key':       str(uuid.uuid4()),
-                      'readings':  readings
+                      'key': str(uuid.uuid4()),
+                      'readings': readings
               }
               return wrapper
           else:
@@ -141,12 +97,11 @@ The *plugin_start* method, as with other plugin calls, is called with the plugin
 .. code-block:: python
 
   loop = asyncio.get_event_loop()
-
-  app = web.Application( middlewares=[middleware.error_middleware] )
-  app.router.add_route( 'POST', '/', SensorPhoneIngest.render_post )
+  app = web.Application(middlewares=[middleware.error_middleware])
+  app.router.add_route('POST', '/', SensorPhoneIngest.render_post)
   handler = app.make_handler()
-  coro = loop.create_server( handler, host, port )
-  server = asyncio.ensure_future( coro )
+  coro = loop.create_server(handler, host, port)
+  server = asyncio.ensure_future(coro)
 
 This code first gets the event loop for this Python execution, it then creates the web application and adds a route for the POST request. In this case it is calling the *render_post* method of the object *SensorPhone*. It then goes on to create the handler and install the web server instance into the event system.
 
@@ -174,7 +129,7 @@ The async handler is defined for incoming message has the responsibility of taki
 
           for readings in messages:
                key = str(uuid.uuid4())
-  await Ingest.add_readings(asset=asset, timestamp=timestamp, key=key, readings=readings)
+      await Ingest.add_readings(asset=asset, timestamp=timestamp, key=key, readings=readings)
 
   except ...
 

--- a/extras/python/fogbench/__main__.py
+++ b/extras/python/fogbench/__main__.py
@@ -61,7 +61,6 @@ import aiohttp
 from aiocoap import *
 from cbor2 import dumps
 
-# FIXME: remove relative import
 from .exceptions import *
 
 __author__ = "Praveen Garg"
@@ -79,8 +78,8 @@ _tot_byte_transferred = []
 _num_iterated = 0
 """Statistics to be collected"""
 
-# TODO: have its own sys/ console logger
 # _logger = logger.setup(__name__)
+
 
 def local_timestamp():
     """
@@ -225,7 +224,6 @@ async def send_to_coap(payload):
     request = Message(payload=dumps(payload), code=POST)
     request.opt.uri_host = arg_host
     request.opt.uri_port = arg_port
-    # request.opt.uri_path = ("other", "block")
     request.opt.uri_path = ("other", "sensor-values")
 
     response = await context.request(request).response


### PR DESCRIPTION
- [x]  Fixed FOGL-1429 using plugin page missing links
- [x]  Removed reference of CoAP/ HTTP services listing on foglamp start (out of the box)
- [x] Added reference of dht11 plugin repo and building in writing using plugin guide
- [x] other misc fixes