### PR TITLE
FOGL-1841 purge error fixes

### DIFF
--- a/python/foglamp/tasks/purge/purge.py
+++ b/python/foglamp/tasks/purge/purge.py
@@ -22,7 +22,6 @@ Statistics reported by Purge process are:
     -> Remaining readings
     All these statistics are inserted into the log table
 """
-import asyncio
 import time
 
 from foglamp.common.audit_logger import AuditLogger
@@ -105,17 +104,22 @@ class Purge(FoglampProcess):
         start_time = time.strftime('%Y-%m-%d %H:%M:%S.%s', time.localtime(time.time()))
 
         payload = PayloadBuilder().AGGREGATE(["count", "*"]).payload()
-        result = await self._storage_async.query_tbl_with_payload("readings", payload)
+        result = await self._readings_storage_async.query(payload)
         total_count = result['rows'][0]['count_*']
-
         payload = PayloadBuilder().AGGREGATE(["min", "last_object"]).payload()
         result = await self._storage_async.query_tbl_with_payload("streams", payload)
-        last_id = result["rows"][0]["min_last_object"] if result["count"] == 1 else 0
-
-        flag = "purge" if config['retainUnsent']['value'] == "False" else "retain"
+        last_object = result["rows"][0]["min_last_object"]
+        if result["count"] == 1:
+            # FIXME: Remove below check when fix from storage layer
+            # Below check is required as If no streams entry exists in DB storage layer returns response as below:
+            # {'rows': [{'min_last_object': ''}], 'count': 1}
+            # BTW it should return integer i.e 0 not in string
+            last_id = 0 if last_object == '' else last_object
+        else:
+            last_id = 0
+        flag = "purge" if config['retainUnsent']['value'].lower() == "false" else "retain"
         try:
             if int(config['age']['value']) != 0:
-
                 result = await self._readings_storage_async.purge(age=config['age']['value'], sent_id=last_id, flag=flag)
 
                 total_count = result['readings']

--- a/tests/unit/python/foglamp/tasks/purge/test_purge.py
+++ b/tests/unit/python/foglamp/tasks/purge/test_purge.py
@@ -27,7 +27,6 @@ __version__ = "${VERSION}"
 @asyncio.coroutine
 def q_result(*args):
     table = args[0]
-
     if table == 'readings':
         return {"rows": [{"count_*": 1}], "count": 1}
 
@@ -135,17 +134,25 @@ class TestPurge:
                 p._storage_async = MagicMock(spec=StorageClientAsync)
                 p._readings_storage_async = MagicMock(spec=ReadingsStorageClientAsync)
                 audit = p._audit
-                with patch.object(p._storage_async, "query_tbl_with_payload",
-                                  side_effect=q_result) as patch_storage:
-                    with patch.object(p._readings_storage_async, 'purge', side_effect=self.store_purge) as mock_storage_purge:
-                        with patch.object(audit, 'information', return_value=mock_audit_info()) as audit_info:
-                            # Test the positive case when all if conditions in purge_data pass
-                            assert expected_return == await p.purge_data(conf)
-                            assert audit_info.called
-                            args, kwargs = mock_storage_purge.call_args
-                            assert kwargs == expected_calls
-                assert patch_storage.called
-                assert 2 == patch_storage.call_count
+                with patch.object(p._readings_storage_async, "query",
+                                  return_value=q_result('readings')) as patch_query:
+                    with patch.object(p._storage_async, "query_tbl_with_payload",
+                                      return_value=q_result('streams')) as patch_storage:
+                        with patch.object(p._readings_storage_async, 'purge',
+                                          side_effect=self.store_purge) as mock_storage_purge:
+                            with patch.object(audit, 'information', return_value=mock_audit_info()) as audit_info:
+                                # Test the positive case when all if conditions in purge_data pass
+                                assert expected_return == await p.purge_data(conf)
+                                assert audit_info.called
+                                args, kwargs = mock_storage_purge.call_args
+                                assert kwargs == expected_calls
+                    assert patch_storage.called
+                    assert 1 == patch_storage.call_count
+                    args, kwargs = patch_storage.call_args
+                    assert ('streams', '{"aggregate": {"operation": "min", "column": "last_object"}}') == args
+                assert patch_query.called
+                args1, kwargs1 = patch_query.call_args
+                assert ('{"aggregate": {"operation": "count", "column": "*"}}',) == args1
 
     @pytest.mark.parametrize("conf, expected_return", [
         ({"retainUnsent": {"value": "False"}, "age": {"value": "0"}, "size": {"value": "0"}}, (0, 0)),
@@ -170,14 +177,18 @@ class TestPurge:
                 p._storage_async = MagicMock(spec=StorageClientAsync)
                 p._readings_storage_async = MagicMock(spec=ReadingsStorageClientAsync)
                 audit = p._audit
-                with patch.object(p._storage_async, "query_tbl_with_payload",
-                                  side_effect=q_result) as patch_storage:
-                    with patch.object(p._readings_storage_async, 'purge', side_effect=self.store_purge):
-                        with patch.object(audit, 'information', return_value=mock_audit_info()):
-                            assert expected_return == await p.purge_data(conf)
-                            p._logger.info.assert_called_once_with("No rows purged")
-                assert patch_storage.called
-                assert 2 == patch_storage.call_count
+                with patch.object(p._readings_storage_async, "query",
+                                  return_value=q_result('readings')) as patch_query:
+                    with patch.object(p._storage_async, "query_tbl_with_payload",
+                                      return_value=q_result('streams')) as patch_storage:
+                        with patch.object(p._readings_storage_async, 'purge', side_effect=self.store_purge):
+                            with patch.object(audit, 'information', return_value=mock_audit_info()):
+                                assert expected_return == await p.purge_data(conf)
+                                p._logger.info.assert_called_once_with("No rows purged")
+                    assert patch_storage.called
+                    assert 1 == patch_storage.call_count
+                assert patch_query.called
+                assert 1 == patch_query.call_count
 
     @pytest.mark.parametrize("conf, expected_return", [
         ({"retainUnsent": {"value": "True"}, "age": {"value": "-1"}, "size": {"value": "-1"}}, (0, 0))
@@ -201,13 +212,17 @@ class TestPurge:
                 p._storage_async = MagicMock(spec=StorageClientAsync)
                 p._readings_storage_async = MagicMock(spec=ReadingsStorageClientAsync)
                 audit = p._audit
-                with patch.object(p._storage_async, "query_tbl_with_payload",
-                                  side_effect=q_result) as patch_storage:
-                    with patch.object(p._readings_storage_async, 'purge', side_effect=self.store_purge):
-                        with patch.object(audit, 'information', return_value=mock_audit_info()):
-                            assert expected_return == await p.purge_data(conf)
-                assert patch_storage.called
-                assert 2 == patch_storage.call_count
+                with patch.object(p._readings_storage_async, "query",
+                                  return_value=q_result('readings')) as patch_query:
+                    with patch.object(p._storage_async, "query_tbl_with_payload",
+                                      return_value=q_result('streams')) as patch_storage:
+                        with patch.object(p._readings_storage_async, 'purge', side_effect=self.store_purge):
+                            with patch.object(audit, 'information', return_value=mock_audit_info()):
+                                assert expected_return == await p.purge_data(conf)
+                    assert patch_storage.called
+                    assert 1 == patch_storage.call_count
+                assert patch_query.called
+                assert 1 == patch_query.call_count
 
     @pytest.mark.parametrize("conf, expected_error_key",
                              [({"retainUnsent": {"value": "True"}, "age": {"value": "bla"}, "size": {"value": "0"}},
@@ -233,23 +248,23 @@ class TestPurge:
                 p._storage_async = MagicMock(spec=StorageClientAsync)
                 p._readings_storage_async = MagicMock(spec=ReadingsStorageClientAsync)
                 audit = p._audit
-                with patch.object(p._storage_async, "query_tbl_with_payload",
-                                  side_effect=q_result) as patch_storage:
-                    with patch.object(p._readings_storage_async, 'purge', side_effect=self.store_purge) as mock_storage_purge:
-                        with patch.object(audit, 'information', return_value=mock_audit_info()) as audit_info:
-                            # Test the code block when purge failed because of invalid configuration
-                            await p.purge_data(conf)
-                            p._logger.error.assert_called_with('Configuration item {} bla should be integer!'.
-                                                               format(expected_error_key))
-                assert patch_storage.called
-                assert 2 == patch_storage.call_count
+                with patch.object(p._readings_storage_async, "query",
+                                  return_value=q_result('readings')) as patch_query:
+                    with patch.object(p._storage_async, "query_tbl_with_payload",
+                                      return_value=q_result('streams')) as patch_storage:
+                        with patch.object(p._readings_storage_async, 'purge', side_effect=self.store_purge):
+                            with patch.object(audit, 'information', return_value=mock_audit_info()):
+                                # Test the code block when purge failed because of invalid configuration
+                                await p.purge_data(conf)
+                                p._logger.error.assert_called_with('Configuration item {} bla should be integer!'.
+                                                                   format(expected_error_key))
+                    assert patch_storage.called
+                    assert 1 == patch_storage.call_count
+                assert patch_query.called
+                assert 1 == patch_query.call_count
 
     async def test_run(self):
         """Test that run calls all units of purge process"""
-        @asyncio.coroutine
-        def mock_audit_info():
-            return ""
-
         @asyncio.coroutine
         def mock_config():
             return "Some config"


### PR DESCRIPTION
**Fixed items:**
1)  Total count for readings with readings storage client `query` method now (As it seems to be faster than actual call)
2) For response when streams aggregated infor for min + last object like  `{'rows': [{'min_last_object': ''}], 'count': 1}`
It should be fixed from storage layer and return integer value when no data in streams table, before it was working only due to we have prerequisite entries in init.sql for stream table
3) `config['retainUnsent']['value'].lower()` - Fixed as this condition always flag value set to `retain`
4) unit tests refactored as per new change


**NOTE** - Purge by size errors are still there as no support for any of engine. See https://scaledb.atlassian.net/browse/FOGL-1301