### PR TITLE
FOGL-1627 Add master statistics keys

### DIFF
--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -106,8 +106,19 @@ async def get_stats(req):
     stats = json.loads(res.body.decode())
 
     def filter_stat(k):
-        v = [s['value'] for s in stats if s['key'] == k]
-        return int(v[0])
+
+        """
+        there is no statistics about 'Readings Sent' at the start of FogLAMP
+        so the specific exception is caught and 0 is returned to avoid the error 'index out of range'
+        calling the API ping.
+        """
+        try:
+            v = [s['value'] for s in stats if s['key'] == k]
+            value = int(v[0])
+        except IndexError:
+            value = 0
+
+        return value
 
     data_read = filter_stat('READINGS')
     data_sent = filter_stat('Readings Sent')

--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -109,11 +109,8 @@ async def get_stats(req):
         v = [s['value'] for s in stats if s['key'] == k]
         return int(v[0])
 
-    def filter_sent_stat():
-        return sum([int(s['value']) for s in stats if s['key'].upper().startswith('NORTH')])
-
     data_read = filter_stat('READINGS')
-    data_sent = filter_sent_stat()
+    data_sent = filter_stat('Readings Sent')
     data_purged = filter_stat('PURGED')
 
     return data_read, data_sent, data_purged

--- a/scripts/foglamp
+++ b/scripts/foglamp
@@ -24,7 +24,7 @@ set -e
 #
 USAGE="Usage: `basename ${0}` {start|stop|status|reset|kill|help|version}"
 
-# Remove any toekn cache left over from a previous execution
+# Remove any token cache left over from a previous execution
 rm -f ~/.foglamp_token
 
 # Check FOGLAMP_ROOT

--- a/tests/unit/python/foglamp/services/core/api/test_common_ping.py
+++ b/tests/unit/python/foglamp/services/core/api/test_common_ping.py
@@ -54,6 +54,7 @@ async def test_ping_http_allow_ping_true(test_server, test_client, loop):
         {"value": 3, "key": "North Readings to PI", "description": "blah2"},
         {"value": 4, "key": "North Statistics to PI", "description": "blah3"},
         {"value": 10, "key": "North Statistics to OCS", "description": "blah5"},
+        {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
     ]}
 
     @asyncio.coroutine
@@ -85,7 +86,7 @@ async def test_ping_http_allow_ping_true(test_server, test_client, loop):
                     content_dict = json.loads(content)
                     assert 0.0 < content_dict["uptime"]
                     assert 2 == content_dict["dataRead"]
-                    assert 17 == content_dict["dataSent"]
+                    assert 100 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is True
                 mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
@@ -107,6 +108,7 @@ async def test_ping_http_allow_ping_false(test_server, test_client, loop):
             {"value": 3, "key": "North Readings to PI", "description": "blah2"},
             {"value": 4, "key": "North Statistics to PI", "description": "blah3"},
             {"value": 10, "key": "North Statistics to OCS", "description": "blah5"},
+            {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
         ]}
         return result
 
@@ -134,7 +136,7 @@ async def test_ping_http_allow_ping_false(test_server, test_client, loop):
                     content_dict = json.loads(content)
                     assert 0.0 < content_dict["uptime"]
                     assert 2 == content_dict["dataRead"]
-                    assert 17 == content_dict["dataSent"]
+                    assert 100 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is True
                 mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
@@ -153,6 +155,7 @@ async def test_ping_http_auth_required_allow_ping_true(test_server, test_client,
                 {"value": 3, "key": "North Readings to PI", "description": "blah2"},
                 {"value": 4, "key": "North Statistics to PI", "description": "blah3"},
                 {"value": 10, "key": "North Statistics to OCS", "description": "blah5"},
+                {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
                ]}
 
     @asyncio.coroutine
