### PR TITLE
FOGL-1654: C++ North plugins have incorrect API

### DIFF
--- a/C/common/config_category.cpp
+++ b/C/common/config_category.cpp
@@ -236,15 +236,33 @@ void ConfigCategory::checkDefaultValuesOnly() const
 }
 
 /**
- * Add an item to a configuration category
+ * Add an item to a category
+ *
+ * @param name	The item name
+ * @param item	The item value
  */
-void ConfigCategory::addItem(const std::string& name, const std::string description,
-                             const std::string& type, const std::string def,
-                             const std::string& value)
+void ConfigCategory::addItem(const std::string& name,
+			     const Value& item)
 {
-	m_items.push_back(new CategoryItem(name, description, type, def, value));
+
+	m_items.push_back(new CategoryItem(name, item));
 }
 
+/**
+ * Add an item to a configuration category
+ */
+void ConfigCategory::addItem(const std::string& name,
+			     const std::string description,
+                             const std::string& type,
+			     const std::string def,
+                             const std::string& value)
+{
+	m_items.push_back(new CategoryItem(name,
+					   description,
+					   type,
+					   def,
+					   value));
+}
 
 /**
  * Check for the existance of an item within the configuration category

--- a/C/common/include/config_category.h
+++ b/C/common/include/config_category.h
@@ -53,9 +53,13 @@ class ConfigCategory {
 		ConfigCategory() {};
 		ConfigCategory(const ConfigCategory& orig);
 		~ConfigCategory();
-		void				addItem(const std::string& name, const std::string description,
-							const std::string& type, const std::string def,
+		void				addItem(const std::string& name,
+							const std::string description,
+							const std::string& type,
+							const std::string def,
 							const std::string& value);
+		void 				addItem(const std::string& name,
+							const rapidjson::Value& item);
 		void				setDescription(const std::string& description);
 		std::string                     getName() const { return m_name; };
 		std::string                     getDescription() const { return m_description; };

--- a/C/plugins/north/PI_Server/plugin.cpp
+++ b/C/plugins/north/PI_Server/plugin.cpp
@@ -23,10 +23,16 @@
 using namespace std;
 
 #define PLUGIN_NAME "PI_Server"
+
 /**
  * Plugin specific default configuration
  */
-#define PLUGIN_DEFAULT_CONFIG "\"URL\": { " \
+#define PLUGIN_DEFAULT_CONFIG "{ " \
+			"\"plugin\": { " \
+				"\"description\": \"PI Server North C Plugin\", " \
+				"\"type\": \"string\", " \
+				"\"default\": \"" PLUGIN_NAME "\" }, " \
+			"\"URL\": { " \
 				"\"description\": \"The URL of the PI Connector to send data to\", " \
 				"\"type\": \"string\", " \
 				"\"default\": \"https://pi-server:5460/ingress/messages\" }, " \
@@ -43,22 +49,18 @@ using namespace std;
         			"\"description\": \"Seconds between each retry for the communication with the OMF PI Connector Relay, " \
                        		"NOTE : the time is doubled at each attempt.\", \"type\": \"integer\", \"default\": \"1\" }, " \
 			"\"StaticData\": { " \
-				"\"description\": \"Static data to include in each sensor reading sent to OMF.\", " \
+				"\"description\": \"Static data to include in each sensor reading sent to PI Server.\", " \
 				"\"type\": \"string\", \"default\": \"Location: Palo Alto, Company: Dianomic\" }, " \
 			"\"formatNumber\": { " \
         			"\"description\": \"OMF format property to apply to the type Number\", " \
 				"\"type\": \"string\", \"default\": \"float64\" }, " \
 			"\"formatInteger\": { " \
         			"\"description\": \"OMF format property to apply to the type Integer\", " \
