### PR TITLE
FOGL-1798 - Bad request when config item value is non-string value irrespective of the type

### DIFF
--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -202,7 +202,7 @@ async def set_configuration_item(request):
     try:
         value = data['value']
         if not isinstance(value, str):
-            raise web.HTTPBadRequest(reason='{} should be passed in double quotes'.format(value))
+            raise web.HTTPBadRequest(reason='{} should be a string literal, in double quotes'.format(value))
     except KeyError:
         raise web.HTTPBadRequest(reason='Missing required value for {}'.format(config_item))
 

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -201,6 +201,8 @@ async def set_configuration_item(request):
 
     try:
         value = data['value']
+        if not isinstance(value, str):
+            raise web.HTTPBadRequest(reason='{} should be passed in double quotes'.format(value))
     except KeyError:
         raise web.HTTPBadRequest(reason='Missing required value for {}'.format(config_item))
 

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -231,7 +231,7 @@ class TestConfiguration:
     @pytest.mark.parametrize("payload, message", [
         ({"valu": '8082'}, "Missing required value for http_port"),
         ({"valu": 8082}, "Missing required value for http_port"),
-        ({"value": 8082}, "8082 should be passed in double quotes")
+        ({"value": 8082}, "8082 should be a string literal, in double quotes")
     ])
     async def test_set_config_item_bad_request(self, client, payload, message, category_name='rest_api', item_name='http_port'):
         storage_client_mock = MagicMock(StorageClientAsync)

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -228,14 +228,18 @@ class TestConfiguration:
                 patch_get_cat_item.assert_called_once_with(category_name, item_name)
             patch_set_entry.assert_called_once_with(category_name, item_name, payload['value'])
 
-    async def test_set_config_item_bad_request(self, client, category_name='rest_api', item_name='http_port'):
-        payload = {"valu": '8082'}
+    @pytest.mark.parametrize("payload, message", [
+        ({"valu": '8082'}, "Missing required value for http_port"),
+        ({"valu": 8082}, "Missing required value for http_port"),
+        ({"value": 8082}, "8082 should be passed in double quotes")
+    ])
+    async def test_set_config_item_bad_request(self, client, payload, message, category_name='rest_api', item_name='http_port'):
         storage_client_mock = MagicMock(StorageClientAsync)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             resp = await client.put('/foglamp/category/{}/{}'.format(category_name, item_name),
                                     data=json.dumps(payload))
             assert 400 == resp.status
-            assert 'Missing required value for {}'.format(item_name) == resp.reason
+            assert message == resp.reason
 
     async def test_set_config_item_not_found(self, client, category_name='rest_api', item_name='http_port'):
         async def async_mock():


### PR DESCRIPTION
```
curl -v -sX PUT http://localhost:8081/foglamp/category/North%20Readings%20to%20PI/blockSize -d '{"value":13}' | grep "HTTP/1.1"

< HTTP/1.1 400 13 should be passed in double quotes
```