### PR TITLE
FOGL-2193 C get plugin info now on the basis on the combination of directory & lib name

### DIFF
--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -74,7 +74,7 @@ class PluginDiscovery(object):
         configs = []
         for l in libs:
             try:
-                jdoc = utils.get_plugin_info(l)
+                jdoc = utils.get_plugin_info(l, dir=plugin_type)
                 if bool(jdoc):
                     plugin_config = {'name': l,
                                      'type': plugin_type,

--- a/python/foglamp/services/core/api/filters.py
+++ b/python/foglamp/services/core/api/filters.py
@@ -75,7 +75,7 @@ async def create_filter(request: web.Request) -> web.Response:
             raise ValueError("This '{}' filter already exists".format(filter_name))
 
         # Load C filter plugin info
-        loaded_plugin_info = apiutils.get_plugin_info(plugin_name)
+        loaded_plugin_info = apiutils.get_plugin_info(plugin_name, dir='filter')
         if not loaded_plugin_info or 'config' not in loaded_plugin_info:
             message = "Can not get 'plugin_info' detail from plugin '{}'".format(plugin_name)
             raise ValueError(message)

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -183,7 +183,7 @@ async def add_service(request):
             script = '["services/south_c"]' if plugin_info['mode'] == 'poll' else '["services/south"]'
         except ImportError as ex:
             # Checking for C-type plugins
-            plugin_info = apiutils.get_plugin_info(plugin)
+            plugin_info = apiutils.get_plugin_info(plugin, dir=service_type)
             if plugin_info['type'] != service_type:
                 msg = "Plugin of {} type is not supported".format(plugin_info['type'])
                 _logger.exception(msg)

--- a/python/foglamp/services/core/api/task.py
+++ b/python/foglamp/services/core/api/task.py
@@ -163,7 +163,7 @@ async def add_task(request):
         except ImportError as ex:
             # Checking for C-type plugins
             script = '["tasks/north_c"]'
-            plugin_info = apiutils.get_plugin_info(plugin)
+            plugin_info = apiutils.get_plugin_info(plugin, dir=task_type)
             if plugin_info['type'] != task_type:
                 msg = "Plugin of {} type is not supported".format(plugin_info['type'])
                 _logger.exception(msg)

--- a/python/foglamp/services/core/api/utils.py
+++ b/python/foglamp/services/core/api/utils.py
@@ -8,10 +8,10 @@ _logger = logger.setup(__name__)
 _lib_path = _FOGLAMP_ROOT + "/" + "plugins"
 
 
-def get_plugin_info(name):
+def get_plugin_info(name, dir):
     try:
         arg1 = _find_c_util('get_plugin_info')
-        arg2 = _find_c_lib(name)
+        arg2 = _find_c_lib(name, dir)
         cmd_with_args = [arg1, arg2, "plugin_info"]
         p = subprocess.Popen(cmd_with_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
@@ -24,8 +24,9 @@ def get_plugin_info(name):
         return jdoc
 
 
-def _find_c_lib(name):
-    for path, subdirs, files in os.walk(_lib_path):
+def _find_c_lib(name, dir):
+    _path =_lib_path + "/" + dir
+    for path, subdirs, files in os.walk(_path):
         for fname in files:
             # C-binary file
             if fname.endswith(name + '.so'):

--- a/tests/unit/python/foglamp/common/test_plugin_discovery.py
+++ b/tests/unit/python/foglamp/common/test_plugin_discovery.py
@@ -333,18 +333,18 @@ class TestPluginDiscovery:
                 assert actual is None
         patch_log_warn.assert_called_once_with('Plugin http-north is discarded due to invalid type')
 
-    @pytest.mark.parametrize("info, direction", [
+    @pytest.mark.parametrize("info, dir", [
         (mock_c_plugins_config[0], "south"),
         (mock_c_plugins_config[1], "north"),
         (mock_c_plugins_config[2], "filter"),
         (mock_c_plugins_config[3], "notify")
     ])
-    def test_fetch_c_plugins_installed(self, info, direction):
+    def test_fetch_c_plugins_installed(self, info, dir):
         with patch.object(utils, "find_c_plugin_libs", return_value=[info['name']]) as patch_plugin_lib:
             with patch.object(utils, "get_plugin_info", return_value=info) as patch_plugin_info:
-                PluginDiscovery.fetch_c_plugins_installed(direction, True)
-            patch_plugin_info.assert_called_once_with(info['name'])
-        patch_plugin_lib.assert_called_once_with(direction)
+                PluginDiscovery.fetch_c_plugins_installed(dir, True)
+            patch_plugin_info.assert_called_once_with(info['name'], dir=dir)
+        patch_plugin_lib.assert_called_once_with(dir)
 
     @pytest.mark.parametrize("info, exc_count", [
         ({}, 0),
@@ -356,7 +356,7 @@ class TestPluginDiscovery:
             with patch.object(utils, "find_c_plugin_libs", return_value=["Random"]) as patch_plugin_lib:
                 with patch.object(utils, "get_plugin_info",  return_value=info) as patch_plugin_info:
                     PluginDiscovery.fetch_c_plugins_installed("south", False)
-                patch_plugin_info.assert_called_once_with('Random')
+                patch_plugin_info.assert_called_once_with('Random', dir='south')
             patch_plugin_lib.assert_called_once_with('south')
             assert exc_count == patch_log_exc.call_count
 
@@ -370,7 +370,7 @@ class TestPluginDiscovery:
             with patch.object(utils, "find_c_plugin_libs", return_value=["PI_Server"]) as patch_plugin_lib:
                 with patch.object(utils, "get_plugin_info", return_value=info) as patch_plugin_info:
                     PluginDiscovery.fetch_c_plugins_installed("north", False)
-                patch_plugin_info.assert_called_once_with('PI_Server')
+                patch_plugin_info.assert_called_once_with('PI_Server', dir='north')
             patch_plugin_lib.assert_called_once_with('north')
             assert exc_count == patch_log_exc.call_count
 

--- a/tests/unit/python/foglamp/services/core/api/test_api_utils.py
+++ b/tests/unit/python/foglamp/services/core/api/test_api_utils.py
@@ -36,9 +36,9 @@ class TestUtils:
             with patch.object(utils, '_find_c_lib', return_value=None) as patch_lib:
                 with patch.object(utils.subprocess, "Popen", side_effect=Exception):
                     with patch.object(utils._logger, 'exception') as patch_logger:
-                        assert {} == utils.get_plugin_info(plugin_name)
+                        assert {} == utils.get_plugin_info(plugin_name, dir='south')
                     assert 1 == patch_logger.call_count
-            patch_lib.assert_called_once_with(plugin_name)
+            patch_lib.assert_called_once_with(plugin_name, 'south')
         patch_util.assert_called_once_with('get_plugin_info')
 
     @patch('subprocess.Popen')
@@ -49,7 +49,7 @@ class TestUtils:
                 attrs = {'communicate.return_value': (b'{"name": "Random", "version": "1.0.0", "type": "south", "interface": "1.0.0", "config": {"plugin" : { "description" : "Random C south plugin", "type" : "string", "default" : "Random" }, "asset" : { "description" : "Asset name", "type" : "string", "default" : "Random" } } }\n', 'error')}
                 process_mock.configure_mock(**attrs)
                 mock_subproc_popen.return_value = process_mock
-                j = utils.get_plugin_info('Random')
+                j = utils.get_plugin_info('Random', dir='south')
                 assert {'name': 'Random', 'type': 'south', 'version': '1.0.0', 'interface': '1.0.0', 'config': {'plugin': {'description': 'Random C south plugin', 'type': 'string', 'default': 'Random'}, 'asset': {'description': 'Asset name', 'type': 'string', 'default': 'Random'}}} == j
-            patch_lib.assert_called_once_with('Random')
+            patch_lib.assert_called_once_with('Random', 'south')
         patch_util.assert_called_once_with('get_plugin_info')

--- a/tests/unit/python/foglamp/services/core/api/test_filters.py
+++ b/tests/unit/python/foglamp/services/core/api/test_filters.py
@@ -213,7 +213,7 @@ class TestFilters:
                         assert "Can not get 'plugin_info' detail from plugin '{}'".format(plugin_name) == resp.reason
                     assert 1 == log_exc.call_count
                     log_exc.assert_called_once_with("Add filter, caught exception: Can not get 'plugin_info' detail from plugin '{}'".format(plugin_name))
-                api_utils_patch.assert_called_once_with(plugin_name)
+                api_utils_patch.assert_called_once_with(plugin_name, dir='filter')
             get_cat_info_patch.assert_called_once_with(category_name='test')
 
     async def test_create_filter_value_error_3(self, client):
@@ -229,7 +229,7 @@ class TestFilters:
                         assert "Loaded plugin 'python35', type 'south', doesn't match the specified one '{}', type 'filter'".format(plugin_name) == resp.reason
                     assert 1 == log_exc.call_count
                     log_exc.assert_called_once_with("Add filter, caught exception: Loaded plugin 'python35', type 'south', doesn't match the specified one '{}', type 'filter'".format(plugin_name))
-                api_utils_patch.assert_called_once_with(plugin_name)
+                api_utils_patch.assert_called_once_with(plugin_name, dir='filter')
             get_cat_info_patch.assert_called_once_with(category_name='test')
 
     async def test_create_filter_value_error_4(self, client):
@@ -257,7 +257,7 @@ class TestFilters:
                     assert 'filters' == args[0]
                     assert {"where": {"column": "name", "condition": "=", "value": "test"}} == json.loads(args[1])
                     # query_tbl_patch.assert_called_once_with('filters', '{"where": {"column": "name", "condition": "=", "value": "test"}}')
-                api_utils_patch.assert_called_once_with(plugin_name)
+                api_utils_patch.assert_called_once_with(plugin_name, dir='filter')
             get_cat_info_patch.assert_called_once_with(category_name='test')
 
     async def test_create_filter_storage_error(self, client):
@@ -278,7 +278,7 @@ class TestFilters:
                             log_exc.assert_called_once_with('Failed to create filter. %s', 'something went wrong')
                         args, kwargs = _delete_cfg_patch.call_args
                         assert name == args[1]
-                api_utils_patch.assert_called_once_with(plugin_name)
+                api_utils_patch.assert_called_once_with(plugin_name, dir='filter')
             get_cat_info_patch.assert_called_once_with(category_name=name)
 
     async def test_create_filter_exception(self, client):
@@ -323,7 +323,7 @@ class TestFilters:
                     assert 'filters' == args[0]
                     assert {"where": {"column": "name", "condition": "=", "value": "test"}} == json.loads(args[1])
                     # query_tbl_patch.assert_called_once_with('filters', '{"where": {"column": "name", "condition": "=", "value": "test"}}')
-                api_utils_patch.assert_called_once_with(plugin_name)
+                api_utils_patch.assert_called_once_with(plugin_name, dir='filter')
             assert 2 == get_cat_info_patch.call_count
 
     async def test_delete_filter(self, client):


### PR DESCRIPTION
**Notes:**
_Area of testing with C plugins:_ `'north' | 'south' | 'filter' | 'notify' (under development, use [FOGL-1998](
https://github.com/foglamp/foglamp-notify-python35/tree/FOGL-1998))`
- [x] plugin_discovery
- [x] Add service
- [x] Add task
- [x] Add filter