### PR TITLE
Fogl-572 - Verification of data type value in configuration manager

### DIFF
--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -145,13 +145,11 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 # If Entry item exists in optional list, then update expected item entries
                 if entry_name in optional_item_entries:
                     if entry_name == 'readonly':
-                        if entry_val.lower() not in ("true", "false"):
-                            raise ValueError('Unrecognized value for entry_name {}'.format(entry_name))
+                        if self._validate_type_value('boolean', entry_val) is False:
+                            raise ValueError('Unrecognized value for item_name {}'.format(entry_name))
                     else:
-                        try:
-                            _value = int(entry_val)
-                        except Exception:
-                            raise ValueError('Unrecognized value for entry_name {}'.format(entry_name))
+                        if self._validate_type_value('integer', entry_val) is False:
+                            raise ValueError('Unrecognized value for item_name {}'.format(entry_name))
 
                     d = {entry_name: entry_val}
                     expected_item_entries.update(d)
@@ -176,9 +174,12 @@ class ConfigurationManager(ConfigurationManagerSingleton):
             if set_value_val_from_default_val:
                 if self._validate_type_value(get_entry_val("type"), get_entry_val("default")) is False:
                     raise ValueError('Unrecognized value for item_name {}'.format(item_name))
+                if 'readonly' in item_val:
+                    item_val['readonly'] = self._clean('boolean',  item_val['readonly'])
+
                 item_val['default'] = self._clean(item_val['type'], item_val['default'])
                 item_val['value'] = item_val['default']
-
+       
         return category_val_copy
 
     async def _create_new_category(self, category_name, category_val, category_description):

--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -124,17 +124,23 @@ class ConfigurationManager(ConfigurationManagerSingleton):
             if type(item_val) is not dict:
                 raise TypeError('item_value must be a dict for item_name {}'.format(item_name))
 
-            optional_item_entries = {'readonly': "false", 'order': 0, 'length': 0, 'maximum': 0, 'minimum': 0}
+            optional_item_entries = {'readonly': 0, 'order': 0, 'length': 0, 'maximum': 0, 'minimum': 0}
             expected_item_entries = {'description': 0, 'default': 0, 'type': 0}
 
             if require_entry_value:
                 expected_item_entries['value'] = 0
+
+            def get_entry_val(k):
+                v = [val for name, val in item_val.items() if name == k]
+                return v[0]
+
             for entry_name, entry_val in item_val.items():
                 if type(entry_name) is not str:
                     raise TypeError('entry_name must be a string for item_name {}'.format(item_name))
                 if type(entry_val) is not str:
                     raise TypeError(
                         'entry_val must be a string for item_name {} and entry_name {}'.format(item_name, entry_name))
+
                 # If Entry item exists in optional list, then update expected item entries
                 if entry_name in optional_item_entries:
                     d = {entry_name: entry_val}
@@ -156,7 +162,11 @@ class ConfigurationManager(ConfigurationManagerSingleton):
             for needed_key, needed_value in expected_item_entries.items():
                 if needed_value == 0:
                     raise ValueError('Missing entry_name {} for item_name {}'.format(needed_key, item_name))
+
             if set_value_val_from_default_val:
+                if self._validate_type_value(get_entry_val("type"), get_entry_val("default")) is False:
+                    raise ValueError('Unrecognized value name for item_name {}'.format(item_name))
+                item_val['default'] = self._clean(item_val['type'], item_val['default'])
                 item_val['value'] = item_val['default']
 
         return category_val_copy
