### PR TITLE
FOGL-2028: severity in the syslog

### DIFF
--- a/C/common/logger.cpp
+++ b/C/common/logger.cpp
@@ -42,7 +42,7 @@ void Logger::debug(const string& msg, ...)
 	va_list args;
 	va_start(args, msg);
 	string *fmt = format(msg, args);
-	syslog(LOG_DEBUG, "%s", fmt->c_str());
+	syslog(LOG_DEBUG, "DEBUG: %s", fmt->c_str());
 	delete fmt;
 	va_end(args);
 }
@@ -52,7 +52,7 @@ void Logger::info(const string& msg, ...)
 	va_list args;
 	va_start(args, msg);
 	string *fmt = format(msg, args);
-	syslog(LOG_INFO, "%s", fmt->c_str());
+	syslog(LOG_INFO, "INFO: %s", fmt->c_str());
 	delete fmt;
 	va_end(args);
 }
@@ -62,7 +62,7 @@ void Logger::warn(const string& msg, ...)
 	va_list args;
 	va_start(args, msg);
 	string *fmt = format(msg, args);
-	syslog(LOG_WARNING, "%s", fmt->c_str());
+	syslog(LOG_WARNING, "WARNING: %s", fmt->c_str());
 	delete fmt;
 	va_end(args);
 }
@@ -72,7 +72,7 @@ void Logger::error(const string& msg, ...)
 	va_list args;
 	va_start(args, msg);
 	string *fmt = format(msg, args);
-	syslog(LOG_ERR, "%s", fmt->c_str());
+	syslog(LOG_ERR, "ERROR: %s", fmt->c_str());
 	delete fmt;
 	va_end(args);
 }
@@ -82,7 +82,7 @@ void Logger::fatal(const string& msg, ...)
 	va_list args;
 	va_start(args, msg);
 	string *fmt = format(msg, args);
-	syslog(LOG_CRIT, "%s", fmt->c_str());
+	syslog(LOG_CRIT, "FATAL: %s", fmt->c_str());
 	delete fmt;
 	va_end(args);
 }


### PR DESCRIPTION


the standard mechanism requires a configuration of the syslog to have the severity (called priority)
as text and number, example : user.info, 6
the proposal is to add manually a text, so it will be available by default  without configuration.

```
sudo vi /etc/rsyslog.conf 

# add
$template precise,"%pri-text%, %syslogpriority%,%syslogfacility%,%timegenerated%,%HOSTNAME%,%syslogtag%,%msg%\n"
$ActionFileDefaultTemplate precise
 
# after the line
$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
```
 
new output : 
```

user.info, 6,1,Nov  8 14:50:07,ihsdev,FogLAMP, Storage[26551]: INFO: Starting service...
user.info, 6,1,Nov  8 14:50:08,ihsdev,FogLAMP[26520], INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=646ac7c3-3ff5-4d61-948d-405facf02d1f: <FogLAMP Storage, type=Storage, protocol=http, address=localhost, service port=35443, management port=43705, status=1>
user.info, 6,1,Nov  8 14:50:08,ihsdev,FogLAMP, Storage[26551]: INFO: Registered service 646ac7c3-3ff5-4d61-948d-405facf02d1f.
user.err, 3,1,Nov  8 14:50:08,ihsdev,FogLAMP, Storage[26551]: ERROR: Failed to register configuration category: {"error": {"message": "[AttributeError] 'NoneType' object has no attribute 'register'"}}.
user.err, 3,1,Nov  8 14:50:10,ihsdev,FogLAMP, Storage[26551]: ERROR: Failed to register configuration category: {"error": {"message": "[AttributeError] 'NoneType' object has no attribute 'register'"}}.
user.info, 6,1,Nov  8 14:50:12,ihsdev,FogLAMP[26520], INFO: server: foglamp.services.core.server: 'foglamp.readings' has 39 rows, 'foglamp.streams' last_objects reset is not required
user.info, 6,1,Nov  8 14:50:12,ihsdev,FogLAMP[26520], INFO: server: foglamp.services.core.server: start scheduler
user.info, 6,1,Nov  8 14:50:12,ihsdev,FogLAMP[26520], INFO: scheduler: foglamp.services.core.scheduler.scheduler: Starting
u

```

 