### PR TITLE
FOGL-2102: Python/OCS - Add support in SP/Python datatype for arrays of floating point numbers

### DIFF
--- a/python/foglamp/plugins/north/common/common.py
+++ b/python/foglamp/plugins/north/common/common.py
@@ -78,30 +78,33 @@ def evaluate_type(value):
      Raises:
      """
 
-    try:
-        float(value)
-
+    if type(value) is list:
+        evaluated_type = "array"
+    else:
         try:
-            # Evaluates if it is a int or a number
-            if str(int(float(value))) == str(value):
+            float(value)
 
-                # Checks the case having .0 as 967.0
-                int_str = str(int(float(value)))
-                value_str = str(value)
+            try:
+                # Evaluates if it is a int or a number
+                if str(int(float(value))) == str(value):
 
-                if int_str == value_str:
-                    evaluated_type = "integer"
+                    # Checks the case having .0 as 967.0
+                    int_str = str(int(float(value)))
+                    value_str = str(value)
+
+                    if int_str == value_str:
+                        evaluated_type = "integer"
+                    else:
+                        evaluated_type = "number"
+
                 else:
                     evaluated_type = "number"
 
-            else:
-                evaluated_type = "number"
+            except ValueError:
+                evaluated_type = "string"
 
         except ValueError:
             evaluated_type = "string"
-
-    except ValueError:
-        evaluated_type = "string"
 
     return evaluated_type
 

--- a/python/foglamp/plugins/north/pi_server/pi_server.py
+++ b/python/foglamp/plugins/north/pi_server/pi_server.py
@@ -661,8 +661,17 @@ class PIServerNorthPlugin(object):
             elif item_type == "number":
                 omf_type[typename][1]["properties"][item] = {"type": item_type,
                                                              "format": self._config['formatNumber']}
+
+            elif item_type == "array":
+                omf_type[typename][1]["properties"][item] = {
+                                                                "type": item_type,
+                                                                "items": {
+                                                                    "type": "number"
+                                                                }
+                                                             }
             else:
                 omf_type[typename][1]["properties"][item] = {"type": item_type}
+
 
         if _log_debug_level == 3:
             self._logger.debug("_create_omf_type_automatic - sensor_id |{0}| - omf_type |{1}| ".format(sensor_id, str(omf_type)))

--- a/python/foglamp/plugins/north/pi_server/pi_server.py
+++ b/python/foglamp/plugins/north/pi_server/pi_server.py
@@ -666,7 +666,8 @@ class PIServerNorthPlugin(object):
                 omf_type[typename][1]["properties"][item] = {
                                                                 "type": item_type,
                                                                 "items": {
-                                                                    "type": "number"
+                                                                    "type": "number",
+                                                                    "format": self._config['formatNumber']
                                                                 }
                                                              }
             else:


### PR DESCRIPTION
preview, working stage

testing cases : 

```
14	sensor_array	1a6cd43a-d316-43d9-a0d4-dd1e57221800	{"shaft1":[0.1]}	2018-11-25 10:01:01.081574+01:00	2018-11-25 16:33:28.092
15	sensor_array	1a6cd43a-d316-43d9-a0d4-dd1e57221801	{"shaft1":[0.21,0.22]}	2018-11-25 10:02:01.081574+01:00	2018-11-25 16:33:28.092
16	sensor_array	1a6cd43a-d316-43d9-a0d4-dd1e57221802	{"shaft1":[0.31,0.32,0.33]}	2018-11-25 10:03:01.081574+01:00	2018-11-25 16:33:28.092
17	sensor_array	1a6cd43a-d316-43d9-a0d4-dd1e57221803	{"shaft1":[0.11,0.12]}	2018-11-25 10:04:01.081574+01:00	2018-11-25 16:33:28.092
18	sensor_array	1a6cd43a-d316-43d9-a0d4-dd1e57221804	{"shaft1":[0.121]}	2018-11-25 10:05:01.081574+01:00	2018-11-25 16:33:28.092
19	sensor_array	1a6cd43a-d316-43d9-a0d4-dd1e57221805	{"shaft1":[-1, 0, 1, 0.121, 2.2]}	2018-11-25 10:06:01.081574+01:00	2018-11-25 16:33:28.092
20	sensor_array	1a6cd43a-d316-43d9-a0d4-dd1e57221806	{"shaft1":[-1, 0, 1, -0.1, 0.0, 0.1, 2.2]}	2018-11-25 10:07:01.081574+01:00	2018-11-25 16:33:28.092
21	sensor_array_int	1a6cd43a-d316-43d9-a0d4-dd1e572218201	{"shaft_2":[0]}	2018-11-25 10:05:01.081574+01:00	2018-11-25 16:33:28.092
22	sensor_array_int	1a6cd43a-d316-43d9-a0d4-dd1e572218202	{"shaft_2":[0,1]}	2018-11-25 10:06:01.081574+01:00	2018-11-25 16:33:28.092
23	sensor_array_int	1a6cd43a-d316-43d9-a0d4-dd1e572218203	{"shaft_2":[-1,0,1]}	2018-11-25 10:07:01.081574+01:00	2018-11-25 16:33:28.092
24	sensor_int	1a6cd43a-d316-43d9-a0d4-dd1e57221810	{"asset_int":1}	2018-11-25 10:06:01.081574+01:00	2018-11-25 16:33:28.092
25	sensor_float	1a6cd43a-d316-43d9-a0d4-dd1e57221811	{"asset_float":2.2}	2018-11-25 10:07:01.081574+01:00	2018-11-25 16:33:28.092
26	sensor_string	1a6cd43a-d316-43d9-a0d4-dd1e57221812	{"asset_string":"test_3"}	2018-11-25 10:08:01.081574+01:00	2018-11-25 16:33:28.092
```

NOTE : used

curl -X PUT http://localhost:8081/foglamp/category/P_North_Readings_to_OCS/blockSize           -d '{ "value" :  "1" }'


Data on OCS : 

![screenshot - 28-nov-18 15_55_56](https://user-images.githubusercontent.com/4919069/49160088-3cd99780-f326-11e8-86d0-eef3c8afe909.png)


![screenshot - 28-nov-18 15_56_18](https://user-images.githubusercontent.com/4919069/49160095-406d1e80-f326-11e8-82c9-5a3a5eebac96.png)


