### PR TITLE
FOGL-2157: log added

### DIFF
--- a/C/tasks/north/sending_process/sending_process.cpp
+++ b/C/tasks/north/sending_process/sending_process.cpp
@@ -148,7 +148,11 @@ static void loadDataThread(SendingProcess *loadData)
 						  loadData->getStreamId(),
 						  readIdx);
 
-			if (loadData->isRunning()) {
+	                Logger::getLogger()->warn("SendingProcess is faster to load data than the destination to process them,"
+	                                          " so all the %lu in memory buffers are full and the load thread should wait until at least a buffer is freed.",
+	                                          loadData->getMemoryBufferSize());
+
+	                if (loadData->isRunning()) {
 
 				// Load thread is put on hold, only if the execution should proceed
 				unique_lock<mutex> lock(waitMutex);


### PR DESCRIPTION
samples :

```
user.info, 6,1,Dec 10 15:51:47,ihsdev,FogLAMP, Process[22509]: INFO: SendingProcess loadDataThread: ('readings' stream id 4), readIdx 0, buffer is NOT empty, waiting ...
user.warning, 4,1,Dec 10 15:51:47,ihsdev,FogLAMP, Process[22509]: WARNING: SendingProcess is faster to load data than the destination to process them, so all the 10 in memory buffers are full and the load thread should wait until at least a buffer is freed.

user.info, 6,1,Dec 10 15:51:47,ihsdev,FogLAMP, Process[22509]: INFO: SendingProcess loadDataThread: ('readings' stream id 4), readIdx 2, buffer is NOT empty, waiting ...
user.warning, 4,1,Dec 10 15:51:47,ihsdev,FogLAMP, Process[22509]: WARNING: SendingProcess is faster to load data than the destination to process them, so all the 10 in memory buffers are full and the load thread should wait until at least a buffer is freed.

user.info, 6,1,Dec 10 15:51:47,ihsdev,FogLAMP, Process[22509]: INFO: SendingProcess loadDataThread: ('readings' stream id 4), readIdx 3, buffer is NOT empty, waiting ...
user.warning, 4,1,Dec 10 15:51:47,ihsdev,FogLAMP, Process[22509]: WARNING: SendingProcess is faster to load data than the destination to process them, so all the 10 in memory buffers are full and the load thread should wait until at least a buffer is freed.

user.info, 6,1,Dec 10 15:51:47,ihsdev,FogLAMP, Process[22509]: INFO: SendingProcess loadDataThread: ('readings' stream id 4), readIdx 4, buffer is NOT empty, waiting ...
user.warning, 4,1,Dec 10 15:51:47,ihsdev,FogLAMP, Process[22509]: WARNING: SendingProcess is faster to load data than the destination to process them, so all the 10 in memory buffers are full and the load thread should wait until at least a buffer is freed.
user.info, 6,1,Dec 10 15:51:51,ihsdev,FogLAMP, Process[22509]: INFO: SendingProcess loadDataThread: ('readings' stream id 4), readIdx 0, buffer is NOT empty, waiting ...

```