### PR TITLE
FOGL-1907 - South plugin as North Task and North Plugin as South Service should not be allowed

### DIFF
--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -94,12 +94,15 @@ class PluginDiscovery(object):
 
             # Fetch configuration from the configuration defined in the plugin
             plugin_info = _plugin.plugin_info()
-            plugin_config = {
-                'name': plugin_info['config']['plugin']['default'],
-                'type': plugin_info['type'],
-                'description': plugin_info['config']['plugin']['description'],
-                'version': plugin_info['version']
-            }
+            if plugin_info['type'] == plugin_type:
+                plugin_config = {
+                    'name': plugin_info['config']['plugin']['default'],
+                    'type': plugin_info['type'],
+                    'description': plugin_info['config']['plugin']['description'],
+                    'version': plugin_info['version']
+                }
+            else:
+                _logger.warning("Plugin {} is discarded due to invalid type".format(plugin_dir))
         except ImportError as ex:
             _logger.error('Plugin "{}" import problem from path "{}". {}'.format(plugin_dir, plugin_module_path, str(ex)))
         except Exception as ex:

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -123,12 +123,20 @@ async def add_service(request):
             script = '["services/south"]' if service_type == 'south' else '["services/north"]'
             # Fetch configuration from the configuration defined in the plugin
             plugin_info = _plugin.plugin_info()
+            if plugin_info['type'] != service_type:
+                msg = "Plugin of {} type is not supported".format(plugin_info['type'])
+                _logger.exception(msg)
+                return web.HTTPBadRequest(reason=msg)
             plugin_config = plugin_info['config']
             process_name = 'south'
         except ImportError as ex:
             # Checking for C-type plugins
             script = '["services/south_c"]' if service_type == 'south' else '["services/north_c"]'
             plugin_info = apiutils.get_plugin_info(plugin)
+            if plugin_info['type'] != service_type:
+                msg = "Plugin of {} type is not supported".format(plugin_info['type'])
+                _logger.exception(msg)
+                return web.HTTPBadRequest(reason=msg)
             plugin_config = plugin_info['config']
             process_name = 'south_c'
             if not plugin_config:

--- a/python/foglamp/services/core/api/task.py
+++ b/python/foglamp/services/core/api/task.py
@@ -14,7 +14,6 @@ from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.common.storage_client.payload_builder import PayloadBuilder
 from foglamp.common.storage_client.exceptions import StorageServerError
 
-
 from foglamp.services.core import server
 from foglamp.services.core import connect
 from foglamp.services.core.scheduler.entities import Schedule, TimedSchedule, IntervalSchedule, ManualSchedule
@@ -139,12 +138,20 @@ async def add_task(request):
             script = '["tasks/north"]'
             # Fetch configuration from the configuration defined in the plugin
             plugin_info = _plugin.plugin_info()
+            if plugin_info['type'] != task_type:
+                msg = "Plugin of {} type is not supported".format(plugin_info['type'])
+                _logger.exception(msg)
+                return web.HTTPBadRequest(reason=msg)
             plugin_config = plugin_info['config']
             process_name = 'north'
         except ImportError as ex:
             # Checking for C-type plugins
             script = '["tasks/north_c"]'
             plugin_info = apiutils.get_plugin_info(plugin)
+            if plugin_info['type'] != task_type:
+                msg = "Plugin of {} type is not supported".format(plugin_info['type'])
+                _logger.exception(msg)
+                return web.HTTPBadRequest(reason=msg)
             plugin_config = plugin_info['config']
             process_name = 'north_c'
             if not plugin_config:


### PR DESCRIPTION
Restriction on south plugin as north task and vice-versa; 
Also restricted on plugin discovery and fixed some bad tests and new unit tests added