### PR TITLE
FOGL-893-new : Sending process verbose errors if connection failed. #933

### DIFF
--- a/python/foglamp/plugins/north/common/common.py
+++ b/python/foglamp/plugins/north/common/common.py
@@ -33,7 +33,7 @@ MESSAGES_LIST = {
     "e000021": "cannot complete the preparation of the in memory structure.",
     "e000022": "unable to extend the memory structure with new data.",
     "e000023": "cannot prepare sensor information for the destination - error details |{0}|",
-    "e000024": "an error occurred during the request to the destination - error details |{0}|",
+    "e000024": "an error occurred during the HTTP post command - destination |{0}| - error details |{1}|",
 
     "e000030": "cannot update the reached position.",
     "e000031": "cannot complete the sending operation - error details |{0}|",

--- a/python/foglamp/plugins/north/common/common.py
+++ b/python/foglamp/plugins/north/common/common.py
@@ -33,7 +33,7 @@ MESSAGES_LIST = {
     "e000021": "cannot complete the preparation of the in memory structure.",
     "e000022": "unable to extend the memory structure with new data.",
     "e000023": "cannot prepare sensor information for the destination - error details |{0}|",
-    "e000024": "an error occurred during the request to the destination - destination |{0}| - error details |{1}|",
+    "e000024": "an error occurred during the request to the destination - server address |{0}| - error details |{1}|",
 
     "e000030": "cannot update the reached position.",
     "e000031": "cannot complete the sending operation - error details |{0}|",

--- a/python/foglamp/plugins/north/common/common.py
+++ b/python/foglamp/plugins/north/common/common.py
@@ -33,7 +33,7 @@ MESSAGES_LIST = {
     "e000021": "cannot complete the preparation of the in memory structure.",
     "e000022": "unable to extend the memory structure with new data.",
     "e000023": "cannot prepare sensor information for the destination - error details |{0}|",
-    "e000024": "an error occurred during the HTTP post command - destination |{0}| - error details |{1}|",
+    "e000024": "an error occurred during the request to the destination - destination |{0}| - error details |{1}|",
 
     "e000030": "cannot update the reached position.",
     "e000031": "cannot complete the sending operation - error details |{0}|",

--- a/python/foglamp/plugins/north/common/exceptions.py
+++ b/python/foglamp/plugins/north/common/exceptions.py
@@ -36,6 +36,6 @@ class DataSendError(NorthPluginException):
         self.reason = reason
 
 
-class URLPostError(Exception):
-    """ Unable to fetch from the HTTP server """	    """ Unable to post to the HTTP server """
+class URLConnectionError(Exception):
+    """ Unable to connect to the server """
     pass

--- a/python/foglamp/plugins/north/common/exceptions.py
+++ b/python/foglamp/plugins/north/common/exceptions.py
@@ -34,3 +34,8 @@ class DataSendError(NorthPluginException):
     def __init__(self, reason):
         super(DataSendError, self).__init__(reason)
         self.reason = reason
+
+
+class URLPostError(Exception):
+    """ Unable to fetch from the HTTP server """	    """ Unable to post to the HTTP server """
+    pass

--- a/python/foglamp/plugins/north/pi_server/pi_server.py
+++ b/python/foglamp/plugins/north/pi_server/pi_server.py
@@ -798,20 +798,12 @@ class PIServerNorthPlugin(object):
 
             except (TimeoutError, asyncio.TimeoutError) as ex:
 
-                # The conversion to a string of the exception TimeoutError produces an empty string,
-                # so it forces a proper message
-                if str(ex) == "":
-                    details = type(ex).__name__
-                else:
-                    details = str(ex)
-
-                _message = plugin_common.MESSAGES_LIST["e000024"].format(self._config['URL'], details)
+                _message = plugin_common.MESSAGES_LIST["e000024"].format(self._config['URL'], "connection Timeout")
                 _error = plugin_exceptions.URLConnectionError(_message)
 
             except Exception as ex:
 
                 details = str(ex)
-
                 _message = plugin_common.MESSAGES_LIST["e000024"].format(self._config['URL'], details)
                 _error = plugin_exceptions.URLConnectionError(_message)
 

--- a/python/foglamp/plugins/north/pi_server/pi_server.py
+++ b/python/foglamp/plugins/north/pi_server/pi_server.py
@@ -353,8 +353,6 @@ def plugin_init(data):
     _config['URL'] = data['URL']['value']
     _config['producerToken'] = data['producerToken']['value']
     _config['OMFMaxRetry'] = int(data['OMFMaxRetry']['value'])
-    # FIXME:
-    _config['OMFMaxRetry'] = 1
     _config['OMFRetrySleepTime'] = int(data['OMFRetrySleepTime']['value'])
     _config['OMFHttpTimeout'] = int(data['OMFHttpTimeout']['value'])
 
@@ -414,9 +412,6 @@ async def plugin_send(data, raw_data, stream_id):
     type_id = _config_omf_types['type-id']['value']
 
     omf_north = PIServerNorthPlugin(data['sending_process_instance'], data, _config_omf_types, _logger)
-
-    # FIXME:
-
 
     # Alloc the in memory buffer
     buffer_size = len(raw_data)

--- a/python/foglamp/plugins/north/pi_server/pi_server.py
+++ b/python/foglamp/plugins/north/pi_server/pi_server.py
@@ -415,7 +415,7 @@ async def plugin_send(data, raw_data, stream_id):
 
     # Alloc the in memory buffer
     buffer_size = len(raw_data)
-    data_to_send = [None for x in range(buffer_size)]
+    data_to_send = [None for _ in range(buffer_size)]
 
     is_data_available, new_position, num_sent = omf_north.transform_in_memory_data(data_to_send, raw_data)
 
@@ -805,13 +805,13 @@ class PIServerNorthPlugin(object):
                     details = str(ex)
 
                 _message = plugin_common.MESSAGES_LIST["e000024"].format(self._config['URL'], details)
-                _error = plugin_exceptions.URLPostError(_message)
+                _error = plugin_exceptions.URLConnectionError(_message)
             else:
                 # Evaluate the HTTP status codes
                 if not str(status_code).startswith('2'):
                     _tmp_text = "status code " + str(status_code) + " - " + text
                     _message = plugin_common.MESSAGES_LIST["e000024"].format(self._config['URL'], _tmp_text)
-                    _error = plugin_exceptions.URLPostError(_message)
+                    _error = plugin_exceptions.URLConnectionError(_message)
 
                 self._logger.debug("message type |{0}| response: |{1}| |{2}| ".format(
                     message_type,

--- a/python/foglamp/tasks/north/sending_process.py
+++ b/python/foglamp/tasks/north/sending_process.py
@@ -198,7 +198,7 @@ class SendingProcess(FoglampProcess):
     """ The amount of time the fetch operation will sleep if there are no more data to load or in case of an error """
     TASK_SEND_SLEEP = 0.5
     """ The amount of time the sending operation will sleep in case of an error """
-    TASK_SLEEP_MAX_INCREMENTS = 4
+    TASK_SLEEP_MAX_INCREMENTS = 7
     """ Maximum number of increments for the sleep handling, the amount of time is doubled at every sleep """
     TASK_SEND_UPDATE_POSITION_MAX = 10
     """ the position is updated after the specified numbers of interactions of the sending task """

--- a/tests/system/suites/end_to_end_PI/t/0030_prepare_PI.test
+++ b/tests/system/suites/end_to_end_PI/t/0030_prepare_PI.test
@@ -51,6 +51,11 @@ if [[ "$?" != "0" ]]; then
     exit 1
 fi
 
+${TEST_BASEDIR}/bash/wait_creation_cfg.bash "OMF_TYPES/type-id"
+if [[ "$?" != "0" ]]; then
+    exit 1
+fi
+
 # Configures FogLAMP with the required settings
 curl -s -X PUT http://${FOGLAMP_SERVER}:${FOGLAMP_PORT}/foglamp/category/${SENDING_PROCESS_DATA}/URL           -d '{ "value" : "https://'${PI_SERVER}':'${PI_SERVER_PORT}'/ingress/messages"}'
 curl -s -X PUT http://${FOGLAMP_SERVER}:${FOGLAMP_PORT}/foglamp/category/${SENDING_PROCESS_DATA}/producerToken -d '{ "value" : "'${OMF_PRODUCER_TOKEN}'" }'

--- a/tests/unit/python/foglamp/plugins/north/pi_server/test_pi_server.py
+++ b/tests/unit/python/foglamp/plugins/north/pi_server/test_pi_server.py
@@ -1290,19 +1290,16 @@ class TestPIServerNorthPlugin:
         # To avoid the wait time
         with patch.object(time, 'sleep', return_value=True):
 
-            with patch.object(fixture_omf_north._logger, 'warning', return_value=True) as patched_logger:
+            with patch.object(aiohttp.ClientSession,
+                              'post',
+                              return_value=MockAiohttpClientSessionError()
+                              ) as patched_aiohttp:
 
-                with patch.object(aiohttp.ClientSession,
-                                  'post',
-                                  return_value=MockAiohttpClientSessionError()
-                                  ) as patched_aiohttp:
-
-                    # Tests the raising of the exception
-                    with pytest.raises(Exception):
-                        await fixture_omf_north.send_in_memory_data_to_picromf("Type", p_test_data)
+                # Tests the raising of the exception
+                with pytest.raises(Exception):
+                    await fixture_omf_north.send_in_memory_data_to_picromf("Type", p_test_data)
 
         assert patched_aiohttp.call_count == max_retry
-        assert patched_logger.called
 
     @pytest.mark.parametrize(
         "p_data_origin, "


### PR DESCRIPTION
**Ready**

cases : 

Exceptions
```
Aug 28 11:12:09 ubuntu FogLAMP[1359] ERROR: sending_process: sending_process_North Readings to PI: cannot complete the sending operation - error details |an error occurred during the request to the destination - destination |https://WIN-4M7ODKB0RH2:5460/ingress/messages| - error details |Cannot connect to host win-4m7odkb0rh2:5460 ssl:None [Connect call failed ('192.168.1.235', 5460)]||

```

```
Aug 28 14:00:25 ubuntu FogLAMP[3023] ERROR: sending_process: sending_process_North Readings to PI: cannot complete the sending operation - error details |an error occurred during the request to the destination - destination |https://WIN-4M7ODKB0RH2:5460/ingress/messages| - error details |TimeoutError||
```

Status code 400 - type float, sending string : 
```
Aug 28 14:02:13 ubuntu FogLAMP[18981] ERROR: sending_process: sending_process_North Readings to PI: cannot complete the sending operation - error details |an error occurred during the request to the destination - destination |https://WIN-4M7ODKB0RH2:5460/ingress/messages| - error details |status code 400 - {"code":10,"message":"Type redefinition.","source":"foglamp_data.1126_fogbench_luxometer_typename_measurement.1.0.0.0","description":"OMF type with ID 'foglamp_data.1126_fogbench_luxometer_typename_measurement.1.0.0.0' has been already defined differently. Redefinition of the type with the same ID is not allowed."}||
```

Audit : 
```
49          STRMN       1           {"error - on _task_send_data":"cannot complete the sending operation - error details |an error occurred during the request to the destination - destination |https://WIN-4M7ODKB0RH2:5460/ingress/messages| - error details |status code 400 - {\"code\":10,\"message\":\"Type redefinition.\",\"source\":\"foglamp_data.1126_fogbench_luxometer_typename_measurement.1.0.0.0\",\"description\":\  2018-08-28 14:04:06.790

```