### PR TITLE
FOGL-1943 Removed unused config and Avoid object instantiation on each queue ingest 

### DIFF
--- a/python/foglamp/common/statistics.py
+++ b/python/foglamp/common/statistics.py
@@ -17,6 +17,7 @@ __version__ = "${VERSION}"
 
 _logger = logger.setup(__name__)
 
+
 async def create_statistics(storage=None):
     stat = Statistics(storage)
     await stat._init()

--- a/python/foglamp/services/south/ingest.py
+++ b/python/foglamp/services/south/ingest.py
@@ -52,12 +52,6 @@ class Ingest(object):
     _sensor_stats = {}  # type: dict
     """Number of sensor readings accepted before statistics were written to storage"""
 
-    _write_statistics_task = None  # type: asyncio.Task
-    """asyncio task for :meth:`_write_statistics`"""
-
-    _write_statistics_sleep_task = None  # type: asyncio.Task
-    """asyncio task for asyncio.sleep"""
-
     _stop = False
     """True when the server needs to stop"""
 
@@ -91,10 +85,6 @@ class Ingest(object):
     _readings_list_size = 0  # type: int
     """Maximum number of readings items in each buffer"""
 
-    # Configuration (begin)
-    _write_statistics_frequency_seconds = 5
-    """The number of seconds to wait before writing readings-related statistics to storage"""
-
     _readings_buffer_size = 4096
     """Maximum number of readings to buffer in memory(_max_concurrent_readings_inserts x _readings_insert_batch_size)"""
 
@@ -113,12 +103,13 @@ class Ingest(object):
     _max_readings_insert_batch_reconnect_wait_seconds = 10
     """The maximum number of seconds to wait before reconnecting to storage when inserting readings"""
 
+    # Configuration (end)
+
     _payload_events = []
     """The list of unique reading payload for asset tracker"""
 
-    # Configuration (end)
-
     _stats = None
+    """Statistics class instance"""
 
     @classmethod
     async def _read_config(cls):
