### PR TITLE
FOGL-1671 fixed issue with invalid json

### DIFF
--- a/C/plugins/north/ThingSpeak/plugin.cpp
+++ b/C/plugins/north/ThingSpeak/plugin.cpp
@@ -37,13 +37,13 @@ using namespace rapidjson;
 			"\"write_api_key\": { " \
 				"\"description\": \"The write_api_key supplied by ThingSpeak for this channel\", " \
 				"\"type\": \"string\", \"default\": \"\" }, " \
-			"\"fields\": \"{ " \
+			"\"fields\": { " \
 				"\"description\": \"The fields to send ThingSpeak\", " \
-				"\"type\": \"JSON\", \"default\": \"{ " \
+				"\"type\": \"JSON\", \"default\": { " \
 				    "\"elements\":[" \
 				    "{ \"asset\":\"sinusoid\"," \
 				    "\"reading\":\"sinusoid\"}" \
-				"]}\" }"
+				"]} }"
 		
 
 #define THINGSPEAK_PLUGIN_DESC "\"plugin\": {\"description\": \"ThingSpeak North\", \"type\": \"string\", \"default\": \"thingspeak\"}"


### PR DESCRIPTION
Fixed issue with invalid JSON
foglamp@foglamp-dev:~/FogLAMP$ /home/foglamp/FogLAMP/build/C/plugins/utils/get_plugin_info ~/FogLAMP/plugins/north/ThingSpeak/libThingSpeak.so plugin_info|jq
{
  "plugin": {
    "description": "ThingSpeak North",
    "type": "string",
    "default": "thingspeak"
  },
  "URL": {
    "description": "The URL of the ThingSpeak service",
    "type": "string",
    "default": "https://api.thingspeak.com/channels"
  },
  "channelId": {
    "description": "The channel id for this thingSpeak channel",
    "type": "string",
    "default": "0"
  },
  "write_api_key": {
    "description": "The write_api_key supplied by ThingSpeak for this channel",
    "type": "string",
    "default": ""
  },
  "fields": {
    "description": "The fields to send ThingSpeak",
    "type": "JSON",
    "default": {
      "elements": [
        {
          "asset": "sinusoid",
          "reading": "sinusoid"
        }
      ]
    }
  }
}
foglamp@foglamp-dev:~/FogLAMP$