### PR TITLE
compilation fixes for C tests to find Python 3.x lib

### DIFF
--- a/tests/unit/C/common/CMakeLists.txt
+++ b/tests/unit/C/common/CMakeLists.txt
@@ -28,30 +28,11 @@ include_directories(../../../../C/thirdparty/Simple-Web-Server)
 file(GLOB test_sources "../../../../C/common/*.cpp" "../../../../C/plugins/common/*.cpp" "../../../../C/services/common/*.cpp")
 file(GLOB unittests "*.cpp")
  
-# Find Python.h 3.5 header file
-set(_PYTHON_3.5_INCLUDES /usr/include/python3.5m /usr/include/python3.5m)
-list(APPEND _PYTHON_3.5_INCLUDES /usr/include/python3.5 /usr/include/python3.5)
-find_path(Python3.5_INCLUDE NAMES Python.h PATHS ${_PYTHON_3.5_INCLUDES})
-if (NOT Python3.5_INCLUDE)
-        message(WARNING
-        " Python 3.5 header file 'Python.h' not found in /usr/include. \n"
-        " Target '${PROJECT_NAME}' filter is not built.")
-        return()
-else()
-        message(STATUS "Found Python 3.5 header file 'Python.h' in " ${Python3.5_INCLUDE})
-endif()
+# Find python3.x dev/lib package
+find_package(PythonLibs 3 REQUIRED)
 
-# Find Python 3.5 library
-find_library(FoundPython_3.5 NAMES python3.5m python35m python3.5 python35)
-if (NOT FoundPython_3.5)
-        message(FATAL_ERROR "Python 3.5 library not found.")
-        return()
-else()
-        message(STATUS "Found Python 3.5 library in " ${FoundPython_3.5})
-endif()
-
-# Add Python 3.5 header files
-include_directories(${Python3.5_INCLUDE})
+# Add Python 3.x header files
+include_directories(${PYTHON_INCLUDE_DIRS})
 
 
 # Link runTests with what we want to test and the GTest and pthread library
@@ -62,6 +43,6 @@ target_link_libraries(RunTests  ${UUIDLIB})
 target_link_libraries(RunTests  ${COMMONLIB})
 target_link_libraries(RunTests -lssl -lcrypto -lz)
 
-# Add Python 3.5 library
-target_link_libraries(RunTests -lpython3.5m)
+# Add Python 3.x library
+target_link_libraries(RunTests ${PYTHON_LIBRARIES})
 

--- a/tests/unit/C/plugins/common/CMakeLists.txt
+++ b/tests/unit/C/plugins/common/CMakeLists.txt
@@ -30,30 +30,11 @@ file(GLOB plugin_common_sources "../../../../../C/plugins/common/*.cpp")
 file(GLOB services_common_sources "../../../../../C/services/common/*.cpp")
 file(GLOB unittests "*.cpp")
  
-# Find Python.h 3.5 header file
-set(_PYTHON_3.5_INCLUDES /usr/include/python3.5m /usr/include/python3.5m)
-list(APPEND _PYTHON_3.5_INCLUDES /usr/include/python3.5 /usr/include/python3.5)
-find_path(Python3.5_INCLUDE NAMES Python.h PATHS ${_PYTHON_3.5_INCLUDES})
-if (NOT Python3.5_INCLUDE)
-        message(WARNING
-        " Python 3.5 header file 'Python.h' not found in /usr/include. \n"
-        " Target '${PROJECT_NAME}' filter is not built.")
-        return()
-else()
-        message(STATUS "Found Python 3.5 header file 'Python.h' in " ${Python3.5_INCLUDE})
-endif()
+# Find python3.x dev/lib package
+find_package(PythonLibs 3 REQUIRED)
 
