### PR TITLE
FOGL-672 - Core should take action when a microservice is observed to be failed

### DIFF
--- a/python/foglamp/services/core/service_registry/monitor.py
+++ b/python/foglamp/services/core/service_registry/monitor.py
@@ -15,7 +15,6 @@ from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.services.core.service_registry.service_registry import ServiceRegistry
 from foglamp.common.service_record import ServiceRecord
 from foglamp.services.core import connect
-from foglamp.services.core import server
 
 __author__ = "Ashwin Gopalakrishnan, Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -101,8 +100,8 @@ class Monitor(object):
                     check_count[service_record._id] += 1
                     self._logger.info("Marked as doubtful micro-service %s", service_record.__repr__())
                 except Exception as ex:  # TODO: Fix too broad exception clause
-                    # Fixme: Investigate as why no exception message can appear, e.g. Apr 16 15:32:08 nerd51-ThinkPad
-                    # FogLAMP[423] INFO: monitor: foglamp.services.core.service_registry.monitor: Exception occurred
+                    # Fixme: Investigate as why no exception message can appear,
+                    # e.g. FogLAMP[423] INFO: monitor: foglamp.services.core.service_registry.monitor: Exception occurred
                     # during monitoring:
 
                     if "" != str(ex).strip():  # i.e. if a genuine exception occurred
@@ -161,6 +160,7 @@ class Monitor(object):
         self._restart_failed = config['restart_failed']['value']
 
     async def restart_service(self, service_record):
+        from foglamp.services.core import server  # To avoid cyclic import as server also imports monitor
         schedule = await server.Server.scheduler.get_schedule_by_name(service_record._name)
         await server.Server.scheduler.queue_task(schedule.schedule_id)
         self.restarted_services.remove(service_record._id)


### PR DESCRIPTION
The attempt to restart a failed microservice is controlled by a configuration key "restart_failed" which can be set to "manual" or "auto" mode. In "manual" mode, the service is never attempted to be restarted by the monitoring process. In "auto" mode, the monitoring process attempts to restart the microservice as soon as acquires "failed" state.

To test, please proceed as follows:
1. Start foglamp.
2. Install http-south plugin.
3. Confirm vide "curl -X GET http://localhost:8081/foglamp/service | jq" if http-south service is running.
4. Find HTTP_SOUTH processes by ps -ef | grep HTTP and kill those processes.
5. Again observe vide curl command that the status of the http-south service first changes to "unresponsive" and then to "failed".
6. It remains in "failed" state if "restart_failed" config is set to "manual", or
7. It remains in "failed" state for a few seconds and then changes to "running" state if "restart_failed" config is set to "auto". The restart of the service can also be confifmed by entries in syslog.

Test suite result:
`=================================================== 1137 passed, 33 skipped in 83.50 seconds ====================================================
`
