### PR TITLE
Fogl-1564

### DIFF
--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -304,12 +304,8 @@ class ConfigurationManager(ConfigurationManagerSingleton):
         None
         """
         try:
-            if root is not None:
-                info = await self._read_all_groups(root)
-            else:
-                info = await self._read_all_category_names()
-
-            return info
+           info = await self._read_all_groups(root) if root is not None else await self._read_all_category_names()
+           return info
         except:
             _logger.exception(
                 'Unable to read all category names')

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -43,6 +43,7 @@ async def get_categories(request):
 
     :Example:
             curl -X GET http://localhost:8081/foglamp/category
+            curl -X GET http://localhost:8081/foglamp/category?root=true
     """
     # TODO: make it optimized and elegant
     cf_mgr = ConfigurationManager(connect.get_storage_async())

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -46,7 +46,12 @@ async def get_categories(request):
     """
     # TODO: make it optimized and elegant
     cf_mgr = ConfigurationManager(connect.get_storage_async())
-    categories = await cf_mgr.get_all_category_names()
+
+    if 'root' in request.query and request.query['root'].lower() == 'true':
+        categories = await cf_mgr.get_all_category_names(root=True)
+    else:
+        categories = await cf_mgr.get_all_category_names()
+        
     categories_json = [{"key": c[0], "description": c[1]} for c in categories]
 
     return web.json_response({'categories': categories_json})

--- a/python/foglamp/services/core/server.py
+++ b/python/foglamp/services/core/server.py
@@ -497,9 +497,9 @@ class Server:
         # Create the parent category for all general configuration categories
         try:
             await cls._configuration_manager.create_category("General", {}, 'General', True)
-            await cls._configuration_manager.create_child_category("General", ["service","rest_api"])
+            await cls._configuration_manager.create_child_category("General", ["service", "rest_api"])
         except KeyError:
-            _logger.error('Failed to create General parent confoguration category for service')
+            _logger.error('Failed to create General parent configuration category for service')
             raise
 
         # Create the parent category for all advanced configuration categories
@@ -507,7 +507,7 @@ class Server:
             await cls._configuration_manager.create_category("Advanced", {}, 'Advanced', True)
             await cls._configuration_manager.create_child_category("Advanced", ["SMNTR", "SCHEDULER"])
         except KeyError:
-            _logger.error('Failed to create Advanced parent confoguration category for service')
+            _logger.error('Failed to create Advanced parent configuration category for service')
             raise
 
 

--- a/python/foglamp/services/south/server.py
+++ b/python/foglamp/services/south/server.py
@@ -102,8 +102,8 @@ class Server(FoglampMicroservice):
                 raise
             # Create the parent category for all south service
             try:
-                parent_payload = json.dumps({"key": "South", "description":"South microservies","value":{},
-                    "children": [self._name], "keep_original_items":True})
+                parent_payload = json.dumps({"key": "South", "description": "South microservices", "value": {},
+                                             "children": [self._name], "keep_original_items": True})
                 self._core_microservice_management_client.create_configuration_category(parent_payload)
             except KeyError:
                 message = self._MESSAGES_LIST['e000004'].format(self._name)

--- a/python/foglamp/tasks/north/sending_process.py
+++ b/python/foglamp/tasks/north/sending_process.py
@@ -1080,12 +1080,11 @@ class SendingProcess:
 
             # Create the parent category for all north services
             try:
-                parent_payload = json.dumps({"key": "North", "description":"North tasks","value":{},
-                    "children": [cat_name], "keep_original_items":True})
+                parent_payload = json.dumps({"key": "North", "description": "North tasks", "value": {},
+                                             "children": [cat_name], "keep_original_items": True})
                 self._core_task_management_client.create_configuration_category(parent_payload)
             except KeyError:
-                message = self._MESSAGES_LIST['e000030'].format(self._name)
-                _LOGGER.error(message)
+                _LOGGER.error("Failed to create North parent configuration category for sending process")
                 raise
 
             return _config_from_manager

--- a/python/foglamp/tasks/purge/purge.py
+++ b/python/foglamp/tasks/purge/purge.py
@@ -86,10 +86,10 @@ class Purge(FoglampProcess):
 
         # Create the parent category for all processes
         try:
-            cfg_manager.create_category("Processes", {}, "Utilities", True)
-            cfg_manager.create_child_category("Processes", [self._CONFIG_CATEGORY_NAME])
+            await cfg_manager.create_category("Processes", {}, "Utilities", True)
+            await cfg_manager.create_child_category("Processes", [self._CONFIG_CATEGORY_NAME])
         except KeyError:
-            _LOGGER.error("Failed to create parent configuratrion category for purge process")
+            self._logger.error("Failed to create Processes parent configuration category for purge process")
             raise
 
         return await cfg_manager.get_category_all_items(self._CONFIG_CATEGORY_NAME)

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -51,6 +51,51 @@ class TestConfiguration:
                 assert result == json_response
             patch_get_all_items.assert_called_once_with()
 
+    @pytest.mark.parametrize("value", [
+        "True", "true", "trUe", "TRUE"
+    ])
+    async def test_get_categories_with_root_true(self, client, value):
+        async def async_mock():
+            return [('General', 'General'), ('Advanced', 'Advanced')]
+
+        result = {'categories': [{'key': 'General', 'description': 'General'},
+                                 {'key': 'Advanced', 'description': 'Advanced'}]}
+
+        storage_client_mock = MagicMock(StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+            with patch.object(c_mgr, 'get_all_category_names', return_value=async_mock()) as patch_get_all_items:
+                resp = await client.get('/foglamp/category?root={}'.format(value))
+                assert 200 == resp.status
+                r = await resp.text()
+                json_response = json.loads(r)
+                assert result == json_response
+            patch_get_all_items.assert_called_once_with(root=True)
+
+    @pytest.mark.parametrize("value", [
+        "False", "false", "fAlsE", "FALSE"
+    ])
+    async def test_get_categories_with_root_false(self, client, value):
+        async def async_mock():
+            return [('service', 'FogLAMP Service'), ('rest_api', 'FogLAMP Admin and User REST API'),
+                    ('SMNTR', 'Service Monitor'), ('SCHEDULER', 'Scheduler configuration')]
+
+        result = {'categories': [{'key': 'service', 'description': 'FogLAMP Service'},
+                                 {'key': 'rest_api', 'description': 'FogLAMP Admin and User REST API'},
+                                 {'key': 'SMNTR', 'description': 'Service Monitor'},
+                                 {'key': 'SCHEDULER', 'description': 'Scheduler configuration'}]}
+
+        storage_client_mock = MagicMock(StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+            with patch.object(c_mgr, 'get_all_category_names', return_value=async_mock()) as patch_get_all_items:
+                resp = await client.get('/foglamp/category?root={}'.format(value))
+                assert 200 == resp.status
+                r = await resp.text()
+                json_response = json.loads(r)
+                assert result == json_response
+            patch_get_all_items.assert_called_once_with(root=False)
+
     async def test_get_category_not_found(self, client, category_name='blah'):
         async def async_mock():
             return None

--- a/tests/unit/python/foglamp/tasks/purge/test_purge.py
+++ b/tests/unit/python/foglamp/tasks/purge/test_purge.py
@@ -81,9 +81,9 @@ class TestPurge:
         @asyncio.coroutine
         def q_result(*args):
             if args[0] == 'PURGE_READ':
-               assert len(args) == 3
+               assert 3 == len(args)
             if args[0] == 'Processes':
-                assert len(args) == 4
+                assert 4 == len(args)
 
         mockStorageClientAsync = MagicMock(spec=StorageClientAsync)
         mockAuditLogger = AuditLogger(mockStorageClientAsync)

--- a/tests/unit/python/foglamp/tasks/purge/test_purge.py
+++ b/tests/unit/python/foglamp/tasks/purge/test_purge.py
@@ -82,7 +82,7 @@ class TestPurge:
         def q_result(*args):
             if args[0] == 'PURGE_READ':
                assert 3 == len(args)
-            if args[0] == 'Processes':
+            if args[0] == 'Utilities':
                 assert 4 == len(args)
 
         mockStorageClientAsync = MagicMock(spec=StorageClientAsync)
@@ -97,7 +97,7 @@ class TestPurge:
                         with patch.object(mock_cm, 'get_category_all_items', return_value=mock_cm_return()) as mock_get_cat:
                             await p.set_configuration()
                             mock_get_cat.assert_called_once_with('PURGE_READ')
-                    mock_create_child_cat.assert_called_once_with('Processes', ['PURGE_READ'])
+                    mock_create_child_cat.assert_called_once_with('Utilities', ['PURGE_READ'])
 
     @pytest.fixture()
     async def store_purge(self, **kwargs):


### PR DESCRIPTION
Implemented 
1) ?root=true/false in /foglamp/category endpoint
 
```
curl -sX GET http://localhost:8081/foglamp/category | jq
{
  "categories": [
    {
      "description": "OMF North Plugin - C Code",
      "key": "North_Readings_to_PI"
    },
    {
      "description": "OMF North Plugin",
      "key": "SEND_PR_1"
    },
    {
      "description": "OMF North Statistics Plugin",
      "key": "SEND_PR_2"
    },
    {
      "description": "OCS North Plugin",
      "key": "SEND_PR_4"
    },
    {
      "description": "Scheduler configuration",
      "key": "SCHEDULER"
    },
    {
      "description": "Service Monitor",
      "key": "SMNTR"
    },
    {
      "description": "FogLAMP Admin and User REST API",
      "key": "rest_api"
    },
    {
      "description": "FogLAMP Service",
      "key": "service"
    },
    {
      "description": "General",
      "key": "General"
    },
    {
      "description": "Advanced",
      "key": "Advanced"
    },
    {
      "description": "Purge the readings table",
      "key": "PURGE_READ"
    },
    {
      "description": "Utilities",
      "key": "Utilities"
    }
  ]
}
```

``` 
curl -sX GET http://localhost:8081/foglamp/category?root=true | jq
{
  "categories": [
    {
      "description": "General",
      "key": "General"
    },
    {
      "description": "Advanced",
      "key": "Advanced"
    },
    {
      "description": "Utilities",
      "key": "Utilities"
    }
  ]
}
```

```
curl -sX GET http://localhost:8081/foglamp/category?root=false | jq
{
  "categories": [
    {
      "description": "OMF North Plugin - C Code",
      "key": "North_Readings_to_PI"
    },
    {
      "description": "OMF North Plugin",
      "key": "SEND_PR_1"
    },
    {
      "description": "OMF North Statistics Plugin",
      "key": "SEND_PR_2"
    },
    {
      "description": "OCS North Plugin",
      "key": "SEND_PR_4"
    },
    {
      "description": "Scheduler configuration",
      "key": "SCHEDULER"
    },
    {
      "description": "Service Monitor",
      "key": "SMNTR"
    },
    {
      "description": "FogLAMP Admin and User REST API",
      "key": "rest_api"
    },
    {
      "description": "FogLAMP Service",
      "key": "service"
    },
    {
      "description": "Purge the readings table",
      "key": "PURGE_READ"
    }
  ]
}
```

2. GET /foglamp/category?parent=General
This is as equivalent to existing endpoint /foglamp/category/General/children. So skipped
```
curl -sX GET http://localhost:8081/foglamp/category/General/children | jq
{
  "categories": [
    {
      "description": "FogLAMP Admin and User REST API",
      "key": "rest_api"
    },
    {
      "description": "FogLAMP Service",
      "key": "service"
    }
  ]
}
```
3. Should we restrict merge category values for General, Utilities, Advanced etc? i.e root one

Kindly advise.
