### PR TITLE
Fogl 2145 - plugin discovery API to support C-filter and C-notify plugins

### DIFF
--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -10,7 +10,7 @@ import os
 from foglamp.common import logger
 from foglamp.services.core.api import utils
 
-__author__ = "Amarendra K Sinha"
+__author__ = "Amarendra K Sinha, Ashish Jabble"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
@@ -31,10 +31,14 @@ class PluginDiscovery(object):
             plugins_list_south = cls.fetch_plugins_installed("south", is_config)
             plugins_list_c_north = cls.fetch_c_plugins_installed("north", is_config)
             plugins_list_c_south = cls.fetch_c_plugins_installed("south", is_config)
+            plugins_list_filter = cls.fetch_c_plugins_installed("filter", is_config)
             plugins_list.extend(plugins_list_north)
             plugins_list.extend(plugins_list_c_north)
             plugins_list.extend(plugins_list_south)
             plugins_list.extend(plugins_list_c_south)
+            plugins_list.extend(plugins_list_filter)
+        elif plugin_type == 'filter':
+            plugins_list = cls.fetch_c_plugins_installed(plugin_type, is_config)
         else:
             plugins_list = cls.fetch_plugins_installed(plugin_type, is_config)
             plugins_list.extend(cls.fetch_c_plugins_installed(plugin_type, is_config))

--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -31,13 +31,15 @@ class PluginDiscovery(object):
             plugins_list_south = cls.fetch_plugins_installed("south", is_config)
             plugins_list_c_north = cls.fetch_c_plugins_installed("north", is_config)
             plugins_list_c_south = cls.fetch_c_plugins_installed("south", is_config)
-            plugins_list_filter = cls.fetch_c_plugins_installed("filter", is_config)
+            plugins_list_c_filter = cls.fetch_c_plugins_installed("filter", is_config)
+            plugins_list_c_notify = cls.fetch_c_plugins_installed("notify", is_config)
             plugins_list.extend(plugins_list_north)
             plugins_list.extend(plugins_list_c_north)
             plugins_list.extend(plugins_list_south)
             plugins_list.extend(plugins_list_c_south)
-            plugins_list.extend(plugins_list_filter)
-        elif plugin_type == 'filter':
+            plugins_list.extend(plugins_list_c_filter)
+            plugins_list.extend(plugins_list_c_notify)
+        elif plugin_type == 'filter' or plugin_type == 'notify':
             plugins_list = cls.fetch_c_plugins_installed(plugin_type, is_config)
         else:
             plugins_list = cls.fetch_plugins_installed(plugin_type, is_config)

--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -26,7 +26,7 @@ async def get_plugins_installed(request):
     :Example:
         curl -X GET http://localhost:8081/foglamp/plugins/installed
         curl -X GET http://localhost:8081/foglamp/plugins/installed?config=true
-        curl -X GET http://localhost:8081/foglamp/plugins/installed?type=north|south|filter
+        curl -X GET http://localhost:8081/foglamp/plugins/installed?type=north|south|filter|notify
         curl -X 'GET http://localhost:8081/foglamp/plugins/installed?type=north&config=true'
     """
 
@@ -35,8 +35,8 @@ async def get_plugins_installed(request):
     if 'type' in request.query and request.query['type'] != '':
         plugin_type = request.query['type'].lower()
 
-    if plugin_type is not None and plugin_type not in ['north', 'south', 'filter']:
-        raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south' or 'filter'.")
+    if plugin_type is not None and plugin_type not in ['north', 'south', 'filter', 'notify']:
+        raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify'.")
 
     if 'config' in request.query:
         config = request.query['config']

--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -26,7 +26,7 @@ async def get_plugins_installed(request):
     :Example:
         curl -X GET http://localhost:8081/foglamp/plugins/installed
         curl -X GET http://localhost:8081/foglamp/plugins/installed?config=true
-        curl -X GET http://localhost:8081/foglamp/plugins/installed?type=north
+        curl -X GET http://localhost:8081/foglamp/plugins/installed?type=north|south|filter
         curl -X 'GET http://localhost:8081/foglamp/plugins/installed?type=north&config=true'
     """
 
@@ -35,8 +35,8 @@ async def get_plugins_installed(request):
     if 'type' in request.query and request.query['type'] != '':
         plugin_type = request.query['type'].lower()
 
-    if plugin_type is not None and plugin_type not in ['north', 'south']:
-        raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south'.")
+    if plugin_type is not None and plugin_type not in ['north', 'south', 'filter']:
+        raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south' or 'filter'.")
 
     if 'config' in request.query:
         config = request.query['config']

