### PR TITLE
FOGL-1477 - Add API for discovery of available plugins

### DIFF
--- a/python/foglamp/common/common.py
+++ b/python/foglamp/common/common.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+"""Common definitions"""
+
+import os
+
+__author__ = "Amarendra K Sinha"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+_FOGLAMP_DATA = os.getenv("FOGLAMP_DATA", default=None)
+_FOGLAMP_ROOT = os.getenv("FOGLAMP_ROOT", default='/usr/local/foglamp')

--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -8,6 +8,7 @@
 
 import os
 from foglamp.common import logger
+from foglamp.common.common import _FOGLAMP_ROOT
 
 __author__ = "Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -16,9 +17,6 @@ __version__ = "${VERSION}"
 
 
 _logger = logger.setup(__name__)
-
-_FOGLAMP_DATA = os.getenv("FOGLAMP_DATA", default=None)
-_FOGLAMP_ROOT = os.getenv("FOGLAMP_ROOT", default='/usr/local/foglamp')
 
 
 class PluginDiscovery(object):

--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+"""Common Plugin Discovery Class"""
+
+import os
+from foglamp.common import logger
+
+__author__ = "Amarendra K Sinha"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+_logger = logger.setup(__name__)
+
+_FOGLAMP_DATA = os.getenv("FOGLAMP_DATA", default=None)
+_FOGLAMP_ROOT = os.getenv("FOGLAMP_ROOT", default='/usr/local/foglamp')
+
+class PluginDiscoveryInstalled(object):
+    @classmethod
+    def get_plugins(cls, plugin_type):
+        directories = cls.get_plugin_folders(plugin_type)
+        configs = []
+        for d in directories:
+            configs.append(cls.get_plugin_config(d, plugin_type))
+        return configs
+
+    @classmethod
+    def get_plugin_folders(cls, plugin_type):
+        directories = []
+        try:
+            directories = [d for d in os.listdir(_FOGLAMP_ROOT + "/python/foglamp/plugins/"+plugin_type)
+                           if os.path.isdir(_FOGLAMP_ROOT + "/python/foglamp/plugins/" + plugin_type + "/" + d) and
+                           not d.startswith("__") and d != "empty" and d != "common"]
+        except FileNotFoundError:
+            pass
+        return directories
+
+    @classmethod
+    def get_plugin_config(cls, plugin_name, plugin_type):
+        plugin_module_path = "foglamp.plugins.south" if plugin_type == 'south' else "foglamp.plugins.north"
+
+        # Now load the plugin to fetch its configuration
+        try:
+            # "plugin_module_path" is fixed by design. It is MANDATORY to keep the plugin in the exactly similar named
+            # folder, within the plugin_module_path.
+            import_file_name = "{path}.{dir}.{file}".format(path=plugin_module_path, dir=plugin_name, file=plugin_name)
+            _plugin = __import__(import_file_name, fromlist=[''])
+
+            # Fetch configuration from the configuration defined in the plugin
+            plugin_info = _plugin.plugin_info()
+            plugin_config =  {
+                'name': plugin_info['name'],
+                'type': plugin_info['type'],
+                'description': plugin_info['config']['plugin']['description'],
+                'version': plugin_info['version']
+            }
+        except ImportError as ex:
+            plugin_config = {
+                'name': plugin_name,
+                'description': 'Plugin "{}" import problem from path "{}". {}'.format(plugin_name, plugin_module_path, str(ex))
+            }
+        except Exception as ex:
+            plugin_config = {
+                'name': plugin_name,
+                'description': 'Plugin "{}" raised exception "{}" while fetching config'.format(plugin_name, str(ex))
+            }
+
+        return plugin_config

--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -38,7 +38,8 @@ class PluginDiscoveryInstalled(object):
                            not d.startswith("__") and d != "empty" and d != "common"]
         except FileNotFoundError:
             pass
-        return directories
+        else:
+            return directories
 
     @classmethod
     def get_plugin_config(cls, plugin_name, plugin_type):

--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -20,9 +20,25 @@ _logger = logger.setup(__name__)
 _FOGLAMP_DATA = os.getenv("FOGLAMP_DATA", default=None)
 _FOGLAMP_ROOT = os.getenv("FOGLAMP_ROOT", default='/usr/local/foglamp')
 
