### PR TITLE
FOGL-1839 bad plugins handling for plugin_discovery

### DIFF
--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -67,14 +67,18 @@ class PluginDiscovery(object):
         libs = utils.find_c_plugin_libs(plugin_type)
         configs = []
         for l in libs:
-            jdoc = utils.get_plugin_info(l)
-            if jdoc is not None:
-                plugin_config = {'name': l,
-                                 'type': plugin_type,
-                                 'description': jdoc['config']['plugin']['description'],
-                                 'version': jdoc['version']
-                                 }
-                configs.append(plugin_config)
+            try:
+                jdoc = utils.get_plugin_info(l)
+                if bool(jdoc):
+                    plugin_config = {'name': l,
+                                     'type': plugin_type,
+                                     'description': jdoc['config']['plugin']['description'],
+                                     'version': jdoc['version']
+                                     }
+                    configs.append(plugin_config)
+            except Exception as ex:
+                _logger.exception(ex)
+
         return configs
 
     @classmethod

--- a/python/foglamp/services/core/api/utils.py
+++ b/python/foglamp/services/core/api/utils.py
@@ -17,7 +17,7 @@ def get_plugin_info(name):
         res = out.decode("utf-8")
         jdoc = json.loads(res)
     except (OSError, subprocess.CalledProcessError, Exception) as ex:
-        _logger.exception("C plugin get info failed due to %s", ex)
+        _logger.exception("%s C plugin get info failed due to %s", name, ex)
         return {}
     else:
         return jdoc


### PR DESCRIPTION
**Note**: handling for bad python plugins already there. So, fixed for bad C-plugins. So, list of plugins we return only in case of good plugins.

Also, -ve unit tests added for both python and C type plugins

**Example:**
1) Let say we have below plugins in an evironment

```
Good south python plugins: `sinusoid, coap`
Bad south python plugins: `sensehat, envirophat` (If no external deps installed)
Good north python plugins: `pi_server`

Good south C plugins: `Random`
Bad south C plugins: `dummy` (./plugins/south/libdummy.so)
Good north C plugins: `PI_Server`
Bad north c plugins: `omf` (./plugins/north/libomf.so)
```

```
$ curl -sX GET http://localhost:8081/foglamp/plugins/installed | jq
{
  "plugins": [
{
      "type": "north",
      "version": "1.0.0",
      "description": "PI Server North Plugin",
      "name": "pi_server"
    },
    {
      "type": "north",
      "version": "1.0.0",
      "description": "PI Server North C Plugin",
      "name": "PI_Server"
    },
    {
      "type": "south",
      "version": "1.0",
      "description": "Sinusoid Plugin",
      "name": "sinusoid"
    },
    {
      "type": "south",
      "version": "1.0",
      "description": "CoAP Listener South Plugin",
      "name": "coap"
    },
    {
      "type": "south",
      "version": "1.0.0",
      "description": "Random C south plugin",
      "name": "Random"
    }
  ]
}
```




