### PR TITLE
FOGL-2128 HTTP status code fixes on wrong service and task and tests refactored

### DIFF
--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -86,7 +86,7 @@ async def delete_service(request):
 
         result = await get_schedule(storage, svc)
         if result['count'] == 0:
-            return web.HTTPBadRequest(reason='{} service does not exist.'.format(svc))
+            return web.HTTPNotFound(reason='{} service does not exist.'.format(svc))
 
         svc_schedule = result['rows'][0]
         sch_id = uuid.UUID(svc_schedule['id'])

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -6,8 +6,8 @@
 
 import asyncio
 import datetime
-from aiohttp import web
 import uuid
+from aiohttp import web
 
 from foglamp.common import utils
 from foglamp.common import logger
@@ -82,15 +82,11 @@ async def delete_service(request):
 
     try:
         svc = request.match_info.get('service_name', None)
-
-        if svc is None or svc.strip() == '':
-            raise web.HTTPBadRequest(reason='Missing service_name in requested URL')
-
         storage = connect.get_storage_async()
 
         result = await get_schedule(storage, svc)
         if result['count'] == 0:
-            raise web.HTTPBadRequest(reason='A service with this name does not exist.')
+            return web.HTTPBadRequest(reason='{} service does not exist.'.format(svc))
 
         svc_schedule = result['rows'][0]
         sch_id = uuid.UUID(svc_schedule['id'])

--- a/python/foglamp/services/core/api/task.py
+++ b/python/foglamp/services/core/api/task.py
@@ -269,7 +269,7 @@ async def delete_task(request):
 
         result = await get_schedule(storage, north_instance)
         if result['count'] == 0:
-            return web.HTTPBadRequest(reason='{} north instance does not exist.'.format(north_instance))
+            return web.HTTPNotFound(reason='{} north instance does not exist.'.format(north_instance))
 
         north_instance_schedule = result['rows'][0]
         sch_id = uuid.UUID(north_instance_schedule['id'])

