### PR TITLE
FOGL-1586 regression fix + improvement for true false handling for request.json 

### DIFF
--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -100,9 +100,10 @@ async def add_service(request):
         if service_type not in ['south']:
             raise web.HTTPBadRequest(reason='Only south type is supported.')
         if enabled is not None:
-            if enabled not in ['t', 'f', 'true', 'false']:
-                raise web.HTTPBadRequest(reason='Only "t", "f", "true", "false" are allowed for value of enabled.')
-        is_enabled = True if ((type(enabled) is str and enabled.lower() in ['t', 'true']) or (
+            if enabled not in ['true', 'false', True, False]:
+                raise web.HTTPBadRequest(reason='Only "true", "false", True, False'
+                                                ' are allowed for value of enabled.')
+        is_enabled = True if ((type(enabled) is str and enabled.lower() in ['true']) or (
             (type(enabled) is bool and enabled is True))) else False
 
         # Check if a valid plugin has been provided
@@ -164,7 +165,8 @@ async def add_service(request):
             schedule.process_name = name
             schedule.repeat = datetime.timedelta(0)
             schedule.exclusive = True
-            schedule.enabled = False  # if "enabled" is supplied, it gets activated in save_schedule() via is_enabled flag
+            #  if "enabled" is supplied, it gets activated in save_schedule() via is_enabled flag
+            schedule.enabled = False
 
             # Save schedule
             await server.Server.scheduler.save_schedule(schedule, is_enabled)

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -101,7 +101,7 @@ async def add_service(request):
             raise web.HTTPBadRequest(reason='Only south type is supported.')
         if enabled is not None:
             if enabled not in ['true', 'false', True, False]:
-                raise web.HTTPBadRequest(reason='Only "true", "false", True, False'
+                raise web.HTTPBadRequest(reason='Only "true", "false", true, false'
                                                 ' are allowed for value of enabled.')
         is_enabled = True if ((type(enabled) is str and enabled.lower() in ['true']) or (
             (type(enabled) is bool and enabled is True))) else False

--- a/tests/unit/python/foglamp/services/core/api/test_service.py
+++ b/tests/unit/python/foglamp/services/core/api/test_service.py
@@ -114,19 +114,29 @@ class TestService:
         assert 6 == log_patch_info.call_count
 
     @pytest.mark.parametrize("payload, code, message", [
-        ("blah", 404, "Data payload must be a dictionary"),
-        ({}, 400, "Missing name property in payload."),
-        ({"name": "test"}, 400, "Missing plugin property in payload."),
-        ({"name": "a;b", "plugin": "dht11", "type": "south"}, 400, "Invalid name property in payload."),
-        ({"name": "test", "plugin": "dht@11", "type": "south"}, 400, "Invalid plugin property in payload."),
-        ({"name": "test", "plugin": "dht11", "type": "south", "enabled": "blah"}, 400,
-         'Only "true", "false", True, False are allowed for value of enabled.'),
-        ({"name": "test", "plugin": "dht11"}, 400, "Missing type property in payload."),
-        ({"name": "test", "plugin": "dht11", "type": "blah"}, 400, "Only south type is supported."),
-        ({"name": "test", "plugin": "dht11", "type": "North"}, 406, "north type is not supported for the time being.")
+        ('"blah"', 404, "Data payload must be a dictionary"''),
+        ('{}', 400, "Missing name property in payload."),
+        ('{"name": "test"}', 400, "Missing plugin property in payload."),
+        ('{"name": "a;b", "plugin": "dht11", "type": "south"}', 400, "Invalid name property in payload."),
+        ('{"name": "test", "plugin": "dht@11", "type": "south"}', 400, "Invalid plugin property in payload."),
+        ('{"name": "test", "plugin": "dht11", "type": "south", "enabled": "blah"}', 400,
+         'Only "true", "false", true, false are allowed for value of enabled.'),
+        ('{"name": "test", "plugin": "dht11", "type": "south", "enabled": "t"}', 400,
+         'Only "true", "false", true, false are allowed for value of enabled.'),
+        ('{"name": "test", "plugin": "dht11", "type": "south", "enabled": "True"}', 400,
+         'Only "true", "false", true, false are allowed for value of enabled.'),
+        ('{"name": "test", "plugin": "dht11", "type": "south", "enabled": "False"}', 400,
+         'Only "true", "false", true, false are allowed for value of enabled.'),
+        ('{"name": "test", "plugin": "dht11", "type": "south", "enabled": "1"}', 400,
+         'Only "true", "false", true, false are allowed for value of enabled.'),
+        ('{"name": "test", "plugin": "dht11", "type": "south", "enabled": "0"}', 400,
+         'Only "true", "false", true, false are allowed for value of enabled.'),
+        ('{"name": "test", "plugin": "dht11"}', 400, "Missing type property in payload."),
+        ('{"name": "test", "plugin": "dht11", "type": "blah"}', 400, "Only south type is supported."),
+        ('{"name": "test", "plugin": "dht11", "type": "North"}', 406, "north type is not supported for the time being.")
     ])
     async def test_add_service_with_bad_params(self, client, code, payload, message):
-        resp = await client.post('/foglamp/service', data=json.dumps(payload))
+        resp = await client.post('/foglamp/service', data=payload)
         assert code == resp.status
         assert message == resp.reason
 

--- a/tests/unit/python/foglamp/services/core/api/test_service.py
+++ b/tests/unit/python/foglamp/services/core/api/test_service.py
@@ -206,7 +206,17 @@ class TestService:
                             assert 'Internal Server Error' == resp.reason
                         assert 0 == patch_create_cat.call_count
 
-    async def test_add_service(self, client):
+    p1 = '{"name": "furnace4", "type": "south", "plugin": "dht11"}'
+    p2 = '{"name": "furnace4", "type": "south", "plugin": "dht11", "enabled": false}'
+    p3 = '{"name": "furnace4", "type": "south", "plugin": "dht11", "enabled": true}'
+    p4 = '{"name": "furnace4", "type": "south", "plugin": "dht11", "enabled": "true"}'
+    p5 = '{"name": "furnace4", "type": "south", "plugin": "dht11", "enabled": "false"}'
+
+    @pytest.mark.parametrize("payload", [p1, p2, p3, p4, p5])
+    async def test_add_service(self, client, payload):
+
+        data = json.loads(payload)
+
         async def async_mock(return_value):
             return return_value
 
@@ -250,7 +260,7 @@ class TestService:
         mock.configure_mock(**attrs)
 
         server.Server.scheduler = Scheduler(None, None)
-        data = {"name": "furnace4", "type": "south", "plugin": "dht11"}
+
         description = "Modbus RTU plugin"
 
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -264,7 +274,7 @@ class TestService:
                         with patch.object(c_mgr, 'create_category', return_value=async_mock(None)) as patch_create_cat:
                             with patch.object(server.Server.scheduler, 'save_schedule', return_value=async_mock("")) as patch_save_schedule:
                                 with patch.object(server.Server.scheduler, 'get_schedule_by_name', return_value=async_mock_get_schedule()) as patch_get_schedule:
-                                    resp = await client.post('/foglamp/service', data=json.dumps(data))
+                                    resp = await client.post('/foglamp/service', data=payload)
                                     server.Server.scheduler = None
                                     assert 200 == resp.status
                                     result = await resp.text()

--- a/tests/unit/python/foglamp/services/core/api/test_service.py
+++ b/tests/unit/python/foglamp/services/core/api/test_service.py
@@ -120,7 +120,7 @@ class TestService:
         ({"name": "a;b", "plugin": "dht11", "type": "south"}, 400, "Invalid name property in payload."),
         ({"name": "test", "plugin": "dht@11", "type": "south"}, 400, "Invalid plugin property in payload."),
         ({"name": "test", "plugin": "dht11", "type": "south", "enabled": "blah"}, 400,
-         'Only "t", "f", "true", "false" are allowed for value of enabled.'),
+         'Only "true", "false", True, False are allowed for value of enabled.'),
         ({"name": "test", "plugin": "dht11"}, 400, "Missing type property in payload."),
         ({"name": "test", "plugin": "dht11", "type": "blah"}, 400, "Only south type is supported."),
         ({"name": "test", "plugin": "dht11", "type": "North"}, 406, "north type is not supported for the time being.")


### PR DESCRIPTION
`
curl -sX POST http://localhost:8081/foglamp/service -d '{"name": "Modbus TCP", "type": "south", "plugin": "modbustcp", "enabled": true}'`

 json boolean true maps  to True. And it worked in develop before 1586 last changes because

```
True == 1
True
```