-class PluginDiscoveryInstalled(object):
+
+class PluginDiscovery(object):
+    def __init__(self):
+        pass
+
     @classmethod
-    def get_plugins(cls, plugin_type):
+    def get_plugins_installed(cls, plugin_type=None):
+        if plugin_type is None:
+            plugins_list = []
+            plugins_list_north = cls.fetch_plugins_installed("north")
+            plugins_list_south = cls.fetch_plugins_installed("south")
+            plugins_list.extend(plugins_list_north)
+            plugins_list.extend(plugins_list_south)
+        else:
+            plugins_list = cls.fetch_plugins_installed(plugin_type)
+        return plugins_list
+
+    @classmethod
+    def fetch_plugins_installed(cls, plugin_type):
         directories = cls.get_plugin_folders(plugin_type)
         configs = []
         for d in directories:
@@ -32,9 +48,9 @@ class PluginDiscoveryInstalled(object):
     @classmethod
     def get_plugin_folders(cls, plugin_type):
         directories = []
+        dir_name = _FOGLAMP_ROOT + "/python/foglamp/plugins/"+plugin_type
         try:
-            directories = [d for d in os.listdir(_FOGLAMP_ROOT + "/python/foglamp/plugins/"+plugin_type)
-                           if os.path.isdir(_FOGLAMP_ROOT + "/python/foglamp/plugins/" + plugin_type + "/" + d) and
+            directories = [d for d in os.listdir(dir_name) if os.path.isdir(dir_name + "/" + d) and
                            not d.startswith("__") and d != "empty" and d != "common"]
         except FileNotFoundError:
             pass

--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -24,13 +24,13 @@ async def get_plugins_installed(request):
     """ get list of installed plugins
 
     :Example:
-        curl -X GET http://localhost:8081 /foglamp/plugins/installed
-        curl -X GET http://localhost:8081 /foglamp/plugins/installed?type=north
+        curl -X GET http://localhost:8081/foglamp/plugins/installed
+        curl -X GET http://localhost:8081/foglamp/plugins/installed?type=north
     """
 
     plugin_type = None
     if 'type' in request.query and request.query['type'] != '':
-        plugin_type = request.query['type']
+        plugin_type = request.query['type'].lower()
 
     if plugin_type is not None and plugin_type not in ['north', 'south']:
         raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south'.")

--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -5,7 +5,7 @@
 # FOGLAMP_END
 
 from aiohttp import web
-from foglamp.common.plugin_discovery import PluginDiscoveryInstalled
+from foglamp.common.plugin_discovery import PluginDiscovery
 
 __author__ = "Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -35,13 +35,6 @@ async def get_plugins_installed(request):
     if plugin_type is not None and plugin_type not in ['north', 'south']:
         raise web.HTTPNotFound(reason="Invalid plugin type. Must be 'north' or 'south'.")
 
-    if plugin_type is None:
-        plugins_list = []
-        plugins_list_north = PluginDiscoveryInstalled.get_plugins("north")
-        plugins_list_south = PluginDiscoveryInstalled.get_plugins("south")
-        plugins_list.extend(plugins_list_north)
-        plugins_list.extend(plugins_list_south)
-    else:
-        plugins_list = PluginDiscoveryInstalled.get_plugins(plugin_type)
+    plugins_list = PluginDiscovery.get_plugins_installed(plugin_type)
 
     return web.json_response({"plugins": plugins_list})

--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -33,7 +33,7 @@ async def get_plugins_installed(request):
         plugin_type = request.query['type']
 
     if plugin_type is not None and plugin_type not in ['north', 'south']:
-        raise web.HTTPNotFound(reason="Invalid plugin type. Must be 'north' or 'south'.")
+        raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south'.")
 
     plugins_list = PluginDiscovery.get_plugins_installed(plugin_type)
 

--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+from aiohttp import web
+from foglamp.common.plugin_discovery import PluginDiscoveryInstalled
+
+__author__ = "Amarendra K Sinha"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+_help = """
+    -------------------------------------------------------------------------------
+    | GET             | /foglamp/plugins/installed                                |
+    -------------------------------------------------------------------------------
+"""
+
+
+async def get_plugins_installed(request):
+    """ get list of installed plugins
+
+    :Example:
+        curl -X GET http://localhost:8081 /foglamp/plugins/installed
+        curl -X GET http://localhost:8081 /foglamp/plugins/installed?type=north
+    """
+
+    plugin_type = None
+    if 'type' in request.query and request.query['type'] != '':
+        plugin_type = request.query['type']
+
+    if plugin_type is not None and plugin_type not in ['north', 'south']:
+        raise web.HTTPNotFound(reason="Invalid plugin type. Must be 'north' or 'south'.")
+
+    if plugin_type is None:
+        plugins_list = PluginDiscoveryInstalled.get_plugins("north")
+        plugins_list_south = PluginDiscoveryInstalled.get_plugins("south")
+        plugins_list.extend(plugins_list_south)
+    else:
+        plugins_list = PluginDiscoveryInstalled.get_plugins(plugin_type)
+
+    return web.json_response({"plugins": plugins_list})

--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -36,8 +36,10 @@ async def get_plugins_installed(request):
         raise web.HTTPNotFound(reason="Invalid plugin type. Must be 'north' or 'south'.")
 
     if plugin_type is None:
-        plugins_list = PluginDiscoveryInstalled.get_plugins("north")
+        plugins_list = []
+        plugins_list_north = PluginDiscoveryInstalled.get_plugins("north")
         plugins_list_south = PluginDiscoveryInstalled.get_plugins("south")
+        plugins_list.extend(plugins_list_north)
         plugins_list.extend(plugins_list_south)
     else:
         plugins_list = PluginDiscoveryInstalled.get_plugins(plugin_type)

--- a/python/foglamp/services/core/routes.py
+++ b/python/foglamp/services/core/routes.py
@@ -16,6 +16,7 @@ from foglamp.services.core.api import update
 from foglamp.services.core.api import service
 from foglamp.services.core.api import certificate_store
 from foglamp.services.core.api import support
+from foglamp.services.core.api import plugin_discovery
 
 __author__ = "Ashish Jabble, Praveen Garg, Massimiliano Pinto"
 __copyright__ = "Copyright (c) 2017-2018 OSIsoft, LLC"
@@ -118,6 +119,9 @@ def setup(app):
 
     # Get Syslog
     app.router.add_route('GET', '/foglamp/syslog', support.get_syslog_entries)
+
+    # Get Plugin
+    app.router.add_route('GET', '/foglamp/plugins/installed', plugin_discovery.get_plugins_installed)
 
     # enable cors support
     enable_cors(app)

--- a/tests/unit/python/foglamp/common/test_plugin_discovery.py
+++ b/tests/unit/python/foglamp/common/test_plugin_discovery.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+import asyncio
+import json
+import os
+import copy
+from unittest.mock import Mock, patch
+import pytest
+import builtins
+from foglamp.common.plugin_discovery import PluginDiscovery
+
+
+__author__ = "Amarendra K Sinha"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("common", "plugin-discovery")
+class TestPluginDiscovery:
+    mock_north_folders = ["OMF", "foglamp-north"]
+    mock_south_folders = ["modbus", "http"]
+    mock_all_folders = ["OMF", "foglamp-north", "modbus", "http"]
+    mock_plugins_config = [
+        {
+            "name": "OMF",
+            "type": "north",
+            "description": "OMF to PI connector relay",
+            "version": "1.2"
+        },
+        {
+            "name": "foglamp-north",
+            "type": "north",
+            "description": "Northbound FogLAMP aggregator",
+            "version": "1.0"
+        },
+        {
+            "name": "modbus",
+            "type": "south",
+            "description": "Modbus RTU plugin",
+            "version": "1.1"
+        },
+        {
+            "name": "http",
+            "type": "south",
+            "description": "HTTP request plugin",
+            "version": "1.4"
+        }
+    ]
+    mock_plugins_north_config = [
+        {
+            "name": "OMF",
+            "type": "north",
+            "description": "OMF to PI connector relay",
+            "version": "1.2"
+        },
+        {
+            "name": "foglamp-north",
+            "type": "north",
+            "description": "Northbound FogLAMP aggregator",
+            "version": "1.0"
+        }
+    ]
+    mock_plugins_south_config = [
+        {
+            "name": "modbus",
+            "type": "south",
+            "description": "Modbus RTU plugin",
+            "version": "1.1"
+        },
+        {
+            "name": "http",
+            "type": "south",
+            "description": "HTTP request plugin",
+            "version": "1.4"
+        }
+    ]
+
+    def test_get_plugins_installed_type_none(self, mocker):
+        @asyncio.coroutine
+        def mock_folders():
+            yield TestPluginDiscovery.mock_north_folders
+            yield TestPluginDiscovery.mock_south_folders
+
+        mock_get_folders = mocker.patch.object(PluginDiscovery, "get_plugin_folders", return_value = next(mock_folders()))
+        mock_get_plugin_config = mocker.patch.object(PluginDiscovery, "get_plugin_config", side_effect= TestPluginDiscovery.mock_plugins_config)
+
+        plugins = PluginDiscovery.get_plugins_installed()
+        assert TestPluginDiscovery.mock_plugins_config == plugins
+        assert 2 == mock_get_folders.call_count
+        assert 4 == mock_get_plugin_config.call_count
+
+    def test_get_plugins_installed_type_north(self, mocker):
+        @asyncio.coroutine
+        def mock_folders():
+            yield TestPluginDiscovery.mock_north_folders
+
+        mock_get_folders = mocker.patch.object(PluginDiscovery, "get_plugin_folders", return_value = next(mock_folders()))
+        mock_get_plugin_config = mocker.patch.object(PluginDiscovery, "get_plugin_config", side_effect= TestPluginDiscovery.mock_plugins_north_config)
+
+        plugins = PluginDiscovery.get_plugins_installed("north")
+        assert TestPluginDiscovery.mock_plugins_north_config == plugins
+        assert 1 == mock_get_folders.call_count
+        assert 2 == mock_get_plugin_config.call_count
+
+    def test_get_plugins_installed_type_south(self, mocker):
+        @asyncio.coroutine
+        def mock_folders():
+            yield TestPluginDiscovery.mock_south_folders
+
+        mock_get_folders = mocker.patch.object(PluginDiscovery, "get_plugin_folders", return_value = next(mock_folders()))
+        mock_get_plugin_config = mocker.patch.object(PluginDiscovery, "get_plugin_config", side_effect= TestPluginDiscovery.mock_plugins_south_config)
+
+        plugins = PluginDiscovery.get_plugins_installed("south")
+        assert TestPluginDiscovery.mock_plugins_south_config == plugins
+        assert 1 == mock_get_folders.call_count
+        assert 2 == mock_get_plugin_config.call_count
+
+    def test_fetch_plugins_installed(self, mocker):
+        @asyncio.coroutine
+        def mock_folders():
+            yield TestPluginDiscovery.mock_north_folders
+
+        mock_get_folders = mocker.patch.object(PluginDiscovery, "get_plugin_folders", return_value = next(mock_folders()))
+        mock_get_plugin_config = mocker.patch.object(PluginDiscovery, "get_plugin_config", side_effect= TestPluginDiscovery.mock_plugins_north_config)
+
+        plugins = PluginDiscovery.fetch_plugins_installed("north")
+        assert TestPluginDiscovery.mock_plugins_north_config == plugins
+        assert 1 == mock_get_folders.call_count
+        assert 2 == mock_get_plugin_config.call_count
+
+    def test_get_plugin_folders(self, mocker):
+        @asyncio.coroutine
+        def mock_folders():
+            listdir = copy.deepcopy(TestPluginDiscovery.mock_north_folders)
+            listdir.extend(["__init__", "empty", "common"])
+            yield listdir
+
+        mock_os_listdir = mocker.patch.object(os, "listdir", return_value = next(mock_folders()))
+        mock_os_isdir = mocker.patch.object(os.path, "isdir", return_value = True)
+
+        plugin_folders = PluginDiscovery.get_plugin_folders("north")
+        assert TestPluginDiscovery.mock_north_folders == plugin_folders
+
+    @pytest.mark.skip(reason="Investigate why getting error- TypeError: 'Mock' object does not support indexing")
+    def test_get_plugin_config(self, mocker):
+        _CONFIG_DEFAULT = {
+            'plugin': {
+                'description': "Modbus RTU plugin",
+                'type': 'string',
+                'default': 'modbus'
+            }
+        }
+
+        def mock_plugin_info():
+            return {
+                'name': "modbus",
+                'version': "1.1",
+                'type': "south",
+                'interface': "1.0",
+                'config': _CONFIG_DEFAULT
+            }
+        mock = Mock()
+        attrs = {"plugin_info.return_value": mock_plugin_info()}
+        mock.configure_mock(**attrs)
+        mock_import = mocker.patch.object(builtins, "__import__", mock)
+        plugin_config = PluginDiscovery.get_plugin_config("modbus", "south")
+        assert TestPluginDiscovery.mock_plugins_config[0] == plugin_config

--- a/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+import pytest
+from aiohttp import web
+from foglamp.services.core import routes
+from foglamp.common.plugin_discovery import PluginDiscovery
+
+
+__author__ = "Amarendra K Sinha"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("api", "plugin-discovery")
+class TestPluginDiscoveryApi:
+    mock_north_folders = ["OMF", "foglamp-north"]
+    mock_south_folders = ["modbus", "http"]
+    mock_all_folders = ["OMF", "foglamp-north", "modbus", "http"]
+    mock_plugins_config = [
+        {
+            "name": "OMF",
+            "type": "north",
+            "description": "OMF to PI connector relay",
+            "version": "1.2"
+        },
+        {
+            "name": "foglamp-north",
+            "type": "north",
+            "description": "Northbound FogLAMP aggregator",
+            "version": "1.0"
+        },
+        {
+            "name": "modbus",
+            "type": "south",
+            "description": "Modbus RTU plugin",
+            "version": "1.1"
+        },
+        {
+            "name": "http",
+            "type": "south",
+            "description": "HTTP request plugin",
+            "version": "1.4"
+        }
+    ]
+    mock_plugins_north_config = [
+        {
+            "name": "OMF",
+            "type": "north",
+            "description": "OMF to PI connector relay",
+            "version": "1.2"
+        },
+        {
+            "name": "foglamp-north",
+            "type": "north",
+            "description": "Northbound FogLAMP aggregator",
+            "version": "1.0"
+        }
+    ]
+    mock_plugins_south_config = [
+        {
+            "name": "modbus",
+            "type": "south",
+            "description": "Modbus RTU plugin",
+            "version": "1.1"
+        },
+        {
+            "name": "http",
+            "type": "south",
+            "description": "HTTP request plugin",
+            "version": "1.4"
+        }
+    ]
+    mock_north_plugins = {
+        "plugins": [
+            {
+                "name": "OMF",
+                "type": "north",
+                "description": "OMF to PI connector relay",
+                "version": "1.2"
+            },
+            {
+                "name": "foglamp-north",
+                "type": "north",
+                "description": "Northbound FogLAMP aggregator",
+                "version": "1.0"
+            }
+        ]
+    }
+    mock_south_plugins = {
+        "plugins": [
+            {
+                "name": "modbus",
+                "type": "south",
+                "description": "Modbus RTU plugin",
+                "version": "1.1"
+            },
+            {
+                "name": "http",
+                "type": "south",
+                "description": "HTTP request plugin",
+                "version": "1.4"
+            }
+        ]
+    }
+    mock_all_plugins = {
+        "plugins": [
+            {
+                "name": "OMF",
+                "type": "north",
+                "description": "OMF to PI connector relay",
+                "version": "1.2"
+            },
+            {
+                "name": "foglamp-north",
+                "type": "north",
+                "description": "Northbound FogLAMP aggregator",
+                "version": "1.0"
+            },
+            {
+                "name": "modbus",
+                "type": "south",
+                "description": "Modbus RTU plugin",
+                "version": "1.1"
+            },
+            {
+                "name": "http",
+                "type": "south",
+                "description": "HTTP request plugin",
+                "version": "1.4"
+            }
+        ]
+    }
+
+    @pytest.fixture
+    def client(self, loop, test_client):
+        app = web.Application(loop=loop)
+        # fill the routes table
+        routes.setup(app)
+        return loop.run_until_complete(test_client(app))
+
+    async def test_get_plugins_installed(self, client, mocker):
+        @asyncio.coroutine
+        def mock_folders():
+            yield TestPluginDiscoveryApi.mock_north_folders
+            yield TestPluginDiscoveryApi.mock_south_folders
+
+        mock_get_folders = mocker.patch.object(PluginDiscovery, "get_plugin_folders", return_value = next(mock_folders()))
+        mock_get_plugin_config = mocker.patch.object(PluginDiscovery, "get_plugin_config", side_effect= TestPluginDiscoveryApi.mock_plugins_config)
+
+        resp = await client.get('/foglamp/plugins/installed')
+        assert 200 == resp.status
+        res = await resp.json()
+
+        assert TestPluginDiscoveryApi.mock_all_plugins == res
+
+    async def test_get_plugins_installed_north(self, client, mocker):
+        @asyncio.coroutine
+        def mock_folders():
+            yield TestPluginDiscoveryApi.mock_north_folders
+
+        mock_get_folders = mocker.patch.object(PluginDiscovery, "get_plugin_folders", return_value = next(mock_folders()))
+        mock_get_plugin_config = mocker.patch.object(PluginDiscovery, "get_plugin_config", side_effect= TestPluginDiscoveryApi.mock_plugins_north_config)
+
+        resp = await client.get("/foglamp/plugins/installed?type=north")
+        assert 200 == resp.status
+        res = await resp.json()
+
+        assert TestPluginDiscoveryApi.mock_north_plugins == res
+
+    async def test_get_plugins_installed_south(self, client, mocker):
+        @asyncio.coroutine
+        def mock_folders():
+            yield TestPluginDiscoveryApi.mock_south_folders
+
+        mock_get_folders = mocker.patch.object(PluginDiscovery, "get_plugin_folders", return_value = next(mock_folders()))
+        mock_get_plugin_config = mocker.patch.object(PluginDiscovery, "get_plugin_config", side_effect= TestPluginDiscoveryApi.mock_plugins_south_config)
+
+        resp = await client.get("/foglamp/plugins/installed?type=south")
+        assert 200 == resp.status
+        res = await resp.json()
+
+        assert TestPluginDiscoveryApi.mock_south_plugins == res
+
+    # TODO: Add negative tests after __import__ mocking is resolved.


### PR DESCRIPTION
My local machine contains a few empty plugin folder. So **curl -X GET http://localhost:8081/foglamp/plugins/installed?type=south | jq** gives:
```
{
  "plugins": [
    {
      "name": "Simple Data Simulator Async plugin",
      "description": "Simple Simulator async plugin",
      "version": "1.0",
      "type": "south"
    },
    {
      "name": "http_south",
      "description": "HTTP South Plugin",
      "version": "1.0",
      "type": "south"
    }
  ]
}
```

and **curl -X GET http://localhost:8081/foglamp/plugins/installed | jq** gives:
```
{
  "plugins": [
    {
      "name": "OMF North",
      "description": "OMF North Plugin",
      "version": "1.0.0",
      "type": "north"
    },
    {
      "name": "OCS North",
      "description": "OCS North Plugin",
      "version": "1.0.0",
      "type": "north"
    },
    {
      "name": "Simple Data Simulator Async plugin",
      "description": "Simple Simulator async plugin",
      "version": "1.0",
      "type": "south"
    },
    {
      "name": "http_south",
      "description": "HTTP South Plugin",
      "version": "1.0",
      "type": "south"
    }
  ]
}

```

However, I find a few tests failing as below:
======================================= 15 failed, 1131 passed, 33 skipped, 103 warnings in 83.21 seconds =======================================
`
All tests are failing with identical reason, after upgrading to aiohttp 3.2.1, as below:
```
/home/asinha/Development/FogLAMP/tests/unit/python/foglamp/common/web/test_middleware.py:49: RuntimeWarning: coroutine 'BaseTestServer.start_server' was never awaited
    server.start_server(loop=loop)
```