### PR TITLE
FOG-2075 Documentation fixes

### DIFF
--- a/docs/building_foglamp/04_installation.rst
+++ b/docs/building_foglamp/04_installation.rst
@@ -435,7 +435,7 @@ The command also removes the service installed. |br| You may notice the warning 
 DEPRECATED: Installing the Snap Package
 ---------------------------------------
 
-.. note:: The use of |snappy| allows you to install packages up to version 1.1.1. Newver versions are available with Debian packages.
+.. note:: The use of |snappy| allows you to install packages up to version 1.1.1. Newer versions are available with Debian packages.
 
 |snappy| is a software deployment and package management system originally designed and built by Canonical. Snappy is now available for many Linux distributions, including Ubuntu, Ubuntu Core, Debian, Fedora, Archlinux, Raspbian, Suse, the Yocto project and many others. The package management is based on snap packages that can be installed in a *transactional* environment, i.e. the packages have a current installation and the system can maintain a given number of previous installations. In case of issues with the new packages, Administrators can easily revert to previous installations.
 

--- a/docs/plugin_developers_guide/01_FogLAMP_plugins.rst
+++ b/docs/plugin_developers_guide/01_FogLAMP_plugins.rst
@@ -102,7 +102,7 @@ Installing New Plugins
 As a general rule and unless the documentation states otherwise, plugins should be installed in two ways:
 
 - When the plugin is available as **source code**, it should be installed when **FogLAMP is not running**. |br| This is the recommended method because you may want to manually move the plugin code into the right location where FogLAMP is installed, add pre-requisites and execute the REST commands necessary to start the plugin.
-- When the plugin is available as **package**, it should be installed when **FogLAMP is running**. |br| This is the required method because the package executed pre and post-installtion tasks that require FogLAMP to run. 
+- When the plugin is available as **package**, it should be installed when **FogLAMP is running**. |br| This is the required method because the package executed pre and post-installation tasks that require FogLAMP to run. 
 
 In general, FogLAMP must be restarted when a new plugin has been installed.
 

--- a/docs/plugin_developers_guide/04_north_plugins.rst
+++ b/docs/plugin_developers_guide/04_north_plugins.rst
@@ -60,7 +60,7 @@ The streams are managed by two different North tasks using the same plugin, but 
 
 The output of API call above shows three interesting tasks: the two tasks associated to the OMF plugin, the one to send data (*OMF to PI north*) and the one to send statistics (*North Statistics to PI*).
  
-The two scheduled tasks are associated to two configuration items that can be retrieved using the ``category`` API call. The the items are named ``SEND_PR_1`` and ``SEND_PR_2``.
+The two scheduled tasks are associated to two configuration items that can be retrieved using the ``category`` API call. The items are named ``SEND_PR_1`` and ``SEND_PR_2``.
 
 .. code-block:: console
 


### PR DESCRIPTION
From Jon Scott...

“post-installation” is written as “post-installtion” at: https://foglamp.readthedocs.io/en/master/plugin_developers_guide/01_FogLAMP_plugins.html
“The” appears twice consecutively on: https://foglamp.readthedocs.io/en/master/plugin_developers_guide/04_north_plugins.html
“Newver” instead of Newer” on: https://foglamp.readthedocs.io/en/master/building_foglamp/04_installation.html#deprecated-installing-the-snap-package