### PR TITLE
FOGL-2037:  Change system tests to use SP/C++ instead of the SP/Python - Pi Server test suite

### DIFF
--- a/tests/system/suites/end_to_end_PI/suite.cfg
+++ b/tests/system/suites/end_to_end_PI/suite.cfg
@@ -11,8 +11,8 @@ export PLUGIN_COAP_NAME=foglamp-south-coap
 export PLUGIN_COAP_REPO=https://github.com/foglamp/${PLUGIN_COAP_NAME}
 
 # Configurations related to FogLAMP
-export SENDING_PROCESS_DATA="North%20Readings%20to%20PI"
-export SENDING_PROCESS_STAT="North%20Statistics%20to%20PI"
+export SENDING_PROCESS_DATA="North_Readings_to_PI"
+export SENDING_PROCESS_STAT="North_statistics_to_PI"
 export TMP_FILE_ADD_NORTH_READINGS="${TMP_DIR}/add_north_readings.json"
 
 # PI server references
@@ -23,13 +23,9 @@ export PI_SERVER_PWD=pi-server-pwd
 export PI_SERVER_DATABASE=pi-server-db
 export CONNECTOR_RELAY_VERSION=x.x
 
-# Identifies sensors and measurements types
-export OMF_TYPE_ID=0001
-
-
 if [[ ${CONNECTOR_RELAY_VERSION} == "1.x" ]]; then
 
-    export OMF_PRODUCER_TOKEN=omf_north_${OMF_TYPE_ID}
+    export OMF_PRODUCER_TOKEN=omf_north_0001
 
 elif [[ ${CONNECTOR_RELAY_VERSION} == "2.x" ]]; then
 

--- a/tests/system/suites/end_to_end_PI/t/0020_start.test
+++ b/tests/system/suites/end_to_end_PI/t/0020_start.test
@@ -11,7 +11,6 @@ declare SENDING_PROCESS_DATA
 declare PI_SERVER
 declare PI_SERVER_PORT
 declare OMF_PRODUCER_TOKEN
-declare OMF_TYPE_ID
 
 # Reads configuration setting
 source ${SUITE_BASEDIR}/suite.cfg

--- a/tests/system/suites/end_to_end_PI/t/0030_prepare_PI.test
+++ b/tests/system/suites/end_to_end_PI/t/0030_prepare_PI.test
@@ -11,7 +11,6 @@ declare SENDING_PROCESS_DATA
 declare PI_SERVER
 declare PI_SERVER_PORT
 declare OMF_PRODUCER_TOKEN
-declare OMF_TYPE_ID
 
 # Reads configuration setting
 source ${SUITE_BASEDIR}/suite.cfg
@@ -27,18 +26,14 @@ exec 2>>"${RESULT_DIR}/${TEST_NAME}_err.temp"
 # Enables the pi_server plugin
 bash -c "cat > ${TMP_FILE_ADD_NORTH_READINGS}" << 'EOF'
         {
-            "name": "North Readings to PI",
-            "plugin": "pi_server",
+            "name": "North_Readings_to_PI",
+            "plugin": "PI_Server_V2",
             "type": "north",
             "schedule_type": 3,
             "schedule_day": 0,
             "schedule_time": 0,
             "schedule_repeat": 30,
-            "schedule_enabled": true,
-            "cmd_params": {
-                "stream_id": "1",
-                "debug_level": "1"
-            }
+            "schedule_enabled": true
          }
 EOF
 
@@ -51,15 +46,9 @@ if [[ "$?" != "0" ]]; then
     exit 1
 fi
 
-${TEST_BASEDIR}/bash/wait_creation_cfg.bash "OMF_TYPES/type-id"
-if [[ "$?" != "0" ]]; then
-    exit 1
-fi
-
 # Configures FogLAMP with the required settings
 curl -s -X PUT http://${FOGLAMP_SERVER}:${FOGLAMP_PORT}/foglamp/category/${SENDING_PROCESS_DATA}/URL           -d '{ "value" : "https://'${PI_SERVER}':'${PI_SERVER_PORT}'/ingress/messages"}'
 curl -s -X PUT http://${FOGLAMP_SERVER}:${FOGLAMP_PORT}/foglamp/category/${SENDING_PROCESS_DATA}/producerToken -d '{ "value" : "'${OMF_PRODUCER_TOKEN}'" }'
-curl -s -X PUT http://${FOGLAMP_SERVER}:${FOGLAMP_PORT}/foglamp/category/OMF_TYPES/type-id                     -d '{ "value" : "'${OMF_TYPE_ID}'" }'
 
 # Restarts FogLAMP to ensure the new configurations are used
 ${TEST_BASEDIR}/bash/exec_any_foglamp_command.bash stop  > /dev/null 2>&1

--- a/tests/system/suites/end_to_end_PI/t/0070_read_from_PI.test
+++ b/tests/system/suites/end_to_end_PI/t/0070_read_from_PI.test
@@ -67,7 +67,12 @@ function pi_web_retrieves_value_2x {
 
         # Retrieves the value
         value=`curl -s -u  ${PI_SERVER_UID}:${PI_SERVER_PWD} -X GET -k ${url_asset} |  jq --raw-output '.Items | .[] | select(.Name=="sensor") | .Value | .Value' 2>> $RESULT_DIR/$TEST_NAME.2.temp `
-        echo value :${value}: >> $RESULT_DIR/$TEST_NAME.1.temp 2>&1
+        echo value 1 :${value}: >> $RESULT_DIR/$TEST_NAME.1.temp 2>&1
+
+        # 2 reads to improve the stability of the test
+        sleep 5
+        value=`curl -s -u  ${PI_SERVER_UID}:${PI_SERVER_PWD} -X GET -k ${url_asset} |  jq --raw-output '.Items | .[] | select(.Name=="sensor") | .Value | .Value' 2>> $RESULT_DIR/$TEST_NAME.2.temp `
+        echo value 2 :${value}: >> $RESULT_DIR/$TEST_NAME.1.temp 2>&1
     fi
 
     echo ${value}


### PR DESCRIPTION
possible values for suite.cfg :  

```
###  #########################################################################################:
# FIXME:
# PI server references
export PI_SERVER=WIN-4M7ODKB0RH2
export PI_SERVER_PORT=5460
export PI_SERVER_UID=Administrator
export PI_SERVER_PWD=FogLamp200
export PI_SERVER_DATABASE=osidatabase
export CONNECTOR_RELAY_VERSION=2.x

# Identifies sensors and measurements types
export OMF_TYPE_ID=0010

if [[ ${CONNECTOR_RELAY_VERSION} == "1.x" ]]; then

    export OMF_PRODUCER_TOKEN=omf_north_${OMF_TYPE_ID}

elif [[ ${CONNECTOR_RELAY_VERSION} == "2.x" ]]; then

    # FIXME:
    export OMF_PRODUCER_TOKEN=
    export OMF_PRODUCER_TOKEN='uid=5ced49c3-3a55-40e7-983f-c6cdcd5c5fd1&crt=20180620084136279&sig=GaWXZ1I4Toje3Ly9Z6/wGZ+eC6bC0Njd9bFpv3Un4QI='
fi
###  #########################################################################################:
```