@@ -128,12 +119,6 @@ class Ingest(object):
         category = "{}Advanced".format(cls._parent_service._name)
 
         default_config = {
-            "write_statistics_frequency_seconds": {
-                "description": "Seconds to wait before writing readings-related "
-                               "statistics to storage",
-                "type": "integer",
-                "default": str(cls._write_statistics_frequency_seconds)
-            },
             "readings_buffer_size": {
                 "description": "Maximum number of readings to buffer in memory",
                 "type": "integer",
@@ -185,8 +170,6 @@ class Ingest(object):
         # Create child category
         cls._parent_service._core_microservice_management_client.create_child_category(parent=cls._parent_service._name, children=[category])
 
-        cls._write_statistics_frequency_seconds = int(config['write_statistics_frequency_seconds']
-                                                      ['value'])
         cls._readings_buffer_size = int(config['readings_buffer_size']['value'])
         cls._max_concurrent_readings_inserts = int(config['max_concurrent_readings_inserts']
                                                    ['value'])
@@ -255,8 +238,8 @@ class Ingest(object):
         # Register static statistics
         await cls.stats.register('READINGS', 'Readings received by FogLAMP')
         await cls.stats.register('DISCARDED', 'Readings discarded at the input side by FogLAMP, i.e. '
-                                          'discarded before being  placed in the buffer. This may be due to some '
-                                          'error in the readings themselves.')
+                                              'discarded before being placed in the buffer. This may be due to some '
+                                              'error in the readings themselves.')
 
         cls._stop = False
         cls._started = True
@@ -390,7 +373,6 @@ class Ingest(object):
                 except Exception as ex:
                     attempt += 1
 
-                    # TODO logging each time is overkill
                     _LOGGER.exception('Insert failed on attempt #%s, list index: %s | %s', attempt, list_index, str(ex))
 
                     if cls._stop or attempt >= _MAX_ATTEMPTS:
@@ -550,7 +532,6 @@ class Ingest(object):
         read['read_key'] = str(key)
         read['reading'] = readings
         read['user_ts'] = timestamp
-
         readings_list.append(read)
 
         list_size = len(readings_list)

--- a/python/foglamp/services/south/ingest.py
+++ b/python/foglamp/services/south/ingest.py
@@ -108,7 +108,7 @@ class Ingest(object):
     _payload_events = []
     """The list of unique reading payload for asset tracker"""
 
-    _stats = None
+    stats = None
     """Statistics class instance"""
 
     @classmethod

--- a/tests/unit/python/foglamp/services/south/test_ingest.py
+++ b/tests/unit/python/foglamp/services/south/test_ingest.py
@@ -15,19 +15,19 @@ from foglamp.services.south import ingest
 from foglamp.common.storage_client.storage_client import StorageClientAsync, ReadingsStorageClientAsync
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient
 
-
 __author__ = "Amarendra K Sinha"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
-
 @asyncio.coroutine
 def mock_coro():
     yield from false_coro()
 
+
 async def false_coro():
     return True
+
 
 def get_cat(old_config):
     new_config = {}
@@ -36,6 +36,7 @@ def get_cat(old_config):
         new_value['value'] = new_value['default']
         new_config.update({key: new_value})
     return new_config
+
 
 @pytest.allure.feature("unit")
 @pytest.allure.story("services", "south", "ingest")
@@ -71,12 +72,6 @@ class TestIngest:
         Ingest._max_readings_insert_batch_reconnect_wait_seconds = 10
         Ingest.category = 'South'
         Ingest.default_config = {
-            "write_statistics_frequency_seconds": {
-                "description": "The number of seconds to wait before writing readings-related "
-                               "statistics to storage",
-                "type": "integer",
-                "default": str(Ingest._write_statistics_frequency_seconds)
-            },
             "readings_buffer_size": {
                 "description": "The maximum number of readings to buffer in memory",
                 "type": "integer",
@@ -131,8 +126,6 @@ class TestIngest:
         assert 1 == create_cfg.call_count
         assert 1 == get_cfg.call_count
         new_config = get_cat(Ingest.default_config)
-        assert Ingest._write_statistics_frequency_seconds == \
-               int(new_config['write_statistics_frequency_seconds']['value'])
         assert Ingest._readings_buffer_size == int(new_config['readings_buffer_size']['value'])
         assert Ingest._max_concurrent_readings_inserts == \
                int(new_config['max_concurrent_readings_inserts']['value'])
@@ -146,6 +139,17 @@ class TestIngest:
         
     @pytest.mark.asyncio
     async def test_start(self, mocker):
+
+        class mock_stat:
+            def __init__(self):
+                pass
+
+            async def register(self, key, desc):
+                return None
+
+        async def mock_create(storage):
+            return mock_stat()
+
         # GIVEN
         mocker.patch.object(StorageClientAsync, "__init__", return_value=None)
         mocker.patch.object(ReadingsStorageClientAsync, "__init__", return_value=None)
@@ -155,6 +159,7 @@ class TestIngest:
         get_cfg = mocker.patch.object(MicroserviceManagementClient, "get_configuration_category", return_value=get_cat(Ingest.default_config))
         mocker.patch.object(MicroserviceManagementClient, "get_asset_tracker_events", return_value={'track':[]})
         mocker.patch.object(MicroserviceManagementClient, "create_child_category", return_value=None)
+        mocker.patch.object(statistics, "create_statistics", return_value=mock_create(None))
         parent_service = MagicMock(_core_microservice_management_client=MicroserviceManagementClient())
         mocker.patch.object(Ingest, "_write_statistics", return_value=mock_coro())
         mocker.patch.object(Ingest, "_insert_readings", return_value=mock_coro())
@@ -178,6 +183,17 @@ class TestIngest:
 
     @pytest.mark.asyncio
     async def test_stop(self, mocker):
+
+        class mock_stat:
+            def __init__(self):
+                pass
+
+            async def register(self, key, desc):
+                return None
+
+        async def mock_create(storage):
+            return mock_stat()
+
         # GIVEN
         mocker.patch.object(StorageClientAsync, "__init__", return_value=None)
         mocker.patch.object(ReadingsStorageClientAsync, "__init__", return_value=None)
@@ -187,6 +203,7 @@ class TestIngest:
         get_cfg = mocker.patch.object(MicroserviceManagementClient, "get_configuration_category", return_value=get_cat(Ingest.default_config))
         mocker.patch.object(MicroserviceManagementClient, "get_asset_tracker_events", return_value={'track':[]})
         mocker.patch.object(MicroserviceManagementClient, "create_child_category", return_value=None)
+        mocker.patch.object(statistics, "create_statistics", return_value=mock_create(None))
         parent_service = MagicMock(_core_microservice_management_client=MicroserviceManagementClient())
         mocker.patch.object(Ingest, "_write_statistics", return_value=mock_coro())
         mocker.patch.object(Ingest, "_insert_readings", return_value=mock_coro())


### PR DESCRIPTION
- [x] Avoid object instantiation with call to load (get) stats key on each queue ingest but only when Ingest is started.

- [x] Need to fix failing tests



