### PR TITLE
FOGL-1812-patch - NOPASSWD option further limited to 2 commands only in sudoers file

### DIFF
--- a/scripts/extras/foglamp.sudoers
+++ b/scripts/extras/foglamp.sudoers
@@ -1,2 +1,2 @@
-%sudo ALL=(ALL) NOPASSWD: /usr/bin/apt-get
+%sudo ALL=(ALL) NOPASSWD: /usr/bin/apt-get -y update, /usr/bin/apt-get -y install foglamp
 


### PR DESCRIPTION
Per @Singhal-Vaibhav's [concern](https://github.com/foglamp/FogLAMP/pull/1177#pullrequestreview-174817003) noted in #1177, this PR addresses that issue. Now NOPASSWD is limited to two very specific commands, as being used in update_task.apt. This PR has been successfully tested.