### PR TITLE
allowPing only when is_auth_optional is False

### DIFF
--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -54,12 +54,13 @@ async def ping(request):
     try:
         auth_token = request.token
     except AttributeError:
-        cfg_mgr = ConfigurationManager(connect.get_storage_async())
-        category_item = await cfg_mgr.get_category_item('rest_api', 'allowPing')
-        allow_ping = True if category_item['value'].lower() == 'true' else False
-        if request.is_auth_optional is False and allow_ping is False:
-            _logger.warning("Permission denied for Ping when Auth is mandatory.")
-            raise web.HTTPForbidden
+        if request.is_auth_optional is False:
+            cfg_mgr = ConfigurationManager(connect.get_storage_async())
+            category_item = await cfg_mgr.get_category_item('rest_api', 'allowPing')
+            allow_ping = True if category_item['value'].lower() == 'true' else False
+            if allow_ping is False:
+                _logger.warning("Permission denied for Ping when Auth is mandatory.")
+                raise web.HTTPForbidden
 
     since_started = time.time() - __start_time
 

--- a/tests/unit/python/foglamp/services/core/api/test_common_ping.py
+++ b/tests/unit/python/foglamp/services/core/api/test_common_ping.py
@@ -69,7 +69,6 @@ async def test_ping_http_allow_ping_true(test_server, test_client, loop):
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage_async', return_value=mockedStorageClientAsync):
             with patch.object(mockedStorageClientAsync, 'query_tbl_with_payload', return_value=mock_coro()) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
                     # fill route table
                     routes.setup(app)
@@ -89,7 +88,6 @@ async def test_ping_http_allow_ping_true(test_server, test_client, loop):
                     assert 100 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is True
-                mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
             query_patch.assert_called_once_with('statistics', payload)
         log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
         logger_info.assert_called_once_with(*log_params)
@@ -119,7 +117,6 @@ async def test_ping_http_allow_ping_false(test_server, test_client, loop):
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage_async', return_value=mockedStorageClientAsync):
             with patch.object(mockedStorageClientAsync, 'query_tbl_with_payload', return_value=mock_coro()) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
                     # fill route table
                     routes.setup(app)
@@ -139,7 +136,6 @@ async def test_ping_http_allow_ping_false(test_server, test_client, loop):
                     assert 100 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is True
-                mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
             query_patch.assert_called_once_with('statistics', payload)
         log_params = 'Received %s request for %s', 'GET', '/foglamp/ping'
         logger_info.assert_called_once_with(*log_params)
@@ -264,7 +260,6 @@ async def test_ping_https_allow_ping_true(test_server, ssl_ctx, test_client, loo
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage_async', return_value=mockedStorageClientAsync):
             with patch.object(mockedStorageClientAsync, 'query_tbl_with_payload', return_value=mock_coro()) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
                     # fill route table
                     routes.setup(app)
@@ -298,7 +293,6 @@ async def test_ping_https_allow_ping_true(test_server, ssl_ctx, test_client, loo
                     assert 100 == content_dict["dataSent"]
                     assert 1 == content_dict["dataPurged"]
                     assert content_dict["authenticationOptional"] is True
-                mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
             query_patch.assert_called_once_with('statistics', payload)
         logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/foglamp/ping')
 
@@ -327,7 +321,6 @@ async def test_ping_https_allow_ping_false(test_server, ssl_ctx, test_client, lo
     with patch.object(middleware._logger, 'info') as logger_info:
         with patch.object(connect, 'get_storage_async', return_value=mockedStorageClientAsync):
             with patch.object(mockedStorageClientAsync, 'query_tbl_with_payload', return_value=mock_coro()) as query_patch:
-                with patch.object(ConfigurationManager, "get_category_item", return_value=mock_get_category_item()) as mock_get_cat:
                     app = web.Application(loop=loop, middlewares=[middleware.optional_auth_middleware])
                     # fill route table
                     routes.setup(app)
@@ -354,7 +347,6 @@ async def test_ping_https_allow_ping_false(test_server, ssl_ctx, test_client, lo
                     s = resp.request_info.url.human_repr()
                     assert "https" == s[:5]
                     assert 200 == resp.status
-                mock_get_cat.assert_called_once_with('rest_api', 'allowPing')
             query_patch.assert_called_once_with('statistics', payload)
         logger_info.assert_called_once_with('Received %s request for %s', 'GET', '/foglamp/ping')
 


### PR DESCRIPTION
check allowPing config only if auth is disabled (NOT mandatory).

 It will not always be the case, we will cache rest_api category i.e per FOGL-1688 
*in  real production environment, http will be https (enableHttp: false) and auth enabled, i.e. authentication: mandatory*