### PR TITLE
FOGL-1487 - Create a addScheduledTask REST entry point that is similar to addService

### DIFF
--- a/python/foglamp/common/utils.py
+++ b/python/foglamp/common/utils.py
@@ -6,7 +6,6 @@
 
 """Common utilities"""
 
-from foglamp.common.storage_client.payload_builder import PayloadBuilder
 
 __author__ = "Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"

--- a/python/foglamp/common/utils.py
+++ b/python/foglamp/common/utils.py
@@ -35,25 +35,3 @@ def check_reserved(string):
         if s in reserved:
             return False
     return True
-
-
-async def check_scheduled_processes(storage, process_name):
-    payload = PayloadBuilder().SELECT("name").WHERE(['name', '=', process_name]).payload()
-    result = await storage.query_tbl_with_payload('scheduled_processes', payload)
-    return result['count']
-
-
-async def check_schedules(storage, schedule_name):
-    payload = PayloadBuilder().SELECT("schedule_name").WHERE(['schedule_name', '=', schedule_name]).payload()
-    result = await storage.query_tbl_with_payload('schedules', payload)
-    return result['count']
-
-
-async def revert_scheduled_processes(storage, process_name):
-    payload = PayloadBuilder().WHERE(['name', '=', process_name]).payload()
-    await storage.delete_from_tbl('scheduled_processes', payload)
-
-
-async def revert_configuration(storage, key):
-    payload = PayloadBuilder().WHERE(['key', '=', key]).payload()
-    await storage.delete_from_tbl('configuration', payload)

--- a/python/foglamp/common/utils.py
+++ b/python/foglamp/common/utils.py
@@ -6,6 +6,7 @@
 
 """Common utilities"""
 
+from foglamp.common.storage_client.payload_builder import PayloadBuilder
 
 __author__ = "Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -34,3 +35,25 @@ def check_reserved(string):
         if s in reserved:
             return False
     return True
+
+
+async def check_scheduled_processes(storage, process_name):
+    payload = PayloadBuilder().SELECT("name").WHERE(['name', '=', process_name]).payload()
+    result = await storage.query_tbl_with_payload('scheduled_processes', payload)
+    return result['count']
+
+
+async def check_schedules(storage, schedule_name):
+    payload = PayloadBuilder().SELECT("schedule_name").WHERE(['schedule_name', '=', schedule_name]).payload()
+    result = await storage.query_tbl_with_payload('schedules', payload)
+    return result['count']
+
+
+async def revert_scheduled_processes(storage, process_name):
+    payload = PayloadBuilder().WHERE(['name', '=', process_name]).payload()
+    await storage.delete_from_tbl('scheduled_processes', payload)
+
+
+async def revert_configuration(storage, key):
+    payload = PayloadBuilder().WHERE(['key', '=', key]).payload()
+    await storage.delete_from_tbl('configuration', payload)

--- a/python/foglamp/services/core/api/task.py
+++ b/python/foglamp/services/core/api/task.py
@@ -111,16 +111,16 @@ async def add_task(request):
         if schedule_type == Schedule.Type.TIMED:
             if not schedule_time:
                 raise web.HTTPBadRequest(reason='schedule_time cannot be empty/None for TIMED schedule.')
-            if schedule_day is not None and (not (schedule_day < 1 or schedule_day > 7)):
-                raise web.HTTPBadRequest(reason='schedule_day must either be None or must be an integer, 1(Monday) to 7(Sunday).')
+            if schedule_day is not None and (schedule_day < 1 or schedule_day > 7):
+                raise web.HTTPBadRequest(reason='schedule_day {} must either be None or must be an integer, 1(Monday) to 7(Sunday).'.format(schedule_day))
             if schedule_time < 0 or schedule_time > 86399:
-                raise web.HTTPBadRequest(reason='schedule_time must be an integer and in range 0-86399.')
+                raise web.HTTPBadRequest(reason='schedule_time {} must be an integer and in range 0-86399.'.format(schedule_time))
 
         if schedule_type == Schedule.Type.INTERVAL:
             if schedule_repeat is None:
-                raise web.HTTPBadRequest(reason='schedule_repeat is required for INTERVAL schedule_type.')
+                raise web.HTTPBadRequest(reason='schedule_repeat {} is required for INTERVAL schedule_type.'.format(schedule_repeat))
             elif not isinstance(schedule_repeat, int):