-				"\"type\": \"string\", \"default\": \"int64\" } " 
-
-#define OMF_PLUGIN_DESC "\"plugin\": {\"description\": \"OMF North C Plugin\", " \
-			"\"type\": \"string\", \"default\": \"" PLUGIN_NAME "\"}"
-
-#define PLUGIN_DEFAULT_CONFIG_INFO "{" OMF_PLUGIN_DESC ", " PLUGIN_DEFAULT_CONFIG "}"
+				"\"type\": \"string\", \"default\": \"int64\" } " \
+		" }"
 
 /**
- * The OMF plugin interface
+ * The PI Server plugin interface
  */
 extern "C" {
 
@@ -71,7 +73,7 @@ static PLUGIN_INFORMATION info = {
 	0,				// Flags
 	PLUGIN_TYPE_NORTH,		// Type
 	"1.0.0",			// Interface version
-	PLUGIN_DEFAULT_CONFIG_INFO	// Configuration
+	PLUGIN_DEFAULT_CONFIG		// Configuration
 };
 
 /**
@@ -136,7 +138,7 @@ const string& plugin_extra_config()
 PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 {
 	/**
-	 * Handle plugin the parameters here
+	 * Handle PI Server parameters here
 	 */
 	string url = configData->getValue("URL");
 	unsigned int timeout = atoi(configData->getValue("OMFHttpTimeout").c_str());
@@ -184,7 +186,7 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 	string hostAndPort(hostName + ":" + port);	
 	connector_info.sender = new SimpleHttps(hostAndPort, timeout, timeout);
 
-	// Allocate the OMF data protocol
+	// Allocate the PI Server data protocol
 	connector_info.omf = new OMF(*connector_info.sender,
 				     path,
 				     typesId,

--- a/C/plugins/north/ThingSpeak/plugin.cpp
+++ b/C/plugins/north/ThingSpeak/plugin.cpp
@@ -5,7 +5,7 @@
  *
  * Released under the Apache 2.0 Licence
  *
- * Author: Mark Riddoch
+ * Author: Mark Riddoch, Massimiliano Pinto
  */
 #include <plugin_api.h>
 #include <stdio.h>
@@ -75,58 +75,41 @@ PLUGIN_INFORMATION *plugin_info()
 	return &info;
 }
 
-static const map<const string, const string> plugin_configuration = {
-					{
-						"PLUGIN",
-						string(PLUGIN_DEFAULT_CONFIG)
-					},
-				 };
-
-/**
- * Return default plugin configuration:
- * plugin specific and types_id
- */
-const map<const string, const string>& plugin_config()
-{
-	return plugin_configuration;
-}
-
 /**
  * Initialise the plugin with configuration.
  *
  * This funcion is called to get the plugin handle.
  */
-PLUGIN_HANDLE plugin_init(map<string, string>&& configData)
+PLUGIN_HANDLE plugin_init(const ConfigCategory* configData)
 {
-	ConfigCategory configCategory("cfg", configData["GLOBAL_CONFIGURATION"]);
-	if (! configCategory.itemExists("URL"))
+	if (!configData->itemExists("URL"))
 	{
 		Logger::getLogger()->fatal("ThingSpeak plugin must have a URL defined for the ThinkSpeak API");
 		throw exception();
 	}
-	string url = configCategory.getValue("URL");
-	if (! configCategory.itemExists("channelId"))
+	string url = configData->getValue("URL");
+	if (!configData->itemExists("channelId"))
 	{
 		Logger::getLogger()->fatal("ThingSpeak plugin must have a channel ID defined");
 		throw exception();
 	}
-	int channel = atoi(configCategory.getValue("channelId").c_str());
-	if (! configCategory.itemExists("fields"))
+	int channel = atoi(configData->getValue("channelId").c_str());
+	if (!configData->itemExists("fields"))
 	{
 		Logger::getLogger()->fatal("ThingSpeak plugin must have a field list defined");
 		throw exception();
 	}
-	string apiKey = configCategory.getValue("write_api_key");
+	string apiKey = configData->getValue("write_api_key");
 
 	ThingSpeak *thingSpeak = new ThingSpeak(url, channel, apiKey);
 	thingSpeak->connect();
 
-	if (! configCategory.itemExists("fields"))
+	if (!configData->itemExists("fields"))
 	{
 		Logger::getLogger()->fatal("ThingSpeak plugin must have a field list defined");
 		throw exception();
 	}
-	string fields = configCategory.getValue("fields");
+	string fields = configData->getValue("fields");
 	Document doc;
 	doc.Parse(fields.c_str());
 	if (!doc.HasParseError())

--- a/C/plugins/north/ThingSpeak/plugin.cpp
+++ b/C/plugins/north/ThingSpeak/plugin.cpp
@@ -27,7 +27,12 @@ using namespace rapidjson;
 /**
  * Plugin specific default configuration
  */
-#define PLUGIN_DEFAULT_CONFIG "\"URL\": { " \
+#define PLUGIN_DEFAULT_CONFIG "{ " \
+			"\"plugin\": { " \
+				"\"description\": \"ThingSpeak North\", " \
+				"\"type\": \"string\", " \
+				"\"default\": \"thingspeak\" }, " \
+			"\"URL\": { " \
 				"\"description\": \"The URL of the ThingSpeak service\", " \
 				"\"type\": \"string\", " \
 				"\"default\": \"https://api.thingspeak.com/channels\" }, " \
@@ -43,12 +48,8 @@ using namespace rapidjson;
 				    "\"elements\":[" \
 				    "{ \"asset\":\"sinusoid\"," \
 				    "\"reading\":\"sinusoid\"}" \
-				"]} }"
-		
-
-#define THINGSPEAK_PLUGIN_DESC "\"plugin\": {\"description\": \"ThingSpeak North\", \"type\": \"string\", \"default\": \"thingspeak\"}"
-
-#define PLUGIN_DEFAULT_CONFIG_INFO "{" THINGSPEAK_PLUGIN_DESC ", " PLUGIN_DEFAULT_CONFIG "}"
+				"]} } " \
+		"}"
 
 /**
  * The ThingSpeak plugin interface
@@ -64,7 +65,7 @@ static PLUGIN_INFORMATION info = {
 	0,				// Flags
 	PLUGIN_TYPE_NORTH,		// Type
 	"1.0.0",			// Interface version
-	PLUGIN_DEFAULT_CONFIG_INFO   	// Configuration
+	PLUGIN_DEFAULT_CONFIG		// Configuration
 };
 
 /**

--- a/C/plugins/north/http-north/plugin.cpp
+++ b/C/plugins/north/http-north/plugin.cpp
@@ -21,7 +21,12 @@ using namespace std;
 /**
  * Plugin specific default configuration
  */
-#define PLUGIN_DEFAULT_CONFIG "\"URL\": { " \
+#define PLUGIN_DEFAULT_CONFIG "{ " \
+			"\"plugin\": { " \
+				"\"description\": \"HTTP North C Plugin\", " \
+				"\"type\": \"string\", " \
+				"\"default\": \"http-north\" }, " \
+			"\"URL\": { " \
 				"\"description\": \"The URL of the HTTP Connector to send data to\", " \
 				"\"type\": \"string\", " \
 				"\"default\": \"http://localhost:6683/sensor-reading\" }, " \
@@ -30,17 +35,8 @@ using namespace std;
 				"\"type\": \"integer\", \"default\": \"10\" }, " \
 			"\"verifySSL\": { " \
         			"\"description\": \"Verify SSL certificate\", " \
-				"\"type\": \"boolean\", \"default\": \"False\" }, " \
-			"\"applyFilter\": { " \
-        			"\"description\": \"Whether to apply filter before processing the data\", " \
-				"\"type\": \"boolean\", \"default\": \"False\" }, " \
-			"\"filterRule\": { " \
-				"\"description\": \"JQ formatted filter to apply (applicable if applyFilter is True)\", " \
-				"\"type\": \"string\", \"default\": \".[]\" }"
-
-#define HTTP_NORTH_PLUGIN_DESC "\"plugin\": {\"description\": \"HTTP North C Plugin\", \"type\": \"string\", \"default\": \"http-north\"}"
-
-#define PLUGIN_DEFAULT_CONFIG_INFO "{" HTTP_NORTH_PLUGIN_DESC ", " PLUGIN_DEFAULT_CONFIG "}"
+				"\"type\": \"boolean\", \"default\": \"False\" } " \
+		" }"
 
 /**
  * The HTTP north plugin interface
@@ -56,7 +52,7 @@ static PLUGIN_INFORMATION info = {
 	0,				// Flags
 	PLUGIN_TYPE_NORTH,		// Type
 	"1.0.0",			// Interface version
-	PLUGIN_DEFAULT_CONFIG_INFO	// Configuration
+	PLUGIN_DEFAULT_CONFIG		// Configuration
 };
 
 /**

--- a/C/plugins/north/http-north/plugin.cpp
+++ b/C/plugins/north/http-north/plugin.cpp
@@ -5,7 +5,7 @@
  *
  * Released under the Apache 2.0 Licence
  *
- * Author: Amandeep Singh Arora
+ * Author: Amandeep Singh Arora, Massimiliano Pinto
  */
 #include <iostream>
 #include <string>
@@ -51,20 +51,13 @@ extern "C" {
  * The C API plugin information structure
  */
 static PLUGIN_INFORMATION info = {
-	"http",			// Name
-	"1.0.0",		// Version
-	0,			// Flags
-	PLUGIN_TYPE_NORTH,	// Type
-	"1.0.0",		// Interface version
-	PLUGIN_DEFAULT_CONFIG_INFO   // Configuration
+	"http",				// Name
+	"1.0.0",			// Version
+	0,				// Flags
+	PLUGIN_TYPE_NORTH,		// Type
+	"1.0.0",			// Interface version
+	PLUGIN_DEFAULT_CONFIG_INFO	// Configuration
 };
-
-static const map<const string, const string> plugin_configuration = {
-					{
-						"PLUGIN",
-						string(PLUGIN_DEFAULT_CONFIG)
-					}
-				 };
 
 /**
  * HTTP Server connector info
@@ -90,29 +83,19 @@ PLUGIN_INFORMATION *plugin_info()
 }
 
 /**
- * Return default plugin configuration:
- * plugin specific and types_id
- */
-const map<const string, const string>& plugin_config()
-{
-	return plugin_configuration;
-}
-
-/**
  * Initialise the plugin with configuration.
  *
  * This funcion is called to get the plugin handle.
  */
-PLUGIN_HANDLE plugin_init(map<string, string>&& configData)
+PLUGIN_HANDLE plugin_init(const ConfigCategory* configData)
 {
 	Logger::getLogger()->info("http-north C plugin: %s", __FUNCTION__);
 
 	/**
 	 * Handle the HTTP(S) parameters here
 	 */
-	ConfigCategory configCategory("cfg", configData["GLOBAL_CONFIGURATION"]);
-	string url = configCategory.getValue("URL");
-	unsigned int timeout = atoi(configCategory.getValue("HttpTimeout").c_str());
+	string url = configData->getValue("URL");
+	unsigned int timeout = atoi(configData->getValue("HttpTimeout").c_str());
 
 	/**
 	 * Extract host, port, path from URL

--- a/C/plugins/utils/get_plugin_info.cpp
+++ b/C/plugins/utils/get_plugin_info.cpp
@@ -5,7 +5,7 @@
  *
  * Released under the Apache 2.0 Licence
  *
- * Author: Amandeep Singh Arora
+ * Author: Amandeep Singh Arora, Massimiliano Pinto
  */
 
 #include <stdio.h>
@@ -13,8 +13,12 @@
 #include <unistd.h>
 #include <dlfcn.h>
 #include "plugin_api.h"
+#include <string.h>
+#include <string>
 
 typedef PLUGIN_INFORMATION *(*func_t)();
+typedef std::string *(*extra_config_t)();
+typedef void *(*generic_t)();
 
 /**
  * Extract value of a given symbol from given plugin library
@@ -31,28 +35,63 @@ int main(int argc, char *argv[])
 
   if (argc<2)
   {
-    fprintf(stderr, "Insufficient number of args...\n\nUsage: %s <plugin library> <function to fetch plugin info>\n", argv[0]);
+    fprintf(stderr, "Insufficient number of args...\n\nUsage: %s "
+            "<plugin library> <function to fetch plugin info>\n",
+            argv[0]);
     exit(1);
   }
 
   if (access(argv[1], F_OK|R_OK) != 0)
   {
-    fprintf(stderr, "Unable to access library file '%s', exiting...\n", argv[1]);
+    fprintf(stderr, "Unable to access library file '%s', exiting...\n",
+            argv[1]);
     exit(2);
   }
 
   if ((hndl = dlopen(argv[1], RTLD_GLOBAL|RTLD_LAZY)) != NULL)
   {
-    func_t infoEntry = (func_t)dlsym(hndl, argv[2]);
-    if (infoEntry == NULL)
+    generic_t method = (generic_t)dlsym(hndl, argv[2]);
+    if (method == NULL)
     {
       // Unable to find plugin_info entry point
-      fprintf(stderr, "Plugin library %s does not support %s function : %s\n", argv[1], argv[2], dlerror());
+      fprintf(stderr, "Plugin library %s does not support %s function : %s\n",
+              argv[1],
+              argv[2],
+              dlerror());
       dlclose(hndl);
       exit(3);
     }
-    PLUGIN_INFORMATION *info = (PLUGIN_INFORMATION *)(*infoEntry)();
-    printf("{\"name\": \"%s\", \"version\": \"%s\", \"type\": \"%s\", \"interface\": \"%s\", \"config\": %s}\n", info->name, info->version, info->type, info->interface, info->config);
+    if (strcmp(argv[2], "plugin_info") == 0)
+    {
+	func_t infoEntry = (func_t)method;
+        PLUGIN_INFORMATION *info = (PLUGIN_INFORMATION *)(*infoEntry)();
+        printf("{\"name\": \"%s\", \"version\": \"%s\", \"type\": \"%s\", "
+               "\"interface\": \"%s\", \"config\": %s}\n",
+               info->name,
+               info->version,
+               info->type,
+               info->interface,
+               info->config);
+    }
+    else if (strcmp(argv[2], "plugin_extra_config") == 0)
+    {
+       extra_config_t extraConfigEntry = (extra_config_t)method;	
+       std::string* pluginData = (std::string *)(*extraConfigEntry)();
+       if (pluginData == NULL ||
+           pluginData->empty())
+       {
+          // Set empty JSON object
+          pluginData = new std::string("{}");
+       }
+       printf("{ \"name\": \"Additional configuration\", "
+              "\"description\": \"Additional configuration categories "
+              "to pass to plugin_init\", \"categories\" : %s}\n",
+              pluginData->c_str());
+    }
+    else
+    {
+        printf("Output data format doesn't exist for function '%s'\n", argv[2]);
+    }
   }
   else
   {

--- a/C/tasks/north/sending_process/include/north_plugin.h
+++ b/C/tasks/north/sending_process/include/north_plugin.h
@@ -13,6 +13,7 @@
 #include <plugin.h>
 #include <plugin_manager.h>
 #include <reading.h>
+#include <config_category.h>
 
 /**
  * Class that represents a north plugin.
@@ -32,17 +33,19 @@ class NorthPlugin : public Plugin {
 		~NorthPlugin();
 
 		void			shutdown();
-		std::map<const std::string, const std::string>& 	config() const;
+		PLUGIN_INFORMATION* 	info() const;
+		std::string& 		extra_config() const;
 		uint32_t		send(const std::vector<Reading* >& readings) const;
-		PLUGIN_HANDLE		init(const std::map<std::string, std::string>& config);
+		PLUGIN_HANDLE		init(const ConfigCategory& config);
 
 	private:
 		// Function pointers
 		void			(*pluginShutdownPtr)(const PLUGIN_HANDLE);
-		std::map<const std::string, const std::string>&	(*pluginGetConfig)();
+		PLUGIN_INFORMATION*	(*pluginInfo)();
+		std::string&		(*pluginExtraConfig)();
 		uint32_t		(*pluginSend)(const PLUGIN_HANDLE,
 						      const std::vector<Reading* >& readings);
-		PLUGIN_HANDLE		(*pluginInit)(const std::map<std::string, std::string>& config);
+		PLUGIN_HANDLE		(*pluginInit)(const ConfigCategory* config);
 
 	private:
 		// Attributes

--- a/C/tasks/north/sending_process/include/sending.h
+++ b/C/tasks/north/sending_process/include/sending.h
@@ -79,10 +79,12 @@ class SendingProcess : public FogLampProcess
 		void			setSleepTime(unsigned long val) { m_sleep = val; };
 		void			setReadBlockSize(unsigned long size) { m_block_size = size; };
 		bool			loadPlugin(const std::string& pluginName);
-		const std::map<std::string, std::string>& fetchConfiguration(const std::string& defCfg,
-									     const std::string& plugin_name);
+		ConfigCategory		fetchConfiguration(const std::string& defCfg,
+							   const std::string& pluginName);
 		bool			loadFilters(const std::string& pluginName);
 		bool			setupFiltersPipeline() const;
+		void			handleAdditionalConfiguration(ConfigCategory& config,
+								      const std::string& extraConfig);
 
 		// Make private the copy constructor and operator=
 		SendingProcess(const SendingProcess &);

--- a/C/tasks/north/sending_process/north_plugin.cpp
+++ b/C/tasks/north/sending_process/north_plugin.cpp
@@ -13,6 +13,9 @@
 
 using namespace std;
 
+// Empty value for "plugin_extra_config"
+static string empty_extra_config;
+
 /**
  * Constructor for the class that wraps the OMF north plugin
  *
@@ -71,20 +74,14 @@ PLUGIN_INFORMATION* NorthPlugin::info() const
         return this->pluginInfo();
 }
 
-static string empty_extra_config;
 /**
  * Return plugin additional configuration
  */
 string& NorthPlugin::extra_config() const
 {
-	if (pluginExtraConfig != NULL)
-	{
-		return this->pluginExtraConfig();
-	}
-	else
-	{
-		return empty_extra_config;
-	}
+	return pluginExtraConfig ?
+		this->pluginExtraConfig() :
+		empty_extra_config;
 }
 
 /**

--- a/C/tasks/north/sending_process/north_plugin.cpp
+++ b/C/tasks/north/sending_process/north_plugin.cpp
@@ -22,7 +22,7 @@ using namespace std;
 NorthPlugin::NorthPlugin(const PLUGIN_HANDLE handle) : Plugin(handle)
 {
         // Setup the function pointers to the plugin
-        pluginInit = (PLUGIN_HANDLE (*)(const map<string, string>& config))
+        pluginInit = (PLUGIN_HANDLE (*)(const ConfigCategory* config))
 					manager->resolveSymbol(handle, "plugin_init");
 
 	pluginShutdownPtr = (void (*)(const PLUGIN_HANDLE))
@@ -31,7 +31,11 @@ NorthPlugin::NorthPlugin(const PLUGIN_HANDLE handle) : Plugin(handle)
 	pluginSend = (uint32_t (*)(const PLUGIN_HANDLE, const vector<Reading* >& readings))
 				   manager->resolveSymbol(handle, "plugin_send");
 
-	pluginGetConfig = (map<const string, const string>& (*)())manager->resolveSymbol(handle, "plugin_config");
+	pluginInfo = (PLUGIN_INFORMATION* (*)())
+					      manager->resolveSymbol(handle, "plugin_info");
+
+	pluginExtraConfig = (string& (*)())
+					 manager->resolveSymbol(handle, "plugin_extra_config");
 }
 
 // Destructor
@@ -45,10 +49,10 @@ NorthPlugin::~NorthPlugin()
  * @param config    The configuration data
  * @return          The plugin handle
  */
-PLUGIN_HANDLE NorthPlugin::init(const map<string, string>& config)
+PLUGIN_HANDLE NorthPlugin::init(const ConfigCategory& config)
 {
-	m_instance = this->pluginInit(config);
-	return &m_instance;
+	m_instance = this->pluginInit(&config);
+	return m_instance ? &m_instance : NULL;
 }
 
 /**
@@ -62,12 +66,25 @@ uint32_t NorthPlugin::send(const vector<Reading* >& readings) const
 	return this->pluginSend(m_instance, readings);
 }
 
-/**
- * Return plugin specific configuration
- */
-map<const string, const string>& NorthPlugin::config() const
+PLUGIN_INFORMATION* NorthPlugin::info() const
 {
-	return this->pluginGetConfig();
+        return this->pluginInfo();
+}
+
+static string empty_extra_config;
+/**
+ * Return plugin additional configuration
+ */
+string& NorthPlugin::extra_config() const
+{
+	if (pluginExtraConfig != NULL)
+	{
+		return this->pluginExtraConfig();
+	}
+	else
+	{
+		return empty_extra_config;
+	}
 }
 
 /**

--- a/C/tasks/north/sending_process/sending.cpp
+++ b/C/tasks/north/sending_process/sending.cpp
@@ -146,7 +146,7 @@ SendingProcess::SendingProcess(int argc, char** argv) : FogLampProcess(argc, arg
         }
 
         // Read now the sending process configuration merged with the one
-	// related to the loaded plugin
+        // related to the loaded plugin
         ConfigCategory config = this->fetchConfiguration(sendingDefaultConfig,
 							 m_plugin_name);
 

--- a/C/tasks/north/sending_process/sending_process.cpp
+++ b/C/tasks/north/sending_process/sending_process.cpp
@@ -52,8 +52,6 @@ int main(int argc, char** argv)
 {
 	try
 	{
-        std::string tmp_str;
-
                 // Instantiate SendingProcess class
 		SendingProcess sendingProcess(argc, argv);
                 


### PR DESCRIPTION
WIP

This implementation lets "plugin_init" to use only ConfigCategory parameter
There is an extra API call "plugin_extra_config" at the moment.
We are looking for other solutions, avoiding usage of "plugin_extra_config".

Implementation details


C++ North plugins have incorrect API

- With this change the “plugin_init” method takes as parameter a ConfigCategory object instead of a JSON string map configuration. 

- The "PI_Server" north plugin only has new method “plugin_extra_config”.
   NOTE: if the method “plugin_extra_config” doesn’t exist and it's called, an empty string is returned: 
   no exceptions.

  `string extraConfig = this->m_plugin->extra_config();`

- When this method is called it returns a JSON with additional categories to create/update.
  Those category items (created/updated and fetched) are passed back to plugin via “plugin_init” as 
  new items with this name format:
  CATEGORY_NAME . INTEM_NAME, i.e.
  OMF_TYPES.type-id

   `string typesId = configData->getValue("OMF_TYPES.type-id");`



**_Additions:_**
get_plugin_info utility updated with “plugin_extra_config”:


plugins/utils/get_plugin_info plugins/north/PI_Server/libPI_Server.so.1 plugin_extra_config | jq

```
{
  "name": "Additional configuration",
  "description": "Additional configuration categories to pass to plugin_init",
  "categories": {
    "OMF_TYPES": {
      "type-id": {
        "description": "Identify sensor and measurement types",
        "type": "integer",
        "default": "0001"
      }
    }
  }
}
```
