### PR TITLE
Fogl 2046: Change system tests to use SP/C++ instead of the SP/Python - OCS test suite

### DIFF
--- a/tests/system/suites/end_to_end_OCS/suite.cfg
+++ b/tests/system/suites/end_to_end_OCS/suite.cfg
@@ -11,7 +11,7 @@ export PLUGIN_COAP_NAME=foglamp-south-coap
 export PLUGIN_COAP_REPO=https://github.com/foglamp/${PLUGIN_COAP_NAME}
 
 # Configurations related to FogLAMP
-export SENDING_PROCESS_OCS_DATA="North%20Readings%20to%20OCS"
+export SENDING_PROCESS_OCS_DATA="North_Readings_to_OCS"
 export TMP_FILE_ADD_NORTH_OCS_READINGS="${TMP_DIR}/add_north_ocs_readings.json"
 
 # Related to the specific OCS account
@@ -26,7 +26,7 @@ export OCS_NAMESPACE="ocs_namespace_0001"
 export OCS_TOKEN="ocs_north_0001"
 
 # Identifies sensors and measurements types
-export OCS_TYPE_ID=0001
+export OCS_TYPE_ID=1
 
 # Define the asset information
 export ASSET_CODE="fogbench_smoke_test"

--- a/tests/system/suites/end_to_end_OCS/t/0030_prepare_OCS.test
+++ b/tests/system/suites/end_to_end_OCS/t/0030_prepare_OCS.test
@@ -16,18 +16,14 @@ exec 2>>"${RESULT_DIR}/${TEST_NAME}_err.temp"
 # Enables the OCS plugin
 bash -c "cat > ${TMP_FILE_ADD_NORTH_OCS_READINGS}" << 'EOF'
         {
-            "name": "North Readings to OCS",
-            "plugin": "ocs",
+            "name": "North_Readings_to_OCS",
+            "plugin": "ocs_V2",
             "type": "north",
             "schedule_type": 3,
             "schedule_day": 0,
             "schedule_time": 0,
             "schedule_repeat": 30,
-            "schedule_enabled": true,
-            "cmd_params": {
-                "stream_id": "1",
-                "debug_level": "1"
-            }
+            "schedule_enabled": true
          }
 EOF
 
@@ -40,18 +36,12 @@ if [[ "$?" != "0" ]]; then
     exit 1
 fi
 
-${TEST_BASEDIR}/bash/wait_creation_cfg.bash "OCS_TYPES/type-id"
-if [[ "$?" != "0" ]]; then
-    exit 1
-fi
-
 # Configures FogLAMP with the required settings
 curl -s -X PUT http://${FOGLAMP_SERVER}:${FOGLAMP_PORT}/foglamp/category/"${SENDING_PROCESS_OCS_DATA}"/tenant_id -d '{ "value" : "'${OCS_TENANT}'" }'
 curl -s -X PUT http://${FOGLAMP_SERVER}:${FOGLAMP_PORT}/foglamp/category/"${SENDING_PROCESS_OCS_DATA}"/client_id -d '{ "value" : "'${OCS_CLIENT_ID}'" }'
 curl -s -X PUT http://${FOGLAMP_SERVER}:${FOGLAMP_PORT}/foglamp/category/"${SENDING_PROCESS_OCS_DATA}"/client_secret -d '{ "value" : "'${OCS_CLIENT_SECRET}'" }'
 curl -s -X PUT http://${FOGLAMP_SERVER}:${FOGLAMP_PORT}/foglamp/category/"${SENDING_PROCESS_OCS_DATA}"/namespace -d '{ "value" : "'${OCS_NAMESPACE}'" }'
 
-curl -s -X PUT http://${FOGLAMP_SERVER}:${FOGLAMP_PORT}/foglamp/category/OCS_TYPES/type-id -d '{ "value" : "'${OCS_TYPE_ID}'" }'
 curl -s -X PUT http://${FOGLAMP_SERVER}:${FOGLAMP_PORT}/foglamp/category/"${SENDING_PROCESS_OCS_DATA}"/producerToken -d '{ "value" : "'${OCS_TOKEN}'" }'
 
 # Initializes OCS cleaning all the content of the defined OCS NameSpace


### PR DESCRIPTION
tested in a fresh clean Ubuntu 18 

Configuration used  : 
```
###  #########################################################################################:
# FIXME:
# PI server references
export PI_SERVER=WIN-4M7ODKB0RH2
export PI_SERVER_PORT=5460
export PI_SERVER_UID=Administrator
export PI_SERVER_PWD=FogLamp200
export PI_SERVER_DATABASE=osidatabase
export CONNECTOR_RELAY_VERSION=2.x

# Identifies sensors and measurements types
export OMF_TYPE_ID=0010

if [[ ${CONNECTOR_RELAY_VERSION} == "1.x" ]]; then

    export OMF_PRODUCER_TOKEN=omf_north_${OMF_TYPE_ID}

elif [[ ${CONNECTOR_RELAY_VERSION} == "2.x" ]]; then

    # FIXME:
    export OMF_PRODUCER_TOKEN=
    export OMF_PRODUCER_TOKEN='uid=5ced49c3-3a55-40e7-983f-c6cdcd5c5fd1&crt=20180620084136279&sig=GaWXZ1I4Toje3Ly9Z6/wGZ+eC6bC0Njd9bFpv3Un4QI='
fi
###  #########################################################################################:
```


```
##### FogLAMP System Test #####
Script Suite:     end_to_end_OCS
Suite DIR:        /home/foglamp/FogLAMP/tests/system/suites/end_to_end_OCS
Test DIR:         /home/foglamp/FogLAMP/tests/system/tests
FogLAMP Root:     /home/foglamp/FogLAMP
FogLAMP Data:     /home/foglamp/FogLAMP/data
foglamp command:  /home/foglamp/FogLAMP/scripts/foglamp
fogbench command: /home/foglamp/FogLAMP/scripts/extras/fogbench

Suite Start: 2018-11-19 13:15:29.214273
[2018-11-19 13:15:29.240805] - 0010_prepare - [2018-11-19 13:15:44.559488] (15.312 seconds) - PASSED
[2018-11-19 13:15:44.571980] - 0020_start - [2018-11-19 13:15:51.432782] (6.839 seconds) - PASSED
[2018-11-19 13:15:51.488134] - 0025_prepare_plugins - [2018-11-19 13:16:07.219969] (15.713 seconds) - PASSED
[2018-11-19 13:16:07.252292] - 0030_prepare_OCS - [2018-11-19 13:16:38.108896] (30.816 seconds) - PASSED
[2018-11-19 13:16:38.173650] - 0035_wait_for_start - [2018-11-19 13:16:48.220485] (10.030 seconds) - PASSED
[2018-11-19 13:16:48.230084] - 0040_inject - [2018-11-19 13:16:49.189321] (.941 seconds) - PASSED
[2018-11-19 13:16:49.226331] - 0050_wait_for_flush - [2018-11-19 13:16:59.264881] (10.020 seconds) - PASSED
[2018-11-19 13:16:59.302877] - 0060_read_from_REST - [2018-11-19 13:16:59.464733] (.142 seconds) - PASSED
[2018-11-19 13:16:59.500529] - 0070_read_from_OCS - [2018-11-19 13:17:17.875948] (18.353 seconds) - PASSED
Total Execution Time: 108.672 seconds.
Suite End:   2018-11-19 13:17:17.902558 - COMPLETED

```


```
```
