### PR TITLE
FOGL-1624 create_child category response fixes and parse unquote for category_name fields for child/parent end points

### DIFF
--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -609,14 +609,11 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 result = await self._create_child(category_name, a_new_child)
                 children_from_storage.append(a_new_child)
 
-            cat_dict = await self.get_category_all_items(category_name)
-            cat_dict["children"] = children_from_storage
+            return {"children": children_from_storage}
 
             # TODO: [TO BE DECIDED] - Audit Trail Entry
         except KeyError:
             raise ValueError(result['message'])
-
-        return cat_dict
 
     async def delete_child_category(self, category_name, child_category):
         """Delete a parent-child relationship

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -336,6 +336,8 @@ async def get_child_category(request):
             curl -X GET http://localhost:8081/foglamp/category/south/children
     """
     category_name = request.match_info.get('category_name', None)
+    category_name = urllib.parse.unquote(category_name) if category_name is not None else None
+
     cf_mgr = ConfigurationManager(connect.get_storage_async())
 
     try:
@@ -363,6 +365,8 @@ async def create_child_category(request):
         raise ValueError('Data payload must be a dictionary')
 
     category_name = request.match_info.get('category_name', None)
+    category_name = urllib.parse.unquote(category_name) if category_name is not None else None
+
     children = data.get('children')
 
     try:
@@ -389,6 +393,7 @@ async def delete_child_category(request):
     """
     category_name = request.match_info.get('category_name', None)
     child_category = request.match_info.get('child_category', None)
+    category_name = urllib.parse.unquote(category_name) if category_name is not None else None
 
     cf_mgr = ConfigurationManager(connect.get_storage_async())
     try:
@@ -415,6 +420,7 @@ async def delete_parent_category(request):
 
     """
     category_name = request.match_info.get('category_name', None)
+    category_name = urllib.parse.unquote(category_name) if category_name is not None else None
 
     cf_mgr = ConfigurationManager(connect.get_storage_async())
     try:

--- a/tests/unit/python/foglamp/common/test_configuration_manager.py
+++ b/tests/unit/python/foglamp/common/test_configuration_manager.py
@@ -1546,12 +1546,8 @@ class TestConfigurationManager:
                               return_value=async_mock(all_child_ret_val)) as patch_readall_child:
                 with patch.object(ConfigurationManager, '_create_child',
                                   return_value=async_mock('inserted')) as patch_create_child:
-                    with patch.object(ConfigurationManager, 'get_category_all_items',
-                                      return_value=async_mock({"info": "blah"})) as patch_get_cat:
-                        ret_val = await c_mgr.create_child_category(cat_name, [child_name])
-                        assert 'blah' == ret_val['info']
-                        assert set(['coap', 'http']) == set(ret_val['children'])
-                    patch_get_cat.assert_called_once_with(cat_name)
+                    ret_val = await c_mgr.create_child_category(cat_name, [child_name])
+                    assert {'children': ['http', 'coap']} == ret_val
             patch_readall_child.assert_called_once_with(cat_name)
         patch_create_child.assert_called_once_with(cat_name, child_name)
 
@@ -1575,11 +1571,8 @@ class TestConfigurationManager:
         with patch.object(ConfigurationManager, '_read_category_val', side_effect=q_result):
             with patch.object(ConfigurationManager, '_read_all_child_category_names',
                               return_value=async_mock(all_child_ret_val)) as patch_readall_child:
-                with patch.object(ConfigurationManager, 'get_category_all_items',
-                                  return_value=async_mock({"info": "blah"})) as patch_get_cat:
-                    ret_val = await c_mgr.create_child_category(cat_name, [child_name])
-                    assert {'info': 'blah', 'children': ['coap']} == ret_val
-                patch_get_cat.assert_called_once_with(cat_name)
+                ret_val = await c_mgr.create_child_category(cat_name, [child_name])
+                assert {'children': ['coap']} == ret_val
             patch_readall_child.assert_called_once_with(cat_name)
 
     @pytest.mark.parametrize("cat_name, child_name, message", [

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -494,7 +494,7 @@ class TestConfiguration:
 
     async def test_create_child_category(self, client):
         data = {"children": ["coap", "http", "sinusoid"]}
-        result = {"management_host": {"description": "Management host", "type": "string", "default": "127.0.0.1"}, "children": data["children"]}
+        result = {"children": data["children"]}
 
         @asyncio.coroutine
         def async_mock():


### PR DESCRIPTION
create_category
```
curl -d '{"key": "TEST", "description": "description", "value": {"info": {"description": "Test", "type": "boolean", "default": "true"}}, "children":["rest_api"]}' -sX POST http://192.168.1.103:8081/foglamp/category | jq
{
  "key": "TEST",
  "description": "description",
  "value": {
    "info": {
      "description": "Test",
      "type": "boolean",
      "default": "true",
      "value": "true"
    }
  },
  "children": [
    "rest_api"
  ]
}
```

create_child_category
```
 $ curl -sX POST -d '{"children" : []}' http://192.168.1.103:8081/foglamp/category/North_Statistics_to_PI/children | jq
{
  "children": []
}

$ curl -sX POST -d '{"children" : []}' http://192.168.1.103:8081/foglamp/category/General/children | jq
{
  "children": [
    "North Readings to OCS",
    "SMNTR"
  ]
}
 $ curl -sX POST -d '{"children" : ["service"]}' http://192.168.1.103:8081/foglamp/category/North_Statistics_to_PI/children | jq
{
  "children": [
    "service"
  ]
}
```

**NOTE:** 
1) Initially it was added right https://github.com/foglamp/FogLAMP/pull/887/files, later it comes change via https://github.com/foglamp/FogLAMP/pull/929/files
And it was not catched because I generally test this endpoint with root category one :) [and root category value is "{}" so dict returns with "children" only]
Anyways now fixed

2) And space handling done for child-parent endpoints as we have for other endpoints via https://github.com/foglamp/FogLAMP/pull/915