-# Find Python 3.5 library
-find_library(FoundPython_3.5 NAMES python3.5m python35m python3.5 python35)
-if (NOT FoundPython_3.5)
-        message(FATAL_ERROR "Python 3.5 library not found.")
-        return()
-else()
-        message(STATUS "Found Python 3.5 library in " ${FoundPython_3.5})
-endif()
-
-# Add Python 3.5 header files
-include_directories(${Python3.5_INCLUDE})
+# Add Python 3.x header files
+include_directories(${PYTHON_INCLUDE_DIRS})
 
 # Link runTests with what we want to test and the GTest and pthread library
 add_executable(RunTests ${common_sources} ${plugin_common_sources} ${services_common_sources} ${unittests})
@@ -63,6 +44,6 @@ target_link_libraries(RunTests  ${UUIDLIB})
 target_link_libraries(RunTests  ${COMMONLIB})
 target_link_libraries(RunTests  -lssl -lcrypto -lz)
 
-# Add Python 3.5 library
-target_link_libraries(RunTests -lpython3.5m)
+# Add Python 3.x library
+target_link_libraries(RunTests ${PYTHON_LIBRARIES})
 

--- a/tests/unit/C/services/core/CMakeLists.txt
+++ b/tests/unit/C/services/core/CMakeLists.txt
@@ -30,30 +30,11 @@ file(GLOB common_services "../../../../../C/services/common/*.cpp")
 file(GLOB common_sources "../../../../../C/common/*.cpp")
 file(GLOB unittests "*.cpp")
  
-# Find Python.h 3.5 header file
-set(_PYTHON_3.5_INCLUDES /usr/include/python3.5m /usr/include/python3.5m)
-list(APPEND _PYTHON_3.5_INCLUDES /usr/include/python3.5 /usr/include/python3.5)
-find_path(Python3.5_INCLUDE NAMES Python.h PATHS ${_PYTHON_3.5_INCLUDES})
-if (NOT Python3.5_INCLUDE)
-        message(WARNING
-        " Python 3.5 header file 'Python.h' not found in /usr/include. \n"
-        " Target '${PROJECT_NAME}' filter is not built.")
-        return()
-else()
-        message(STATUS "Found Python 3.5 header file 'Python.h' in " ${Python3.5_INCLUDE})
-endif()
+# Find python3.x dev/lib package
+find_package(PythonLibs 3 REQUIRED)
 
-# Find Python 3.5 library
-find_library(FoundPython_3.5 NAMES python3.5m python35m python3.5 python35)
-if (NOT FoundPython_3.5)
-        message(FATAL_ERROR "Python 3.5 library not found.")
-        return()
-else()
-        message(STATUS "Found Python 3.5 library in " ${FoundPython_3.5})
-endif()
-
-# Add Python 3.5 header files
-include_directories(${Python3.5_INCLUDE})
+# Add Python 3.x header files
+include_directories(${PYTHON_INCLUDE_DIRS})
 
 # Link runTests with what we want to test and the GTest and pthread library
 add_executable(RunTests ${test_sources} ${common_services} ${common_sources} ${unittests})
@@ -62,6 +43,6 @@ target_link_libraries(RunTests  ${Boost_LIBRARIES})
 target_link_libraries(RunTests  ${UUIDLIB})
 target_link_libraries(RunTests  ${COMMONLIB})
 
-# Add Python 3.5 library
-target_link_libraries(RunTests -lpython3.5m)
+# Add Python 3.x library
+target_link_libraries(RunTests ${PYTHON_LIBRARIES})
 


### PR DESCRIPTION
No regression with this change as it passes on FogLAMP-PR-Unit-Tester and below O/P for Ubuntu-18.04

```
nerd039@aj:~/FogLAMP$ $FOGLAMP_ROOT/tests/unit/C/scripts/RunAllTests.sh
Testing ./plugins/storage/common
All tests in ./plugins/storage/common passed
Testing ./plugins/common
All tests in ./plugins/common passed
Testing ./services/storage/postgres/plugins/common
All tests in ./services/storage/postgres/plugins/common passed
Testing ./services/storage/postgres
All tests in ./services/storage/postgres passed
Testing ./services/core
All tests in ./services/core passed
Testing ./common
All tests in ./common passed

```