@@ -183,7 +186,7 @@ async def test_ping_http_auth_required_allow_ping_true(test_server, test_client,
                     content_dict = json.loads(content)
                     assert 0.0 < content_dict["uptime"]
                     assert 2 == content_dict["dataRead"]
-                    assert 17 == content_dict["dataSent"]
+                    assert 100 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is False
                 mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
@@ -202,6 +205,7 @@ async def test_ping_http_auth_required_allow_ping_false(test_server, test_client
         {"value": 3, "key": "North Readings to PI", "description": "blah2"},
         {"value": 4, "key": "North Statistics to PI", "description": "blah3"},
         {"value": 5, "key": "North Statistics to OCS", "description": "blah5"},
+        {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
     ]}
 
     @asyncio.coroutine
@@ -246,6 +250,7 @@ async def test_ping_https_allow_ping_true(test_server, ssl_ctx, test_client, loo
                 {"value": 3, "key": "North Readings to PI", "description": "blah2"},
                 {"value": 4, "key": "North Statistics to PI", "description": "blah3"},
                 {"value": 10, "key": "North Statistics to OCS", "description": "blah5"},
+                {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
                ]}
 
     @asyncio.coroutine
@@ -290,7 +295,7 @@ async def test_ping_https_allow_ping_true(test_server, ssl_ctx, test_client, loo
                     content_dict = json.loads(content)
                     assert 0.0 < content_dict["uptime"]
                     assert 2 == content_dict["dataRead"]
-                    assert 17 == content_dict["dataSent"]
+                    assert 100 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is True
                 mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
@@ -308,6 +313,7 @@ async def test_ping_https_allow_ping_false(test_server, ssl_ctx, test_client, lo
         {"value": 3, "key": "North Readings to PI", "description": "blah2"},
         {"value": 4, "key": "North Statistics to PI", "description": "blah3"},
         {"value": 6, "key": "North Statistics to OCS", "description": "blah5"},
+        {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
     ]}
 
     @asyncio.coroutine
@@ -363,6 +369,7 @@ async def test_ping_https_auth_required_allow_ping_true(test_server, ssl_ctx, te
                 {"value": 3, "key": "North Readings to PI", "description": "blah2"},
                 {"value": 4, "key": "North Statistics to PI", "description": "blah3"},
                 {"value": 10, "key": "North Statistics to OCS", "description": "blah5"},
+                {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
                ]}
 
     @asyncio.coroutine
@@ -407,7 +414,7 @@ async def test_ping_https_auth_required_allow_ping_true(test_server, ssl_ctx, te
                     content_dict = json.loads(content)
                     assert 0.0 < content_dict["uptime"]
                     assert 2 == content_dict["dataRead"]
-                    assert 17 == content_dict["dataSent"]
+                    assert 100 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is False
                     mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
@@ -428,6 +435,7 @@ async def test_ping_https_auth_required_allow_ping_false(test_server, ssl_ctx, t
             {"value": 3, "key": "North Readings to PI", "description": "blah2"},
             {"value": 4, "key": "North Statistics to PI", "description": "blah3"},
             {"value": 6, "key": "North Statistics to OCS", "description": "blah5"},
+            {"value": 100, "key": "Readings Sent", "description": "Readings Sent North"},
         ]}
         return result
 

--- a/tests/unit/python/foglamp/tasks/north/test_sending_process.py
+++ b/tests/unit/python/foglamp/tasks/north/test_sending_process.py
@@ -2247,6 +2247,9 @@ class TestSendingProcess:
         async def mock_stat_key():
             return "sp"
 
+        async def mock_master_stat_key():
+            return 'Readings Sent'
+
         with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
@@ -2263,10 +2266,11 @@ class TestSendingProcess:
 
         with patch.object(sp, '_get_stream_id', return_value=mock_stream()) as mocked_get_stream_id:
             with patch.object(sp, '_get_statistics_key', return_value=mock_stat_key()) as mocked_get_statistics_key:
-                with patch.object(sp._core_microservice_management_client, 'update_configuration_item'):
-                    with patch.object(sp, '_retrieve_configuration'):
-                        with patch.object(sp, '_plugin_load') as mocked_plugin_load:
-                            result = await sp._start()
+                with patch.object(sp, '_get_master_statistics_key', return_value=mock_master_stat_key()):
+                    with patch.object(sp._core_microservice_management_client, 'update_configuration_item'):
+                        with patch.object(sp, '_retrieve_configuration'):
+                            with patch.object(sp, '_plugin_load') as mocked_plugin_load:
+                                result = await sp._start()
 
         assert not result
         assert not mocked_plugin_load.called
@@ -2279,6 +2283,9 @@ class TestSendingProcess:
 
         async def mock_stat_key():
             return "sp"
+
+        async def mock_master_stat_key():
+            return 'Readings Sent'
 
         with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
@@ -2297,11 +2304,12 @@ class TestSendingProcess:
         with patch.object(sp._core_microservice_management_client, 'update_configuration_item'):
             with patch.object(sp, '_get_stream_id', return_value=mock_stream()) as mocked_get_stream_id:
                 with patch.object(sp, '_get_statistics_key', return_value=mock_stat_key()) as mocked_get_statistics_key:
-                    with patch.object(sp, '_retrieve_configuration'):
-                        with patch.object(sp, '_plugin_load') as mocked_plugin_load:
-                            with patch.object(sp._plugin, 'plugin_info') as mocked_plugin_info:
-                                with patch.object(sp, '_is_north_valid', return_value=False) as mocked_is_north_valid:
-                                    result = await sp._start()
+                    with patch.object(sp, '_get_master_statistics_key', return_value=mock_master_stat_key()):
+                        with patch.object(sp, '_retrieve_configuration'):
+                            with patch.object(sp, '_plugin_load') as mocked_plugin_load:
+                                with patch.object(sp._plugin, 'plugin_info') as mocked_plugin_info:
+                                    with patch.object(sp, '_is_north_valid', return_value=False) as mocked_is_north_valid:
+                                        result = await sp._start()
 
         assert not result
         assert mocked_plugin_load.called
@@ -2317,6 +2325,9 @@ class TestSendingProcess:
         async def mock_stat_key():
             return "sp"
 
+        async def mock_master_stat_key():
+            return 'Readings Sent'
+
         with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
@@ -2334,12 +2345,13 @@ class TestSendingProcess:
         with patch.object(sp._core_microservice_management_client, 'update_configuration_item'):
             with patch.object(sp, '_get_stream_id', return_value=mock_stream()) as mocked_get_stream_id:
                 with patch.object(sp, '_get_statistics_key', return_value=mock_stat_key()) as mocked_get_statistics_key:
-                    with patch.object(sp, '_retrieve_configuration') as mocked_retrieve_configuration:
-                        with patch.object(sp, '_plugin_load') as mocked_plugin_load:
-                            with patch.object(sp._plugin, 'plugin_info') as mocked_plugin_info:
-                                with patch.object(sp, '_is_north_valid', return_value=True) as mocked_is_north_valid:
-                                    with patch.object(sp._plugin, 'plugin_init') as mocked_plugin_init:
-                                        result = await sp._start()
+                    with patch.object(sp, '_get_master_statistics_key', return_value=mock_master_stat_key()):
+                        with patch.object(sp, '_retrieve_configuration') as mocked_retrieve_configuration:
+                            with patch.object(sp, '_plugin_load') as mocked_plugin_load:
+                                with patch.object(sp._plugin, 'plugin_info') as mocked_plugin_info:
+                                    with patch.object(sp, '_is_north_valid', return_value=True) as mocked_is_north_valid:
+                                        with patch.object(sp._plugin, 'plugin_init') as mocked_plugin_init:
+                                            result = await sp._start()
 
         assert result
         # mocked_is_stream_id_valid.called_with(STREAM_ID)


### PR DESCRIPTION
3 New statistics keys are added to the statistics table. These are updated by all instances of the sending process

- Readings Sent

- Statistics Sent

- Audit Sent

The choice of which statistics is updated depends on the source of the data the sending process is sending. All readings data sent on all north bound tasks will cause "Readings Sent" to be updated. For Statistics Sent it is the statistics north from all stream and likewise for audit.

In particular the GUI should use the same statistic "Readings Sent" to display the number of readings sent to the north on the status bar at the top.