### PR TITLE
FOGL-2023: SP/C++ : implements a mechanism to increase the amount of the time to wait in case of a communication error

### DIFF
--- a/C/tasks/north/sending_process/sending_process.cpp
+++ b/C/tasks/north/sending_process/sending_process.cpp
@@ -456,12 +456,9 @@ static void sendDataThread(SendingProcess *sendData)
 					sendData->setUpdateDb(false);
 				}
 
-				// FIXME:
-				Logger::getLogger()->debug("DBG - before sleep ");
 				// Error: just wait & continue
 				this_thread::sleep_for(chrono::milliseconds(sleep_time));
 				slept = true;
-				Logger::getLogger()->debug("DBG - after sleep ");
 			}
                 }
 


### PR DESCRIPTION
per execution : 
* wait time - from 0,5 secs to up to 32 secs
* 7 messages like for example : 

```
Nov  6 15:03:03 ihsdev FogLAMP Process[718]: Sending JSON dataType message 'Type' error |Failed to send data: No route to host| - HostPort |WIN-4M7ODKB0RH2:5460| - path |/ingress/messages| - message |[{ "type": "object", "properties": { "Company": {"type": "string"}, "Location": {"type": "string"}, "Name": { "type": "string", "isindex": true } }, "classification": "static", "id": "1_sinusoid_typename_sensor" }, { "type": "object", "properties": {"sinusoid": {"type": "number", "format": "float64"}, "Time": {"type": "string", "isindex": true, "format": "date-time"}}, "classification": "dynamic", "id": "1_sinusoid_typename_measurement" }]|

```