-                raise web.HTTPBadRequest(reason='schedule_repeat must be an integer.')
+                raise web.HTTPBadRequest(reason='schedule_repeat {} must be an integer.'.format(schedule_repeat))
 
         if enabled is not None:
             if enabled not in ['t', 'f', 'true', 'false', 0, 1]:

--- a/python/foglamp/services/core/api/task.py
+++ b/python/foglamp/services/core/api/task.py
@@ -193,7 +193,7 @@ async def add_task(request):
             m, s = divmod(schedule_time if schedule_time is not None else 0, 60)
             h, m = divmod(m, 60)
             schedule.time = datetime.time().replace(hour=h, minute=m, second=s)
-            schedule.repeat = datetime.timedelta(schedule_repeat if schedule_repeat is not None else 0)
+            schedule.repeat = datetime.timedelta(seconds=schedule_repeat if schedule_repeat is not None else 0)
             schedule.exclusive = True
             schedule.enabled = False  # if "enabled" is supplied, it gets activated in save_schedule() via is_enabled flag
 

--- a/python/foglamp/services/core/routes.py
+++ b/python/foglamp/services/core/routes.py
@@ -17,6 +17,7 @@ from foglamp.services.core.api import service
 from foglamp.services.core.api import certificate_store
 from foglamp.services.core.api import support
 from foglamp.services.core.api import plugin_discovery
+from foglamp.services.core.api import task
 
 __author__ = "Ashish Jabble, Praveen Garg, Massimiliano Pinto"
 __copyright__ = "Copyright (c) 2017-2018 OSIsoft, LLC"
@@ -122,6 +123,9 @@ def setup(app):
 
     # Get Plugin
     app.router.add_route('GET', '/foglamp/plugins/installed', plugin_discovery.get_plugins_installed)
+
+    # Task
+    app.router.add_route('POST', '/foglamp/scheduled/task', task.add_task)
 
     # enable cors support
     enable_cors(app)

--- a/python/foglamp/tasks/north/sending_process.py
+++ b/python/foglamp/tasks/north/sending_process.py
@@ -1135,7 +1135,7 @@ class SendingProcess:
             is_valid_stream = await self._is_stream_id_valid(stream_id)
             if is_valid_stream:
                 # config from sending process
-                self._retrieve_configuration(stream_id, cat_keep_original=True)
+                self._retrieve_configuration(stream_id, cat_name=self._mgt_name, cat_keep_original=True)
                 exec_sending_process = self._config['enable']
                 if self._config['enable']:
                     self._plugin_load()
@@ -1148,7 +1148,7 @@ class SendingProcess:
                     if self._is_north_valid():
                         try:
                             # config from plugin
-                            self._retrieve_configuration(stream_id, cat_config=self._plugin_info['config'], cat_keep_original=True)
+                            self._retrieve_configuration(stream_id, cat_name=self._mgt_name, cat_config=self._plugin_info['config'], cat_keep_original=True)
                             data = self._config_from_manager
                             data.update({'sending_process_instance': self})
                             self._plugin_handle = self._plugin.plugin_init(data)

