### PR TITLE
FOGL-1872 patch | encode url for category name for create_child_category foglamp microservice client request

### DIFF
--- a/python/foglamp/common/microservice_management_client/microservice_management_client.py
+++ b/python/foglamp/common/microservice_management_client/microservice_management_client.py
@@ -260,7 +260,7 @@ class MicroserviceManagementClient(object):
         :return:
         """
         data = {"children": children}
-        url = '/foglamp/service/category/{}/children'.format(parent)
+        url = '/foglamp/service/category/{}/children'.format(urllib.parse.quote(parent))
 
         self._management_client_conn.request(method='POST', url=url, body=json.dumps(data))
         r = self._management_client_conn.getresponse()


### PR DESCRIPTION
current develop is broken, if we use a space or any such character that need url encoding, in add service. e.g. `SVC #1`, `FL 1`


With  FOGL-1872, PR #1149 use this action.

https://github.com/foglamp/FogLAMP/pull/1149/files#diff-7df07f442adb2ea900e3799bcbba7defR184