### PR TITLE
FOGL-2178: fixed the mktime usage forcing the use of UTC time.

### DIFF
--- a/C/common/reading_set.cpp
+++ b/C/common/reading_set.cpp
@@ -211,13 +211,13 @@ ReadingSet::clear()
  */
 static void convert_timestamp(const char *str, struct timeval *tv)
 {
-struct tm tm;
+	struct tm tm  = {0};
 
 	memset(&tm, 0, sizeof(tm));
 	strptime(str, "%Y-%m-%d %H:%M:%S", &tm);
 
-    	// mktime handles timezones, so UTC is configured
-	tv->tv_sec = mktime(&tm);
+    	// stores in timeval the UTC time
+	tv->tv_sec = mktime(&tm) - __timezone;
 
 	// Work out the microseconds from the fractional part of the seconds
 	char fractional[10];

--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -452,10 +452,17 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 	// Then get HTTPS POST ret code and return 0 to client on error
 	try
 	{
+		// FIXME::
+		Logger::getLogger()->info("DBG : OMG MESSAGE : HostPort |%s| - path |%s| - message |%s|",
+		                          m_sender.getHostPort().c_str(),
+		                          m_path.c_str(),
+		                          json_not_compressed.c_str() );
+
 		int res = m_sender.sendRequest("POST",
 					       m_path,
 					       readingData,
 					       json);
+
 		if (res != 200 && res != 202 && res != 204)
 		{
 			Logger::getLogger()->error("Sending JSON readings, "

--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -379,6 +379,7 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 {
 	/*
 	 * Iterate over readings:
+	 * Iterate over readings:
 	 * - Send/cache Types
 	 * - transform a reading to OMF format
 	 * - add OMF data to new vector
@@ -452,17 +453,10 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 	// Then get HTTPS POST ret code and return 0 to client on error
 	try
 	{
-		// FIXME::
-		Logger::getLogger()->info("DBG : OMG MESSAGE : HostPort |%s| - path |%s| - message |%s|",
-		                          m_sender.getHostPort().c_str(),
-		                          m_path.c_str(),
-		                          json_not_compressed.c_str() );
-
 		int res = m_sender.sendRequest("POST",
 					       m_path,
 					       readingData,
 					       json);
-
 		if (res != 200 && res != 202 && res != 204)
 		{
 			Logger::getLogger()->error("Sending JSON readings, "

--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -379,7 +379,6 @@ uint32_t OMF::sendToServer(const vector<Reading *>& readings,
 {
 	/*
 	 * Iterate over readings:
-	 * Iterate over readings:
 	 * - Send/cache Types
 	 * - transform a reading to OMF format
 	 * - add OMF data to new vector


### PR DESCRIPTION
this is going to solve : FOGL-2170

test case : 
```
fogbench_humidity_4	{"temperature":48,"humidity":67}	2018-12-14 23:22:09.246744+09:00
fogbench_humidity_3	{"temperature":14,"humidity":9}	2018-12-14 14:02:29.172600+00:00
fogbench_humidity_2	{"temperature":19,"humidity":8}	2018-12-13 09:00:00.001579
fogbench_humidity	{"temperature":19,"humidity":8}	2018-12-13 09:39:23.943579+01:00


``` 


 
![screenshot - 14-dec-18 15_32_41](https://user-images.githubusercontent.com/4919069/50008793-8a583480-ffb5-11e8-81f0-1e3ff92fb5c1.png)

![screenshot - 14-dec-18 15_33_39](https://user-images.githubusercontent.com/4919069/50008842-a4921280-ffb5-11e8-8fde-28d19d0a8691.png)


```
25146	North_Readings_to_PI	2018-12-13 09:32:12.690940+01:00	0	2018-12-13 08:32:12.897

```

![screenshot - 14-dec-18 15_34_32](https://user-images.githubusercontent.com/4919069/50008893-c8555880-ffb5-11e8-908b-bfb9f53fa611.png)