--- a/tests/unit/python/foglamp/services/core/api/test_task.py
+++ b/tests/unit/python/foglamp/services/core/api/test_task.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+
+import builtins
+import asyncio
+import json
+from aiohttp import web
+import pytest
+from unittest.mock import MagicMock, patch
+from foglamp.services.core import routes
+from foglamp.services.core import connect
+from foglamp.common.storage_client.storage_client import StorageClientAsync
+from foglamp.services.core.service_registry.service_registry import ServiceRegistry
+from foglamp.services.core.interest_registry.interest_registry import InterestRegistry
+from foglamp.services.core import server
+from foglamp.services.core.scheduler.scheduler import Scheduler
+from foglamp.services.core.scheduler.entities import Schedule, TimedSchedule, TimedSchedule, \
+    IntervalSchedule, ManualSchedule
+from foglamp.common.configuration_manager import ConfigurationManager
+
+__author__ = "Amarendra K Sinha"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.allure.feature("unit")
+@pytest.allure.story("api", "task")
+class TestService:
+    def setup_method(self):
+        ServiceRegistry._registry = list()
+
+    def teardown_method(self):
+        ServiceRegistry._registry = list()
+
+    @pytest.fixture
+    def client(self, loop, test_client):
+        app = web.Application(loop=loop)
+        # fill the routes table
+        routes.setup(app)
+        return loop.run_until_complete(test_client(app))
+
+    @pytest.mark.parametrize("payload, code, message", [
+        ("blah", 404, "Data payload must be a dictionary"),
+        ({}, 400, 'Missing name property in payload.'),
+        ({"name": "test"}, 400, "Missing plugin property in payload."),
+        ({"name": "test", "plugin": "omf"}, 400, 'Schedule Type is mandatory'),
+        ({"name": "test", "plugin": "omf", "type": 3}, 400, 'Repeat is required for INTERVAL Schedule type.')
+    ])
+    async def test_add_task_with_bad_params(self, client, code, payload, message):
+        resp = await client.post('/foglamp/scheduled/task', data=json.dumps(payload))
+        assert code == resp.status
+        assert message == resp.reason
+
+    async def test_dupe_process_name_add_task(self, client):
+        data = {"name": "north bound", "type": 3, "plugin": "omf", "repeat": 30}
+        async def async_mock():
+            expected = {'count': 1, 'rows': [{'name': 'north bound'}]}
+            return expected
+
+        storage_client_mock = MagicMock(StorageClientAsync)
+        with patch('builtins.__import__', side_effect=MagicMock()):
+            with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+                with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=async_mock()) as query_table_patch:
+                    resp = await client.post('/foglamp/scheduled/task', data=json.dumps(data))
+                    assert 400 == resp.status
+                    assert 'A task with that name already exists' == resp.reason
+                args, kwargs = query_table_patch.call_args
+                assert 'scheduled_processes' == args[0]
+                p = json.loads(args[1])
+                assert {"return": ["name"], "where": {"column": "name", "condition": "=", "value": "north bound"}} == p
+
+    async def test_insert_scheduled_process_exception_add_task(self, client):
+        data = {"name": "north bound", "type": 3, "plugin": "omf", "repeat": 30}
+
+        @asyncio.coroutine
+        def async_mock():
+            expected = {'count': 0, 'rows': []}
+            return expected
+
+        storage_client_mock = MagicMock(StorageClientAsync)
+        with patch('builtins.__import__', side_effect=MagicMock()):
+            with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+                with patch.object(storage_client_mock, 'query_tbl_with_payload', return_value=async_mock()) as query_table_patch:
+                    with patch.object(storage_client_mock, 'insert_into_tbl', side_effect=Exception()) as insert_table_patch:
+                        resp = await client.post('/foglamp/scheduled/task', data=json.dumps(data))
+                        assert 500 == resp.status
+                        assert 'Internal Server Error' == resp.reason
+                    # args, kwargs = insert_table_patch.call_args
+                    # assert 'scheduled_processes' == args[0]
+                    # p1 = json.loads(args[1])
+                    # assert {'name': 'north bound', 'script': '["services/north"]'} == p1
+                args1, kwargs1 = query_table_patch.call_args
+                assert 'schedules' == args1[0]
+                p2 = json.loads(args1[1])
+                assert {'return': ['schedule_name'], 'where': {'column': 'schedule_name', 'condition': '=', 'value': 'north bound'}} == p2
+
+    async def test_dupe_schedule_name_add_task(self, client):
+        def q_result(*arg):
+            table = arg[0]
+            payload = arg[1]
+
+            if table == 'scheduled_processes':
+                assert {'return': ['name'], 'where': {'column': 'name', 'condition': '=', 'value': 'north bound'}} == json.loads(payload)
+                return {'count': 0, 'rows': []}
+            if table == 'schedules':
+                assert {'return': ['schedule_name'], 'where': {'column': 'schedule_name', 'condition': '=', 'value': 'north bound'}} == json.loads(payload)
+                return {'count': 1, 'rows': [{'schedule_name': 'schedule_name'}]}
+
+        @asyncio.coroutine
+        def async_mock():
+            expected = {'rows_affected': 1, "response": "inserted"}
+            return expected
+
+        data = {"name": "north bound", "plugin": "omf", "type": 3, "repeat": 30}
+        description = '{} service configuration'.format(data['name'])
+        storage_client_mock = MagicMock(StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        val = {'plugin': {'default': data['plugin'], 'description': 'Python module name of the plugin to load', 'type': 'string'}}
+        with patch('builtins.__import__', side_effect=MagicMock()):
+            with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+                with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=q_result):
+                    with patch.object(storage_client_mock, 'insert_into_tbl', return_value=async_mock()) as insert_table_patch:
+                        with patch.object(c_mgr, 'create_category', return_value=None) as patch_create_cat:
+                            resp = await client.post('/foglamp/scheduled/task', data=json.dumps(data))
+                            assert 500 == resp.status
+                            assert 'Internal Server Error' == resp.reason
+                        assert 0 == patch_create_cat.call_count
+
+    async def test_add_task(self, client):
+        async def async_mock(return_value):
+            return return_value
+
+        async def async_mock_get_schedule():
+            schedule = TimedSchedule()
+            schedule.schedule_id = '2129cc95-c841-441a-ad39-6469a87dbc8b'
+            return schedule
+
+        @asyncio.coroutine
+        def q_result(*arg):
+            table = arg[0]
+            payload = arg[1]
+
+            if table == 'scheduled_processes':
+                assert {'return': ['name'], 'where': {'column': 'name', 'condition': '=', 'value': 'north bound'}} == json.loads(payload)
+                return {'count': 0, 'rows': []}
+            if table == 'schedules':
+                assert {'return': ['schedule_name'], 'where': {'column': 'schedule_name', 'condition': '=', 'value': 'north bound'}} == json.loads(payload)
+                return {'count': 0, 'rows': []}
+
+        async def async_mock_insert():
+            expected = {'rows_affected': 1, "response": "inserted"}
+            return expected
+
+        mock_plugin_info = {
+                'name': "north bound",
+                'version': "1.1",
+                'type': "north",
+                'interface': "1.0",
+                'config': {
+                            'plugin': {
+                                'description': "North OMF plugin",
+                                'type': 'string',
+                                'default': 'omf'
+                            }
+            }
+        }
+
+        mock = MagicMock()
+        attrs = {"plugin_info.side_effect": [mock_plugin_info]}
+        mock.configure_mock(**attrs)
+
+        server.Server.scheduler = Scheduler(None, None)
+        data = {
+                "name": "north bound",
+                "plugin": "omf",
+                "enabled": True,
+                "type": 3,
+                "day": 0,
+                "time": 0,
+                "repeat": 30,
+                "with_configuration": {
+                    "OMFHttpTimeout": {
+                        "description": "Timeout in seconds for HTTP operations with the OMF PI Connector Relay",
+                        "type": "integer",
+                        "default": "15"
+                    }
+                },
+                "cmd_params": {
+                    "stream_id": "1",
+                    "debug_level": "1"
+                }
+        }
+        description = "North OMF plugin"
+
+        storage_client_mock = MagicMock(StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        val = {'OMFHttpTimeout': {'description': 'Timeout in seconds for HTTP operations with the OMF PI Connector Relay', 'type': 'integer', 'default': '15'}, 'plugin': {'description': 'North OMF plugin', 'type': 'string', 'default': 'omf'}}
+
+        with patch('builtins.__import__', return_value=mock):
+            with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+                with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=q_result):
+                    with patch.object(storage_client_mock, 'insert_into_tbl', return_value=async_mock_insert()) as insert_table_patch:
+                        with patch.object(c_mgr, 'create_category', return_value=async_mock(None)) as patch_create_cat:
+                            with patch.object(server.Server.scheduler, 'save_schedule', return_value=async_mock("")) as patch_save_schedule:
+                                with patch.object(server.Server.scheduler, 'get_schedule_by_name', return_value=async_mock_get_schedule()) as patch_get_schedule:
+                                    resp = await client.post('/foglamp/scheduled/task', data=json.dumps(data))
+                                    server.Server.scheduler = None
+                                    assert 200 == resp.status
+                                    result = await resp.text()
+                                    json_response = json.loads(result)
+                                    assert {'id': '2129cc95-c841-441a-ad39-6469a87dbc8b', 'name': 'north bound'} == json_response
+                                patch_get_schedule.assert_called_once_with(data['name'])
+                            patch_save_schedule.called_once_with()
+                        patch_create_cat.assert_called_once_with(category_name=data['name'], category_description=description, category_value=val, keep_original_items=True)
+
+                    args, kwargs = insert_table_patch.call_args
+                    assert 'scheduled_processes' == args[0]
+                    p = json.loads(args[1])
+                    assert p['name'] == 'north bound'
+                    assert p['script'] in ['["tasks/north", "--stream_id=1", "--debug_level=1"]','["tasks/north", "--debug_level=1", "--stream_id=1"]']
+                    # assert {'name': 'north bound', 'script': '["tasks/north", "--stream_id=1", "--debug_level=1"]'} == p
+
+    # TODO: Add test for negative scenarios