@@ -344,14 +354,20 @@ class ConfigurationManager(ConfigurationManagerSingleton):
         None
         """
         try:
-            # get storage_value_entry and compare against new_value_value, update if different
-            storage_value_entry = await self._read_value_val(category_name, item_name)
+            # get storage_value_entry and compare against new_value_value with its type, update if different
+            storage_value_entry = await self._read_item_val(category_name, item_name)
             # check for category_name and item_name combination existence in storage
             if storage_value_entry is None:
                 raise ValueError("No detail found for the category_name: {} and item_name: {}"
                                  .format(category_name, item_name))
             if storage_value_entry == new_value_entry:
                 return
+
+            if self._validate_type_value(storage_value_entry['type'], new_value_entry) is False:
+                raise TypeError('Unrecognized value name for item_name {}'.format(item_name))
+
+            new_value_entry = self._clean(storage_value_entry['type'], new_value_entry)
+            # TODO: FOGL-985 - it will break in case of JSON object
             await self._update_value_val(category_name, item_name, new_value_entry)
         except:
             _logger.exception(
@@ -695,3 +711,56 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 self._registered_interests[category_name].discard(callback)
                 if len(self._registered_interests[category_name]) == 0:
                     del self._registered_interests[category_name]
+
+    def _validate_type_value(self, _type, _value):
+        def _str_to_bool(item_val):
+            return item_val.lower() in ("true", "false")
+
+        def _str_to_int(item_val):
+            try:
+                _value = int(item_val)
+            except ValueError:
+                return False
+
+            return True
+
+        def _str_to_ipaddress(item_val):
+            import ipaddress
+            try:
+                ipaddress.ip_address(item_val)
+            except ValueError:
+                return False
+
+        def _str_to_json(item_val):
+            if _str_to_bool(item_val) or _str_to_int(item_val) or _str_to_ipaddress(
+                    item_val) or _str_to_password(item_val) or _str_to_x509cert(item_val):
+                return False
+            try:
+                json.loads(item_val)
+                return True
+            except Exception:
+                return False
+
+        def _str_to_password(v):
+            # TODO:
+            pass
+
+        def _str_to_x509cert(v):
+            # TODO:
+            pass
+
+        if _type == 'boolean':
+            return _str_to_bool(_value)
+        elif _type == 'integer':
+            return _str_to_int(_value)
+        elif _type == 'JSON':
+            return _str_to_json(_value)
+        elif _type == 'IPv4' or _type == 'IPv6':
+            return _str_to_ipaddress(_value)
+
+    def _clean(self, item_type, item_val):
+        if item_type == 'boolean':
+            return item_val.lower()
+        if item_type == 'JSON':
+            return json.dumps(json.loads(item_val))
+        return item_val

--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -8,6 +8,7 @@ from importlib import import_module
 import copy
 import json
 import inspect
+import ipaddress
 
 from foglamp.common.storage_client.payload_builder import PayloadBuilder
 from foglamp.common.storage_client.storage_client import StorageClientAsync
@@ -721,13 +722,12 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 _value = int(item_val)
             except ValueError:
                 return False
-
-            return True
+            else:
+                return True
 
         def _str_to_ipaddress(item_val):
-            import ipaddress
             try:
-                ipaddress.ip_address(item_val)
+                return ipaddress.ip_address(item_val)
             except ValueError:
                 return False
 
@@ -737,9 +737,10 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 return False
             try:
                 json.loads(item_val)
-                return True
             except Exception:
                 return False
+            else:
+                return True
 
         def _str_to_password(v):
             # TODO:

--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -144,6 +144,15 @@ class ConfigurationManager(ConfigurationManagerSingleton):
 
                 # If Entry item exists in optional list, then update expected item entries
                 if entry_name in optional_item_entries:
+                    if entry_name == 'readonly':
+                        if entry_val.lower() not in ("true", "false"):
+                            raise ValueError('Unrecognized value for entry_name {}'.format(entry_name))
+                    else:
+                        try:
+                            _value = int(entry_val)
+                        except Exception:
+                            raise ValueError('Unrecognized value for entry_name {}'.format(entry_name))
+
                     d = {entry_name: entry_val}
                     expected_item_entries.update(d)
 
@@ -166,7 +175,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
 
             if set_value_val_from_default_val:
                 if self._validate_type_value(get_entry_val("type"), get_entry_val("default")) is False:
-                    raise ValueError('Unrecognized value name for item_name {}'.format(item_name))
+                    raise ValueError('Unrecognized value for item_name {}'.format(item_name))
                 item_val['default'] = self._clean(item_val['type'], item_val['default'])
                 item_val['value'] = item_val['default']
 

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -184,6 +184,8 @@ async def set_configuration_item(request):
         await cf_mgr.set_category_item_value_entry(category_name, config_item, value)
     except ValueError:
         raise web.HTTPNotFound(reason="No detail found for the category_name: {} and config_item: {}".format(category_name, config_item))
+    except TypeError as ex:
+        raise web.HTTPBadRequest(reason=str(ex))
 
     result = await cf_mgr.get_category_item(category_name, config_item)
     if result is None:


### PR DESCRIPTION
Fixed items:

- [x] Verification for data type has been implemented for fields ['boolean', 'integer', 'string', 'IPv4', 'IPv6']
- [x] unit tests fixed and added as per new changes in

- [ ] For fields like 'X509 certificate', 'password' - pass (As I do not see any references in project, Kindly advise what to do for these)

- [ ] For  'JSON', its blocked by https://scaledb.atlassian.net/browse/FOGL-985