### PR TITLE
FOGL-1967 hexlify and unhexlify added for configuration script type value

### DIFF
--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -14,6 +14,7 @@ from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.common.storage_client.payload_builder import PayloadBuilder
 from foglamp.common.audit_logger import AuditLogger
 from foglamp.common.common import _FOGLAMP_ROOT, _FOGLAMP_DATA
+from foglamp.common import logger
 
 __author__ = "Amarendra K. Sinha, Ashish Jabble"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -34,7 +35,7 @@ _help = """
 """
 
 script_dir = _FOGLAMP_DATA + '/scripts/' if _FOGLAMP_DATA else _FOGLAMP_ROOT + "/data/scripts/"
-
+_logger = logger.setup(__name__)
 
 #################################
 #  Configuration Manager
@@ -95,10 +96,11 @@ async def get_category(request):
 
     for k, v in category.items():
         if v['type'] == 'script':
-            # FIXME: To avoid Non-hexadecimal digit found in a better way
+            # FIXME: To handle Non-hexadecimal digit found in a better way
             try:
                 category[k]["value"] = binascii.unhexlify(v['value'].encode('utf-8')).decode("utf-8")
-            except Exception:
+            except Exception as e:
+                _logger.exception("Non-hexadecimal digit found for config item: {} | {}".format(category[k], str(e)))
                 pass
 
             if cf_mgr._cacheManager.cache[category_name]['value'][k]:
@@ -198,10 +200,11 @@ async def get_category_item(request):
         raise web.HTTPNotFound(reason="No such Category item found for {}".format(config_item))
     try:
         if category_item['type'] == 'script':
-            # FIXME: To avoid Non-hexadecimal digit found in a better way
+            # FIXME: To handle Non-hexadecimal digit found in a better way
             try:
                 category_item['value'] = binascii.unhexlify(category_item['value'].encode('utf-8')).decode("utf-8")
-            except Exception:
+            except Exception as e:
+                _logger.exception("Non-hexadecimal digit found for config item: {} | {}".format(config_item, str(e)))
                 pass
 
             if cf_mgr._cacheManager.cache[category_name]['value'][config_item]:

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -87,7 +87,6 @@ async def get_category(request):
     category_name = request.match_info.get('category_name', None)
     category_name = urllib.parse.unquote(category_name) if category_name is not None else None
 
-    # TODO: make it optimized and elegant
     cf_mgr = ConfigurationManager(connect.get_storage_async())
     category = await cf_mgr.get_category_all_items(category_name)
 
@@ -96,11 +95,11 @@ async def get_category(request):
 
     for k, v in category.items():
         if v['type'] == 'script':
-            # FIXME: To handle Non-hexadecimal digit found in a better way
+            # FIXME: Handle 'Non-hexadecimal digit found' issue
             try:
                 category[k]["value"] = binascii.unhexlify(v['value'].encode('utf-8')).decode("utf-8")
             except Exception as e:
-                _logger.exception("Non-hexadecimal digit found for config item: {} | {}".format(category[k], str(e)))
+                _logger.exception("Got an error while decoding config item: {} | {}".format(category[k], str(e)))
                 pass
 
             if cf_mgr._cacheManager.cache[category_name]['value'][k]:
@@ -193,18 +192,17 @@ async def get_category_item(request):
     category_name = urllib.parse.unquote(category_name) if category_name is not None else None
     config_item = urllib.parse.unquote(config_item) if config_item is not None else None
 
-    # TODO: make it optimized and elegant
     cf_mgr = ConfigurationManager(connect.get_storage_async())
     category_item = await cf_mgr.get_category_item(category_name, config_item)
     if category_item is None:
         raise web.HTTPNotFound(reason="No such Category item found for {}".format(config_item))
     try:
         if category_item['type'] == 'script':
-            # FIXME: To handle Non-hexadecimal digit found in a better way
+            # FIXME: Handle 'Non-hexadecimal digit found' issue
             try:
                 category_item['value'] = binascii.unhexlify(category_item['value'].encode('utf-8')).decode("utf-8")
             except Exception as e:
-                _logger.exception("Non-hexadecimal digit found for config item: {} | {}".format(config_item, str(e)))
+                _logger.exception("Got an error while decoding config item: {} | {}".format(config_item, str(e)))
                 pass
 
             if cf_mgr._cacheManager.cache[category_name]['value'][config_item]:


### PR DESCRIPTION
_Steps to test:_