--- a/tests/unit/python/foglamp/services/core/api/test_task.py
+++ b/tests/unit/python/foglamp/services/core/api/test_task.py
@@ -49,7 +49,7 @@ class TestService:
         ({}, 400, 'Missing name property in payload.'),
         ({"name": "test"}, 400, "Missing plugin property in payload."),
         ({"name": "test", "plugin": "omf"}, 400, 'Missing type property in payload.'),
-        ({"name": "test", "plugin": "omf", "type": "north", "schedule_type": 3}, 400, 'schedule_repeat is required for INTERVAL schedule_type.'),
+        ({"name": "test", "plugin": "omf", "type": "north", "schedule_type": 3}, 400, 'schedule_repeat None is required for INTERVAL schedule_type.'),
         ({"name": "test", "plugin": "omf", "type": "north", "schedule_type": 1}, 400, 'schedule_type cannot be STARTUP: 1')
     ])
     async def test_add_task_with_bad_params(self, client, code, payload, message):

--- a/tests/unit/python/foglamp/services/core/api/test_task.py
+++ b/tests/unit/python/foglamp/services/core/api/test_task.py
@@ -45,13 +45,12 @@ class TestService:
         return loop.run_until_complete(test_client(app))
 
     @pytest.mark.parametrize("payload, code, message", [
-        ("blah", 404, "Data payload must be a dictionary"),
+        ("blah", 500, "Data payload must be a dictionary"),
         ({}, 400, 'Missing name property in payload.'),
         ({"name": "test"}, 400, "Missing plugin property in payload."),
         ({"name": "test", "plugin": "omf"}, 400, 'Missing type property in payload.'),
-        ({"name": "test", "plugin": "omf", "type": "north", "schedule_type": 3}, 400, 'Repeat is required for INTERVAL Schedule type.'),
-        ({"name": "test", "plugin": "omf", "type": "north", "schedule_type": 1}, 400,
-             'Schedule type cannot be STARTUP: 1')
+        ({"name": "test", "plugin": "omf", "type": "north", "schedule_type": 3}, 400, 'schedule_repeat is required for INTERVAL schedule_type.'),
+        ({"name": "test", "plugin": "omf", "type": "north", "schedule_type": 1}, 400, 'schedule_type cannot be STARTUP: 1')
     ])
     async def test_add_task_with_bad_params(self, client, code, payload, message):
         resp = await client.post('/foglamp/scheduled/task', data=json.dumps(payload))


### PR DESCRIPTION
Steps to test:
1. make clean, make, scripts/foglamp reset
2. Start server.
3. Check scripts/foglamp status + syslog that NO 'HTTP North' process is running.
4. In another folder, download, extract and run
[ldeploy-http-north-plugin.sh.zip](https://github.com/foglamp/FogLAMP/files/2191759/ldeploy-http-north-plugin.sh.zip). Before executing this script, please ensure that foglamp-north-http/cmds-http-north.sql contains only below commands:
```
-- SQLite only
-- Plugin loader configuration
INSERT INTO destinations ( id, description)
    VALUES ( 2, 'HTTP North' );

INSERT INTO streams ( id, destination_id, description, last_object )
    VALUES ( 3, 2, 'HTTP North', 0 );

-- Statistics
INSERT INTO statistics (key, description, value, previous_value)
    VALUES('SENT_3', 'Readings data sent via HTTP North', 0, 0);

```
5. Check scripts/foglamp status + syslog that now 'HTTP North' process is running.
6. We may also check the actual sending process by ingesting data via, say fogbench, and see if the sending process via HTTP North is actually working. 

Test result:
`=================================================== 1158 passed, 31 skipped in 84.67 seconds ====================================================
`