--- a/tests/unit/python/foglamp/common/test_plugin_discovery.py
+++ b/tests/unit/python/foglamp/common/test_plugin_discovery.py
@@ -26,6 +26,7 @@ class TestPluginDiscovery:
     mock_south_folders = ["modbus", "http"]
     mock_c_north_folders = ["ocs"]
     mock_c_south_folders = ["dummy"]
+    mock_filter_folders = ["scale"]
     mock_all_folders = ["OMF", "foglamp-north", "modbus", "http"]
     mock_plugins_config = [
         {
@@ -104,6 +105,14 @@ class TestPluginDiscovery:
          }
     ]
 
+    mock_filter_config = [
+        {"name": "scale",
+         "version": "1.0.0",
+         "type": "filter",
+         "description": "Filter Scale plugin",
+         "config": {"plugin": {"default": "scale", "type": "string", "description": "Scale filter plugin"}}}
+    ]
+
     mock_c_plugins_config = [
         {"interface": "1.0.0",
          "version": "1.0.0",
@@ -121,7 +130,13 @@ class TestPluginDiscovery:
                  "description": "OMF North C Plugin"
              }
          }
-         }
+         },
+        {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin",
+         "config": {
+             "plugin": {
+                 "default": "scale",
+                 "type": "string",
+                 "description": "Scale filter plugin"}}}
     ]
 
     def test_get_plugins_installed_type_none(self, mocker):
@@ -134,6 +149,7 @@ class TestPluginDiscovery:
         def mock_c_folders():
             yield TestPluginDiscovery.mock_c_north_folders
             yield TestPluginDiscovery.mock_c_south_folders
+            yield TestPluginDiscovery.mock_filter_folders
 
         mock_get_folders = mocker.patch.object(PluginDiscovery, "get_plugin_folders", return_value=next(mock_folders()))
         mock_get_c_folders = mocker.patch.object(utils, "find_c_plugin_libs", return_value=next(mock_c_folders()))
@@ -149,8 +165,8 @@ class TestPluginDiscovery:
         # assert expected_plugin == plugins
         assert 2 == mock_get_folders.call_count
         assert 4 == mock_get_plugin_config.call_count
-        assert 2 == mock_get_c_folders.call_count
-        assert 2 == mock_get_c_plugin_config.call_count
+        assert 3 == mock_get_c_folders.call_count
+        assert 3 == mock_get_c_plugin_config.call_count
 
     def test_get_plugins_installed_type_north(self, mocker):
         @asyncio.coroutine
@@ -201,6 +217,22 @@ class TestPluginDiscovery:
         # assert expected_plugin == plugins
         assert 1 == mock_get_folders.call_count
         assert 2 == mock_get_plugin_config.call_count
+        assert 1 == mock_get_c_folders.call_count
+        assert 1 == mock_get_c_plugin_config.call_count
+
+    def test_get_plugins_installed_type_filter(self, mocker):
+        @asyncio.coroutine
+        def mock_filter_folders():
+            yield TestPluginDiscovery.mock_filter_folders
+
+        mock_get_c_folders = mocker.patch.object(utils, "find_c_plugin_libs", return_value=next(mock_filter_folders()))
+        mock_get_c_plugin_config = mocker.patch.object(utils, "get_plugin_info",
+                                                       side_effect=TestPluginDiscovery.mock_filter_config)
+
+        plugins = PluginDiscovery.get_plugins_installed("filter")
+        # expected_plugin = TestPluginDiscovery.mock_c_plugins_config[2]
+        # FIXME: ordering issue
+        # assert expected_plugin == plugins
         assert 1 == mock_get_c_folders.call_count
         assert 1 == mock_get_c_plugin_config.call_count
 
@@ -272,14 +304,17 @@ class TestPluginDiscovery:
                 assert actual is None
         patch_log_warn.assert_called_once_with('Plugin http-north is discarded due to invalid type')
 
-    def test_fetch_c_plugins_installed(self):
-        info = {"interface": "1.0.0", "version": "1.0.0", "type": "south", "name": "Random",
-                "config": {"plugin": {"description": "Random C plugin", "type": "string", "default": "Random"}}}
-        with patch.object(utils, "find_c_plugin_libs", return_value=["Random"]) as patch_plugin_lib:
+    @pytest.mark.parametrize("info, direction", [
+        (mock_c_plugins_config[0], "south"),
+        (mock_c_plugins_config[1], "north"),
+        (mock_c_plugins_config[2], "filter")
+    ])
+    def test_fetch_c_plugins_installed(self, info, direction):
+        with patch.object(utils, "find_c_plugin_libs", return_value=[info['name']]) as patch_plugin_lib:
             with patch.object(utils, "get_plugin_info", return_value=info) as patch_plugin_info:
-                PluginDiscovery.fetch_c_plugins_installed("south", True)
-            patch_plugin_info.assert_called_once_with('Random')
-        patch_plugin_lib.assert_called_once_with('south')
+                PluginDiscovery.fetch_c_plugins_installed(direction, True)
+            patch_plugin_info.assert_called_once_with(info['name'])
+        patch_plugin_lib.assert_called_once_with(direction)
 
     @pytest.mark.parametrize("info, exc_count", [
         ({}, 0),

--- a/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
@@ -53,7 +53,9 @@ class TestPluginDiscoveryApi:
         "SOUTH",
         "filter",
         "Filter",
-        "FILTER"
+        "FILTER",
+        "notify",
+        "NOTIFY"
     ])
     async def test_get_plugins_installed_by_params(self, client, param):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value={}) as patch_get_plugin_installed:
@@ -68,12 +70,15 @@ class TestPluginDiscoveryApi:
         ("?type=north&config=false", "north", {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin"}, False),
         ("?type=south&config=false", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin"}, False),
         ("?type=filter&config=false", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin"}, False),
+        ("?type=notify&config=false", "notify", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin"}, False),
         ("?type=north&config=true", "north", {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin",
                                               "config": {"plugin": {"description": "HTTP North-C plugin", "type": "string", "default": "http-north"}}}, True),
         ("?type=south&config=true", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin",
                                               "config": {"plugin": {"description": "sinusoid plugin", "type": "string", "default": "sinusoid", "readonly": "true"}}}, True),
         ("?type=filter&config=true", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin",
-                                                "config": {"offset": {"default": "0.0", "type": "float", "description": "A constant offset"}, "factor": {"default": "100.0", "type": "float", "description": "Scale factor for a reading."}, "plugin": {"default": "scale", "type": "string", "description": "Scale filter plugin"}, "enable": {"default": "false", "type": "boolean", "description": "A switch that can be used to enable or disable."}}}, True)
+                                                "config": {"offset": {"default": "0.0", "type": "float", "description": "A constant offset"}, "factor": {"default": "100.0", "type": "float", "description": "Scale factor for a reading."}, "plugin": {"default": "scale", "type": "string", "description": "Scale filter plugin"}, "enable": {"default": "false", "type": "boolean", "description": "A switch that can be used to enable or disable."}}}, True),
+        ("?type=notify&config=true", "notify", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin",
+                                                "config": {"plugin": {"type": "string", "description": "Email notification plugin", "default": "email"}}}, True)
     ])
     async def test_get_plugins_installed_by_type_and_config(self, client, param, direction, result, is_config):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value=result) as patch_get_plugin_installed:
@@ -85,7 +90,7 @@ class TestPluginDiscoveryApi:
         patch_get_plugin_installed.assert_called_once_with(direction, is_config)
 
     @pytest.mark.parametrize("param, message", [
-        ("?type=blah", "Invalid plugin type. Must be 'north' or 'south' or 'filter'."),
+        ("?type=blah", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify'."),
         ("?config=blah", 'Only "true", "false", true, false are allowed for value of config.'),
         ("?config=False", 'Only "true", "false", true, false are allowed for value of config.'),
         ("?config=True", 'Only "true", "false", true, false are allowed for value of config.'),

--- a/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
@@ -50,7 +50,10 @@ class TestPluginDiscoveryApi:
         "North",
         "South",
         "NORTH",
-        "SOUTH"
+        "SOUTH",
+        "filter",
+        "Filter",
+        "FILTER"
     ])
     async def test_get_plugins_installed_by_params(self, client, param):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value={}) as patch_get_plugin_installed:
@@ -64,10 +67,13 @@ class TestPluginDiscoveryApi:
     @pytest.mark.parametrize("param, direction, result, is_config", [
         ("?type=north&config=false", "north", {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin"}, False),
         ("?type=south&config=false", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin"}, False),
+        ("?type=filter&config=false", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin"}, False),
         ("?type=north&config=true", "north", {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin",
                                               "config": {"plugin": {"description": "HTTP North-C plugin", "type": "string", "default": "http-north"}}}, True),
         ("?type=south&config=true", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin",
-                                              "config": {"plugin": {"description": "sinusoid plugin", "type": "string", "default": "sinusoid", "readonly": "true"}}}, True)
+                                              "config": {"plugin": {"description": "sinusoid plugin", "type": "string", "default": "sinusoid", "readonly": "true"}}}, True),
+        ("?type=filter&config=true", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin",
+                                                "config": {"offset": {"default": "0.0", "type": "float", "description": "A constant offset"}, "factor": {"default": "100.0", "type": "float", "description": "Scale factor for a reading."}, "plugin": {"default": "scale", "type": "string", "description": "Scale filter plugin"}, "enable": {"default": "false", "type": "boolean", "description": "A switch that can be used to enable or disable."}}}, True)
     ])
     async def test_get_plugins_installed_by_type_and_config(self, client, param, direction, result, is_config):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value=result) as patch_get_plugin_installed:
@@ -79,7 +85,7 @@ class TestPluginDiscoveryApi:
         patch_get_plugin_installed.assert_called_once_with(direction, is_config)
 
     @pytest.mark.parametrize("param, message", [
-        ("?type=blah", "Invalid plugin type. Must be 'north' or 'south'."),
+        ("?type=blah", "Invalid plugin type. Must be 'north' or 'south' or 'filter'."),
         ("?config=blah", 'Only "true", "false", true, false are allowed for value of config.'),
         ("?config=False", 'Only "true", "false", true, false are allowed for value of config.'),
         ("?config=True", 'Only "true", "false", true, false are allowed for value of config.'),


### PR DESCRIPTION
```
$ curl -sX GET http://localhost:8081/foglamp/plugins/installed
{
	"plugins": [{
			"description": "PI Server North Plugin",
			"name": "pi_server",
			"type": "north",
			"version": "1.0.0"
		},
		{
			"description": "PI Server North C Plugin",
			"name": "PI_Server_V2",
			"type": "north",
			"version": "1.0.0"
		},
		{
			"description": "Sinusoid Plugin",
			"name": "sinusoid",
			"type": "south",
			"version": "1.0"
		},
		{
			"description": "Random C south plugin",
			"name": "Random",
			"type": "south",
			"version": "1.0.0"
		},
		{
			"description": "Scale filter plugin",
			"name": "scale",
			"type": "filter",
			"version": "1.0.0"
		},
		{
			"description": "Python 3.5 notification plugin",
			"name": "python35",
			"type": "filter",
			"version": "1.0.0"
		},
		{
			"description": "Email notification plugin",
			"name": "email",
			"type": "notify",
			"version": "1.0.0"
		},
		{
			"description": "Python 3.5 notification plugin",
			"name": "python35",
			"type": "notify",
			"version": "1.0.0"
		}
	]
}
```

```
curl -sX GET 'http://localhost:8081/foglamp/plugins/installed?type=filter&config=true' | jq
{
  "plugins": [
    {
      "config": {
        "plugin": {
          "description": "Scale filter plugin",
          "type": "string",
          "default": "scale"
        },
        "offset": {
          "description": "A constant offset to add to every value.",
          "type": "float",
          "default": "0.0"
        },
        "enable": {
          "description": "A switch that can be used to enable or disable execution of the scale filter.",
          "type": "boolean",
          "default": "false"
        },
        "factor": {
          "description": "Scale factor for a reading value.",
          "type": "float",
          "default": "100.0"
        }
      },
      "description": "Scale filter plugin",
      "name": "scale",
      "type": "filter",
      "version": "1.0.0"
    },
    {
      "config": {
        "plugin": {
          "description": "Python 3.5 notification plugin",
          "type": "string",
          "default": "python35"
        },
        "script": {
          "description": "Python 3.5 module to load.",
          "type": "script",
          "default": "notify35"
        },
        "config": {
          "description": "Python 3.5 filter configuration.",
          "type": "JSON",
          "default": {}
        },
        "enable": {
          "description": "A switch that can be used to enable or disable execution of the Python 3.5 notification plugin.",
          "type": "boolean",
          "default": "false"
        }
      },
      "description": "Python 3.5 notification plugin",
      "name": "python35",
      "type": "filter",
      "version": "1.0.0"
    }
  ]
}
```

```
$ curl -sX GET http://localhost:8081/foglamp/plugins/installed?type=notify | jq
{
  "plugins": [
    {
      "description": "Email notification plugin",
      "name": "email",
      "type": "notify",
      "version": "1.0.0"
    },
    {
      "description": "Python 3.5 notification plugin",
      "name": "python35",
      "type": "notify",
      "version": "1.0.0"
    }
  ]
}
```

@MarkRiddoch 
**Questions:**

1) I have added discovery code for only C-plugins (i.e filter, notify). Do we really need to discover it for python as we don't have filter, notification mechanism at Python side?

2) Right now for notification plugins, I have taken "**notify**" convention it from https://github.com/foglamp/foglamp-notify-email/tree/FOGL-1999 as under development and actual development blocked by https://scaledb.atlassian.net/browse/FOGL-1997

So advise  _notify or notification_?

3) Rules and delivery notification plugins stores under same directory **notify**? Or separate?