--- a/python/foglamp/services/core/api/task.py
+++ b/python/foglamp/services/core/api/task.py
@@ -265,15 +265,11 @@ async def delete_task(request):
     """
     try:
         north_instance = request.match_info.get('task_name', None)
-
-        if north_instance is None or north_instance.strip() == '':
-            raise web.HTTPBadRequest(reason='Missing task_name in requested URL')
-
         storage = connect.get_storage_async()
 
         result = await get_schedule(storage, north_instance)
         if result['count'] == 0:
-            raise web.HTTPBadRequest(reason='A north instance task with this name does not exist.')
+            return web.HTTPBadRequest(reason='{} north instance does not exist.'.format(north_instance))
 
         north_instance_schedule = result['rows'][0]
         sch_id = uuid.UUID(north_instance_schedule['id'])

--- a/tests/unit/python/foglamp/services/core/api/test_service.py
+++ b/tests/unit/python/foglamp/services/core/api/test_service.py
@@ -515,7 +515,7 @@ class TestService:
         mocker.patch.object(service, "get_schedule", return_value=mock_bad_result())
 
         resp = await client.delete("/foglamp/service/{}".format(name))
-        assert 400 == resp.status
+        assert 404 == resp.status
         assert '{} service does not exist.'.format(name) == resp.reason
 
 # TODO:  add negative tests and C type plugin add service tests

--- a/tests/unit/python/foglamp/services/core/api/test_service.py
+++ b/tests/unit/python/foglamp/services/core/api/test_service.py
@@ -7,7 +7,7 @@
 
 import asyncio
 import json
-from uuid import uuid4, UUID
+from uuid import UUID
 from aiohttp import web
 import pytest
 from unittest.mock import MagicMock, patch, call
@@ -432,21 +432,24 @@ class TestService:
     async def test_delete_service(self, mocker, client):
         sch_id = '0178f7b6-d55c-4427-9106-245513e46416'
         reg_id = 'd607c5be-792f-4993-96b7-b513674e7d3b'
-        mock_registry = [ServiceRecord(reg_id, "Test", "Southbound", "http", "localhost", "8118", "8118")]
+        name = "Test"
+        sch_name = "Test Service"
+        mock_registry = [ServiceRecord(reg_id, name, "Southbound", "http", "localhost", "8118", "8118")]
+
         async def mock_result():
             return {
                         "count": 1,
                         "rows": [
                             {
                                 "id": sch_id,
-                                "process_name": "Test",
-                                "schedule_name": "Test Service",
+                                "process_name": name,
+                                "schedule_name": sch_name,
                                 "schedule_type": "1",
                                 "schedule_interval": "0",
                                 "schedule_time": "0",
                                 "schedule_day": "0",
                                 "exclusive": "t",
-                                "enabled" : "t"
+                                "enabled": "t"
                             },
                         ]
             }
@@ -461,14 +464,14 @@ class TestService:
 
         mock_registry[0]._status = ServiceRecord.Status.Shutdown
 
-        resp = await client.delete("/foglamp/service/Test Service")
+        resp = await client.delete("/foglamp/service/{}".format(sch_name))
         assert 200 == resp.status
         result = await resp.json()
-        assert result['result'].endswith("Service {} deleted successfully.".format("Test Service"))
+        assert "Service {} deleted successfully.".format(sch_name) == result['result']
 
         assert 1 == get_schedule.call_count
         args, kwargs = get_schedule.call_args_list[0]
-        assert "Test Service" in args
+        assert sch_name in args
 
         assert 1 == delete_schedule.call_count
         delete_schedule_calls = [call(UUID('0178f7b6-d55c-4427-9106-245513e46416'))]
@@ -480,10 +483,10 @@ class TestService:
 
         assert 1 == delete_configuration.call_count
         args, kwargs = delete_configuration.call_args_list[0]
-        assert "Test Service" in args
+        assert sch_name in args
 
         assert 2 == get_registry.call_count
-        get_registry_calls = [call(name='Test Service'), call(name='Test Service')]
+        get_registry_calls = [call(name=sch_name), call(name=sch_name)]
         get_registry.assert_has_calls(get_registry_calls, any_order=True)
 
         assert 1 == remove_registry.call_count
@@ -491,35 +494,28 @@ class TestService:
         remove_registry.assert_has_calls(remove_registry_calls, any_order=True)
 
     async def test_delete_service_exception(self, mocker, client):
-        sch_id = '0178f7b6-d55c-4427-9106-245513e46416'
-        reg_id = 'd607c5be-792f-4993-96b7-b513674e7d3b'
-        mock_registry = [ServiceRecord(reg_id, "Test", "Southbound", "http", "localhost", "8118", "8118")]
-        async def mock_bad_result():
-            return {
-                        "count": 0,
-                        "rows": []
-            }
-
-        mocker.patch.object(connect, 'get_storage_async')
-        scheduler = mocker.patch.object(server.Server, "scheduler", MagicMock())
-        delete_schedule = mocker.patch.object(scheduler, "delete_schedule", return_value=asyncio.sleep(.1))
-        disable_schedule = mocker.patch.object(scheduler, "disable_schedule", return_value=asyncio.sleep(.1))
-        delete_configuration = mocker.patch.object(service, "delete_configuration", return_value=asyncio.sleep(.1))
-        get_registry = mocker.patch.object(ServiceRegistry, 'get', return_value=mock_registry)
-        remove_registry = mocker.patch.object(ServiceRegistry, 'remove_from_registry')
-
-        mock_registry[0]._status = ServiceRecord.Status.Shutdown
-
         resp = await client.delete("/foglamp/service")
         assert 405 == resp.status
-        result = await resp.text()
-        assert result.endswith(" Method Not Allowed")
+        assert 'Method Not Allowed' == resp.reason
 
-        get_schedule = mocker.patch.object(service, "get_schedule", return_value=mock_bad_result())
-        resp = await client.delete("/foglamp/service/Test")
-        # TODO: FOGL-2128
+        reg_id = 'd607c5be-792f-4993-96b7-b513674e7d3b'
+        name = 'Test'
+        mock_registry = [ServiceRecord(reg_id, name, "Southbound", "http", "localhost", "8118", "8118")]
+
+        mocker.patch.object(service, "get_schedule", side_effect=Exception)
+        resp = await client.delete("/foglamp/service/{}".format(name))
         assert 500 == resp.status
-        result = await resp.text()
-        assert result.endswith('A service with this name does not exist.')
+        assert resp.reason is None
+
+        async def mock_bad_result():
+            return {"count": 0, "rows": []}
+
+        mocker.patch.object(connect, 'get_storage_async')
+        mock_registry[0]._status = ServiceRecord.Status.Shutdown
+        mocker.patch.object(service, "get_schedule", return_value=mock_bad_result())
+
+        resp = await client.delete("/foglamp/service/{}".format(name))
+        assert 400 == resp.status
+        assert '{} service does not exist.'.format(name) == resp.reason
 
 # TODO:  add negative tests and C type plugin add service tests

--- a/tests/unit/python/foglamp/services/core/api/test_task.py
+++ b/tests/unit/python/foglamp/services/core/api/test_task.py
@@ -440,7 +440,7 @@ class TestService:
         mocker.patch.object(connect, 'get_storage_async')
         mocker.patch.object(task, "get_schedule", return_value=mock_bad_result())
         resp = await client.delete("/foglamp/scheduled/task/Test")
-        assert 400 == resp.status
+        assert 404 == resp.status
         assert 'Test north instance does not exist.' == resp.reason
 
 # TODO: Add test for negative scenarios


### PR DESCRIPTION
```
curl -X DELETE http://localhost:8081/foglamp/scheduled/task/T
404: T north instance does not exist.

curl -X DELETE http://localhost:8081/foglamp/service/S
404: S service name does not exist.
```

**Note:**
```
svc is None or svc.strip() == ''
```
1. Its dead code, aiohttp will take care of itself as 404
2. Code coverage improved for delete