1) Add sine as service with below config item (make sure test config item exist in sinusoid plugin file)
```
_DEFAULT_CONFIG = {
   .......,
    'test': {
        'description': 'T',
        'type': 'script',
        'default': '',
        'order': '4'
    }

}
```
2. Get sine configuration
```
curl -sX GET http://localhost:8081/foglamp/category/sine | jq

{
    "dataPointsPerSec": {
        "description": "Data points per second",
        "order": "2",
        "type": "integer",
        "default": "1",
        "value": "1"
    },
    "test": {
        "description": "T",
        "order": "4",
        "type": "script",
        "default": "",
        "value": ""
    },
    "plugin": {
        "type": "string",
        "default": "sinusoid",
        "readonly": "true",
        "description": "Sinusoid Plugin",
        "value": "sinusoid"
    },
    "assetName": {
        "description": "Name of Asset",
        "order": "1",
        "type": "string",
        "default": "sinusoid",
        "value": "sinusoid"
    }
}
```

3. Script upload with sine service with [file](https://github.com/foglamp/foglamp-filter-python35/blob/develop/readings35.py)


```
curl -F "script=@readings35.py" http://localhost:8081/foglamp/category/sine/test/upload | jq
{
  "order": "4",
  "type": "script",
  "file": "/home/foglamp/Development/FogLAMP/data/scripts/sine_test_readings35.py",
  "description": "T",
  "default": "",
  "value": "\"\"\"\nFogLAMP filtering for readings data\nusing Python 3.5\n\"\"\"\n\n__author__ = \"Massimiliano Pinto\"\n__copyright__ = \"Copyright (c) 2018 Dianomic Systems\"\n__license__ = \"Apache 2.0\"\n__version__ = \"${VERSION}\"\n\nimport sys\nimport json\n\n\"\"\"\nFilter configuration set by set_filter_config(config)\n\"\"\"\n\n\"\"\"\nfilter_config, global variable\n\"\"\"\nfilter_config = dict()\n\n\"\"\"\nSet the Filter configuration into filter_config (global variable)\n\nInput data is a dict with 'config' key and JSON string version wit data\n\nJSON string is loaded into a dict, set to global variable filter_config\n\nReturn True\n\"\"\"\ndef set_filter_config(configuration):\n    print(configuration)\n    global filter_config\n    filter_config = json.loads(configuration['config'])\n\n    return True\n\n\"\"\"\nMethod for filtering readings data\n\nInput is array of dicts\n[\n    {'reading': {'power_set1': '5980'}, 'asset_code': 'lab1'},\n    {'reading': {'power_set1': '211'}, 'asset_code': 'lab1'}\n]\n\nInput data:\n   readings: can be modified, dropped etc\nOutput is array of dict\n\"\"\"\ndef readings35(readings):\n    # Get list of asset code to filter\n    if ('asset_code' in filter_config):\n        asset_codes = filter_config['asset_code']\n    else:\n        asset_codes = []\n\n    for elem in readings:\n            print(\"IN=\" + str(elem))\n            reading = elem['reading']\n            # Apply some changes: add 500 to all datapoints value\n            for key in reading:\n                newVal = reading[key] + 500\n                reading[key] = newVal\n\n            print(\"OUT=\" + str(elem))\n    return readings\n"
}

```
4. Again Get sine configuration
```
foglamp@nerd-034 ~/Development/foglamp-filter-python35 (FOGL-1826) $ curl -sX GET http://localhost:8081/foglamp/category/sine | jq
{
  "dataPointsPerSec": {
    "description": "Data points per second",
    "default": "1",
    "value": "1",
    "type": "integer",
    "order": "2"
  },
  "assetName": {
    "description": "Name of Asset",
    "default": "sinusoid",
    "value": "sinusoid",
    "type": "string",
    "order": "1"
  },
  "test": {
    "order": "4",
    "type": "script",
    "file": "/home/foglamp/Development/FogLAMP/data/scripts/sine_test_readings35.py",
    "description": "T",
    "default": "",
    "value": "\"\"\"\nFogLAMP filtering for readings data\nusing Python 3.5\n\"\"\"\n\n__author__ = \"Massimiliano Pinto\"\n__copyright__ = \"Copyright (c) 2018 Dianomic Systems\"\n__license__ = \"Apache 2.0\"\n__version__ = \"${VERSION}\"\n\nimport sys\nimport json\n\n\"\"\"\nFilter configuration set by set_filter_config(config)\n\"\"\"\n\n\"\"\"\nfilter_config, global variable\n\"\"\"\nfilter_config = dict()\n\n\"\"\"\nSet the Filter configuration into filter_config (global variable)\n\nInput data is a dict with 'config' key and JSON string version wit data\n\nJSON string is loaded into a dict, set to global variable filter_config\n\nReturn True\n\"\"\"\ndef set_filter_config(configuration):\n    print(configuration)\n    global filter_config\n    filter_config = json.loads(configuration['config'])\n\n    return True\n\n\"\"\"\nMethod for filtering readings data\n\nInput is array of dicts\n[\n    {'reading': {'power_set1': '5980'}, 'asset_code': 'lab1'},\n    {'reading': {'power_set1': '211'}, 'asset_code': 'lab1'}\n]\n\nInput data:\n   readings: can be modified, dropped etc\nOutput is array of dict\n\"\"\"\ndef readings35(readings):\n    # Get list of asset code to filter\n    if ('asset_code' in filter_config):\n        asset_codes = filter_config['asset_code']\n    else:\n        asset_codes = []\n\n    for elem in readings:\n            print(\"IN=\" + str(elem))\n            reading = elem['reading']\n            # Apply some changes: add 500 to all datapoints value\n            for key in reading:\n                newVal = reading[key] + 500\n                reading[key] = newVal\n\n            print(\"OUT=\" + str(elem))\n    return readings\n"
  },
  "plugin": {
    "description": "Sinusoid Plugin",
    "readonly": "true",
    "default": "sinusoid",
    "value": "sinusoid",
    "type": "string"
  }
}

```

**NOTE:**
Value saved in DB as in hexadecimal format and now works with both engines

```
sqlite> select value from configuration where key='sine';
{"dataPointsPerSec":{"description":"Data points per second","default":"1","value":"1","type":"integer","order":"2"},"assetName":{"description":"Name of Asset","default":"sinusoid","value":"sinusoid","type":"string","order":"1"},"test":{"description":"T","default":"","value":"2222220a466f674c414d502066696c746572696e6720666f722072656164696e677320646174610a7573696e6720507974686f6e20332e350a2222220a0a5f5f617574686f725f5f203d20224d617373696d696c69616e6f2050696e746f220a5f5f636f707972696768745f5f203d2022436f70797269676874202863292032303138204469616e6f6d69632053797374656d73220a5f5f6c6963656e73655f5f203d202241706163686520322e30220a5f5f76657273696f6e5f5f203d2022247b56455253494f4e7d220a0a696d706f7274207379730a696d706f7274206a736f6e0a0a2222220a46696c74657220636f6e66696775726174696f6e20736574206279207365745f66696c7465725f636f6e66696728636f6e666967290a2222220a0a2222220a66696c7465725f636f6e6669672c20676c6f62616c207661726961626c650a2222220a66696c7465725f636f6e666967203d206469637428290a0a2222220a536574207468652046696c74657220636f6e66696775726174696f6e20696e746f2066696c7465725f636f6e6669672028676c6f62616c207661726961626c65290a0a496e70757420646174612069732061206469637420776974682027636f6e66696727206b657920616e64204a534f4e20737472696e672076657273696f6e2077697420646174610a0a4a534f4e20737472696e67206973206c6f6164656420696e746f206120646963742c2073657420746f20676c6f62616c207661726961626c652066696c7465725f636f6e6669670a0a52657475726e20547275650a2222220a646566207365745f66696c7465725f636f6e66696728636f6e66696775726174696f6e293a0a202020207072696e7428636f6e66696775726174696f6e290a20202020676c6f62616c2066696c7465725f636f6e6669670a2020202066696c7465725f636f6e666967203d206a736f6e2e6c6f61647328636f6e66696775726174696f6e5b27636f6e666967275d290a0a2020202072657475726e20547275650a0a2222220a4d6574686f6420666f722066696c746572696e672072656164696e677320646174610a0a496e707574206973206172726179206f662064696374730a5b0a202020207b2772656164696e67273a207b27706f7765725f73657431273a202735393830277d2c202761737365745f636f6465273a20276c616231277d2c0a202020207b2772656164696e67273a207b27706f7765725f73657431273a2027323131277d2c202761737365745f636f6465273a20276c616231277d0a5d0a0a496e70757420646174613a0a20202072656164696e67733a2063616e206265206d6f6469666965642c2064726f70706564206574630a4f7574707574206973206172726179206f6620646963740a2222220a6465662072656164696e677333352872656164696e6773293a0a202020202320476574206c697374206f6620617373657420636f646520746f2066696c7465720a20202020696620282761737365745f636f64652720696e2066696c7465725f636f6e666967293a0a202020202020202061737365745f636f646573203d2066696c7465725f636f6e6669675b2761737365745f636f6465275d0a20202020656c73653a0a202020202020202061737365745f636f646573203d205b5d0a0a20202020666f7220656c656d20696e2072656164696e67733a0a2020202020202020202020207072696e742822494e3d22202b2073747228656c656d29290a20202020202020202020202072656164696e67203d20656c656d5b2772656164696e67275d0a20202020202020202020202023204170706c7920736f6d65206368616e6765733a206164642035303020746f20616c6c2064617461706f696e74732076616c75650a202020202020202020202020666f72206b657920696e2072656164696e673a0a202020202020202020202020202020206e657756616c203d2072656164696e675b6b65795d202b203530300a2020202020202020202020202020202072656164696e675b6b65795d203d206e657756616c0a0a2020202020202020202020207072696e7428224f55543d22202b2073747228656c656d29290a2020202072657475726e2072656164696e67730a","type":"script","order":"4"},"plugin":{"description":"Sinusoid Plugin","readonly":"true","default":"sinusoid","value":"sinusoid","type":"string"}}
```