### PR TITLE
Ingest->Statistics writer modified to use new bulk update feature

### DIFF
--- a/python/foglamp/common/statistics.py
+++ b/python/foglamp/common/statistics.py
@@ -4,6 +4,7 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
+import json
 from foglamp.common import logger
 from foglamp.common.storage_client.payload_builder import PayloadBuilder
 from foglamp.common.storage_client.storage_client import StorageClientAsync
@@ -47,6 +48,31 @@ class Statistics(object):
     async def _init(self):
         if self._registered_keys is None:
             await self._load_keys()
+
+    async def update_bulk(self, stat_list):
+        """ UPDATE the value column only of a statistics row based on key
+
+        Args:
+            payload: list of dict {key, value_increment}
+
+        Returns:
+            None
+        """
+        if not isinstance(stat_list, dict):
+            raise TypeError('stat_list must be a dict')
+
+        try:
+            payload = {"updates": []}
+            for k, v in stat_list.items():
+                payload_item = PayloadBuilder() \
+                    .WHERE(["key", "=", k]) \
+                    .EXPR(["value", "+", v]) \
+                    .payload()
+                payload['updates'].append(json.loads(payload_item))
+            await self._storage.update_tbl("statistics", json.dumps(payload, sort_keys=False))
+        except Exception as ex:
+            _logger.exception('Unable to bulk update statistics %s', str(ex))
+            raise
 
     async def update(self, key, value_increment):
         """ UPDATE the value column only of a statistics row based on key


### PR DESCRIPTION
Result of running fogb for 60 seconds with coap plugin:

Total recs generated in 60 seconds: 24898
No. of assets: 1
No. of times statistics table hit for updating statistics: 11
No. of times statistics table hit for registering a new key: 1
**Total no. of DB hits: 12**

This is a vast improvement over develop where the it takes **85 hits** to statistics table for the same no. of recs.

