### PR TITLE
FOGL-2180: system test added for end to end with csv plugin

### DIFF
--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Configuration system/python/conftest.py
+
+"""
+import pytest
+import subprocess
+import os
+
+__author__ = "Vaibhav Singhal"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.fixture
+def reset_foglamp_start():
+    assert os.environ.get('FOGLAMP_ROOT') is not None
+    subprocess.run(["$FOGLAMP_ROOT/scripts/foglamp kill"], shell=True, check=True)
+    subprocess.run(["echo YES | $FOGLAMP_ROOT/scripts/foglamp reset"], shell=True, check=True)
+    subprocess.run(["$FOGLAMP_ROOT/scripts/foglamp start"], shell=True)
+    stat = subprocess.run(["$FOGLAMP_ROOT/scripts/foglamp status"], shell=True, stdout=subprocess.PIPE)
+    assert "FogLAMP not running." not in stat.stdout.decode("utf-8")
+
+
+def pytest_addoption(parser):
+    parser.addoption("--foglamp_url", action="store", default="localhost:8081",
+                     help="foglmap client api url")
+    parser.addoption("--pi_host", action="store", default="pi-server",
+                     help="PI Server Host Name/IP")
+    parser.addoption("--pi_port", action="store", default="5460",
+                     help="PI Server PORT")
+    parser.addoption("--pi_db", action="store", default="pi-server-db",
+                     help="PI Server database")
+    parser.addoption("--pi_admin", action="store", default="pi-server-uid",
+                     help="PI Server user login")
+    parser.addoption("--pi_passwd", action="store", default="pi-server-pwd",
+                     help="PI Server user login password")
+    parser.addoption("--pi_token", action="store", default="omf_north_0001",
+                     help="OMF Producer Token")
+    parser.addoption("--south_plugin_repo", action="store", default="foglamp-south-playback",
+                     help="South Repo to clone")
+    parser.addoption("--south_plugin", action="store", default="playback",
+                     help="Name of the South Plugin")
+    parser.addoption("--north_plugin", action="store", default="PI_Server_V2",
+                     help="Name of the North Plugin")
+    parser.addoption("--asset_name", action="store", default="systemtest",
+                     help="Name of asset")
+
+
+@pytest.fixture
+def foglamp_url(request):
+    return request.config.getoption("--foglamp_url")
+
+
+@pytest.fixture
+def pi_host(request):
+    return request.config.getoption("--pi_host")
+
+
+@pytest.fixture
+def pi_port(request):
+    return request.config.getoption("--pi_port")
+
+
+@pytest.fixture
+def pi_db(request):
+    return request.config.getoption("--pi_db")
+
+
+@pytest.fixture
+def pi_admin(request):
+    return request.config.getoption("--pi_admin")
+
+
+@pytest.fixture
+def pi_passwd(request):
+    return request.config.getoption("--pi_passwd")
+
+
+@pytest.fixture
+def pi_token(request):
+    return request.config.getoption("--pi_token")
+
+
+@pytest.fixture
+def south_plugin_repo(request):
+    return request.config.getoption("--south_plugin_repo")
+
+
+@pytest.fixture
+def south_plugin(request):
+    return request.config.getoption("--south_plugin")
+
+
+@pytest.fixture
+def north_plugin(request):
+    return request.config.getoption("--north_plugin")
+
+
+@pytest.fixture
+def asset_name(request):
+    return request.config.getoption("--asset_name")
+

--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -7,9 +7,9 @@
 """ Configuration system/python/conftest.py
 
 """
-import pytest
 import subprocess
 import os
+import pytest
 
 __author__ = "Vaibhav Singhal"
 __copyright__ = "Copyright (c) 2018 Dianomic Systems"

--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -12,13 +12,13 @@ import subprocess
 import os
 
 __author__ = "Vaibhav Singhal"
-__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__copyright__ = "Copyright (c) 2018 Dianomic Systems"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 
 @pytest.fixture
-def reset_foglamp_start():
+def reset_and_start_foglamp():
     assert os.environ.get('FOGLAMP_ROOT') is not None
     subprocess.run(["$FOGLAMP_ROOT/scripts/foglamp kill"], shell=True, check=True)
     subprocess.run(["echo YES | $FOGLAMP_ROOT/scripts/foglamp reset"], shell=True, check=True)
@@ -42,8 +42,6 @@ def pytest_addoption(parser):
                      help="PI Server user login password")
     parser.addoption("--pi_token", action="store", default="omf_north_0001",
                      help="OMF Producer Token")
-    parser.addoption("--south_plugin_repo", action="store", default="foglamp-south-playback",
-                     help="South Repo to clone")
     parser.addoption("--south_plugin", action="store", default="playback",
                      help="Name of the South Plugin")
     parser.addoption("--north_plugin", action="store", default="PI_Server_V2",
@@ -85,11 +83,6 @@ def pi_passwd(request):
 @pytest.fixture
 def pi_token(request):
     return request.config.getoption("--pi_token")
-
-
-@pytest.fixture
-def south_plugin_repo(request):
-    return request.config.getoption("--south_plugin_repo")
 
 
 @pytest.fixture

--- a/tests/system/python/test_end_to_end_csv.py
+++ b/tests/system/python/test_end_to_end_csv.py
@@ -67,7 +67,7 @@ def _start_folamp_south(south_plugin, asset_name, foglamp_url):
 
 
 def _start_folamp_north(foglamp_url, pi_host, pi_port, north_plugin, pi_token):
-    """Start north service"""
+    """Start north task"""
 
     conn = http.client.HTTPConnection(foglamp_url)
     data = {"name": "North_Readings_to_PI",
@@ -199,7 +199,7 @@ def start_south_north(reset_and_start_foglamp, south_plugin, asset_name, foglamp
     # Start foglamp south service
     csv_file_path = _start_folamp_south(south_plugin, asset_name, foglamp_url)
 
-    # Start foglamp north service
+    # Start foglamp north task
     _start_folamp_north(foglamp_url, pi_host, pi_port, north_plugin, pi_token)
 
     # Provide the fixture value

--- a/tests/system/python/test_end_to_end_csv.py
+++ b/tests/system/python/test_end_to_end_csv.py
@@ -16,8 +16,6 @@ import shutil
 import base64
 import ssl
 import pytest
-from foglamp.common.common import _FOGLAMP_ROOT
-print(_FOGLAMP_ROOT)
 
 __author__ = "Vaibhav Singhal"
 __copyright__ = "Copyright (c) 2018 Dianomic Systems"

--- a/tests/system/python/test_end_to_end_csv.py
+++ b/tests/system/python/test_end_to_end_csv.py
@@ -26,19 +26,18 @@ __version__ = "${VERSION}"
 CSV_NAME = "sample.csv"
 CSV_HEADER = "temperature"
 CSV_DATA = 2.5
-SENSOR_NAME = CSV_HEADER
 
 # Number of tries to make to read PI data and to read North configuration
 NUM_RETRIES = 3
-# Sleep interval between each tries
-SLEEP_INTERVAL = 10
+# Low sleep interval between each tries, used in internal foglamp process waits
+SLEEP_INTERVAL_LOW = 3
+# High sleep interval between each tries, used in external pi webapi waits
+SLEEP_INTERVAL_HIGH = 10
 
 
-@pytest.fixture
-def start_south_north(reset_and_start_foglamp, south_plugin, asset_name, foglamp_url, pi_host, pi_port,
-                      north_plugin, pi_token):
-    """ This fixture clone a south repo and starts both south and north instance """
-    assert os.environ.get('FOGLAMP_ROOT') is not None
+def _start_folamp_south(south_plugin, asset_name, foglamp_url):
+    """Start south service"""
+
     south_config = {"assetName": {"value": "{}".format(asset_name)}, "csvFilename": {"value": "{}".format(CSV_NAME)},
                     "ingestMode": {"value": "batch"}}
     data = {"name": "play", "type": "South", "plugin": "{}".format(south_plugin), "enabled": "true",
@@ -49,7 +48,8 @@ def start_south_north(reset_and_start_foglamp, south_plugin, asset_name, foglamp
     subprocess.run(["rm -rf -d ${FOGLAMP_ROOT}/python/foglamp/plugins/south/*/"], shell=True, check=True)
     subprocess.run(["git clone https://github.com/foglamp/foglamp-south-{}.git /tmp/foglamp-south-{}".
                    format(south_plugin, south_plugin)], shell=True, check=True)
-    subprocess.run(["cp -r /tmp/foglamp-south-{}/python/foglamp/plugins/south/* $FOGLAMP_ROOT/python/foglamp/plugins/south/".format(south_plugin)], shell=True, check=True)
+    subprocess.run(["cp -r /tmp/foglamp-south-{}/python/foglamp/plugins/south/* "
+                    "$FOGLAMP_ROOT/python/foglamp/plugins/south/".format(south_plugin)], shell=True, check=True)
     subprocess.run(["rm -rf $FOGLAMP_ROOT/data/{}".format(CSV_NAME)], shell=True, check=True)
     csv_file_path = os.path.join(os.path.expandvars('${FOGLAMP_ROOT}'), 'data/{}'.format(CSV_NAME))
     f = open(csv_file_path, "w")
@@ -63,7 +63,13 @@ def start_south_north(reset_and_start_foglamp, south_plugin, asset_name, foglamp
     r = r.read().decode()
     retval = json.loads(r)
     assert retval["name"] == "play"
+    return csv_file_path
 
+
+def _start_folamp_north(foglamp_url, pi_host, pi_port, north_plugin, pi_token):
+    """Start north service"""
+
+    conn = http.client.HTTPConnection(foglamp_url)
     data = {"name": "North_Readings_to_PI",
             "plugin": "{}".format(north_plugin),
             "type": "north",
@@ -79,6 +85,7 @@ def start_south_north(reset_and_start_foglamp, south_plugin, asset_name, foglamp
     retval = json.loads(r)
     assert retval["name"] == "North_Readings_to_PI"
 
+    # Test the north is setup and configuration is available
     retry_count = 0
     config_status = None
     while config_status != 200 and retry_count < NUM_RETRIES:
@@ -87,7 +94,7 @@ def start_south_north(reset_and_start_foglamp, south_plugin, asset_name, foglamp
         config_status = r.status
         r.read().decode()
         retry_count += 1
-        time.sleep(SLEEP_INTERVAL)
+        time.sleep(SLEEP_INTERVAL_LOW)
 
     if config_status != 200 or retry_count == NUM_RETRIES:
         assert False, "North plugin config load failed in {} tries".format(NUM_RETRIES)
@@ -103,12 +110,9 @@ def start_south_north(reset_and_start_foglamp, south_plugin, asset_name, foglamp
     r = conn.getresponse()
     assert 200 == r.status
     r.read().decode()
-    yield start_south_north
-    _remove_csv_files(csv_file_path)
-    _remove_directories("/tmp/foglamp-south-{}".format(south_plugin))
 
 
-def _remove_csv_files(file_path=None):
+def _remove_data_file(file_path=None):
     if os.path.exists(file_path):
         os.remove(file_path)
 
@@ -118,12 +122,18 @@ def _remove_directories(dir_path=None):
         shutil.rmtree(dir_path, ignore_errors=True)
 
 
-def _read_data_from_pi(host, port, admin, password, pi_database, asset):
+def _read_data_from_pi(host, admin, password, pi_database, asset):
     """ This method reads data from pi web api """
+
+    # List of pi databases
     dbs = None
+    # PI logical grouping of attributes and child elements
     element = None
+    # List of elements
     url_elements_list = None
+    # Element's EndValue
     url_assets_list = None
+    # Resources in the PI Web API are addressed by WebID, parameter used for deletion of element
     web_id = None
 
     username_password = "{}:{}".format(admin, password)
@@ -167,7 +177,7 @@ def _read_data_from_pi(host, port, admin, password, pi_database, asset):
             r = json.loads(res.read().decode())
             _items = r["Items"]
             for el in _items:
-                if el["Name"] == SENSOR_NAME:
+                if el["Name"] == CSV_HEADER:
                     value = el["Value"]["Value"]
                     # After Value is stored, delete this element
                     conn.request("DELETE", '/piwebapi/elements/{}'.format(web_id), headers=headers)
@@ -178,10 +188,33 @@ def _read_data_from_pi(host, port, admin, password, pi_database, asset):
         return None
 
 
+@pytest.fixture
+def start_south_north(reset_and_start_foglamp, south_plugin, asset_name, foglamp_url, pi_host, pi_port,
+                      north_plugin, pi_token):
+    """ This fixture clone a south repo and starts both south and north instance """
+
+    # Test that FOGLAMP_ROOT environment variable is set
+    assert os.environ.get('FOGLAMP_ROOT') is not None
+
+    # Start foglamp south service
+    csv_file_path = _start_folamp_south(south_plugin, asset_name, foglamp_url)
+
+    # Start foglamp north service
+    _start_folamp_north(foglamp_url, pi_host, pi_port, north_plugin, pi_token)
+
+    # Provide the fixture value
+    yield start_south_north
+
+    # Cleanup code that runs after the caller test is over
+    _remove_data_file(csv_file_path)
+    _remove_directories("/tmp/foglamp-south-{}".format(south_plugin))
+
+
 def test_end_to_end(start_south_north, foglamp_url, pi_host, pi_port, pi_admin, pi_passwd, pi_db, asset_name):
     """ Test that data is inserted in FogLAMP and sent to PI"""
+
     conn = http.client.HTTPConnection(foglamp_url)
-    time.sleep(SLEEP_INTERVAL)
+    time.sleep(SLEEP_INTERVAL_LOW)
     conn.request("GET", '/foglamp/asset')
     r = conn.getresponse()
     assert 200 == r.status
@@ -200,10 +233,11 @@ def test_end_to_end(start_south_north, foglamp_url, pi_host, pi_port, pi_admin, 
     retry_count = 0
     data_from_pi = None
     while data_from_pi is None and retry_count < NUM_RETRIES:
-        data_from_pi = _read_data_from_pi(pi_host, pi_port, pi_admin, pi_passwd, pi_db, asset_name)
+        data_from_pi = _read_data_from_pi(pi_host, pi_admin, pi_passwd, pi_db, asset_name)
         retry_count += 1
-        time.sleep(SLEEP_INTERVAL)
+        time.sleep(SLEEP_INTERVAL_HIGH)
 
     if data_from_pi is None or retry_count == NUM_RETRIES:
         assert False, "Failed to read data from PI"
+
     assert data_from_pi == str(CSV_DATA)

--- a/tests/system/python/test_end_to_end_csv.py
+++ b/tests/system/python/test_end_to_end_csv.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Test system/python/end_to_end_csv.py
+
+"""
+import pytest
+import os
+import subprocess
+import http.client
+import json
+import time
+import shutil
+import base64
+import ssl
+
+__author__ = "Vaibhav Singhal"
+__copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+CSV_NAME = "sample.csv"
+CSV_HEADER = "temperature"
+CSV_DATA = 2.5
+SENSOR_NAME = CSV_HEADER
+
+# Number of tries to make to read PI data and to read North configuration
+NUM_RETRIES = 3
+# Sleep interval between each tries
+SLEEP_INTERVAL = 10
+
+
+@pytest.fixture
+def start_south_north(reset_foglamp_start, south_plugin, south_plugin_repo, asset_name, foglamp_url, pi_host, pi_port,
+                      north_plugin, pi_token):
+    """ This fixture clone a south repo and starts both south and north instance """
+    assert os.environ.get('FOGLAMP_ROOT') is not None
+    south_config = {"assetName": {"value": "{}".format(asset_name)}, "csvFilename": {"value": "{}".format(CSV_NAME)},
+                    "ingestMode": {"value": "batch"}}
+    data = {"name": "play", "type": "South", "plugin": "{}".format(south_plugin), "enabled": "true",
+            "config": south_config}
+
+    conn = http.client.HTTPConnection(foglamp_url)
+    subprocess.run(["rm -rf /tmp/{}".format(south_plugin_repo)], shell=True, check=True)
+    subprocess.run(["rm -rf -d ${FOGLAMP_ROOT}/python/foglamp/plugins/south/*/"], shell=True, check=True)
+    subprocess.run(["git clone https://github.com/foglamp/{}.git /tmp/{}".format(south_plugin_repo, south_plugin_repo)], shell=True, check=True)
+    subprocess.run(["cp -r /tmp/{}/python/foglamp/plugins/south/* $FOGLAMP_ROOT/python/foglamp/plugins/south/".format(south_plugin_repo)], shell=True, check=True)
+    subprocess.run(["rm -rf $FOGLAMP_ROOT/data/{}".format(CSV_NAME)], shell=True, check=True)
+    f = open(os.path.join(os.path.expandvars('${FOGLAMP_ROOT}'), 'data/{}'.format(CSV_NAME)), "w")
+    f.write(CSV_HEADER)
+    f.write("\n{}".format(CSV_DATA))
+    f.close()
+
+    conn.request("POST", '/foglamp/service', json.dumps(data))
+    r = conn.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    retval = json.loads(r)
+    assert retval["name"] == "play"
+
+    data = {"name": "North_Readings_to_PI",
+            "plugin": "{}".format(north_plugin),
+            "type": "north",
+            "schedule_type": 3,
+            "schedule_day": 0,
+            "schedule_time": 0,
+            "schedule_repeat": 30,
+            "schedule_enabled": "false"}
+    conn.request("POST", '/foglamp/scheduled/task', json.dumps(data))
+    r = conn.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    retval = json.loads(r)
+    assert retval["name"] == "North_Readings_to_PI"
+
+    retry_count = 0
+    config_status = None
+    while config_status != 200 and retry_count < NUM_RETRIES:
+        conn.request("GET", '/foglamp/category/North_Readings_to_PI/producerToken')
+        r = conn.getresponse()
+        config_status = r.status
+        r.read().decode()
+        retry_count += 1
+        time.sleep(SLEEP_INTERVAL)
+
+    if config_status != 200 or retry_count == NUM_RETRIES:
+        assert False, "North plugin config load failed in {} tries".format(NUM_RETRIES)
+
+    data = {"URL": "https://{}:{}/ingress/messages".format(pi_host, pi_port), "producerToken": "{}".format(pi_token)}
+    conn.request("PUT", '/foglamp/category/North_Readings_to_PI', json.dumps(data))
+    r = conn.getresponse()
+    assert 200 == r.status
+    r.read().decode()
+
+    data = {"schedule_name": "{}".format("North_Readings_to_PI")}
+    conn.request("PUT", '/foglamp/schedule/enable', json.dumps(data))
+    r = conn.getresponse()
+    assert 200 == r.status
+    r.read().decode()
+    yield start_south_north
+    os.remove(os.path.join(os.path.expandvars('$FOGLAMP_ROOT/data/{}'.format(CSV_NAME))))
+    shutil.rmtree("/tmp/{}".format(south_plugin_repo), ignore_errors=True)
+
+
+def _read_data_from_pi(host, port, admin, password, pi_database, asset):
+    """ This method reads data from pi web api """
+    dbs = None
+    element = None
+    url_elements_list = None
+    url_assets_list = None
+    web_id = None
+
+    username_password = "{}:{}".format(admin, password)
+    userAndPass = base64.b64encode(username_password.encode('ascii')).decode("ascii")
+    headers = {'Authorization': 'Basic %s' % userAndPass}
+    conn = http.client.HTTPSConnection(host, context=ssl._create_unverified_context())
+
+    try:
+        conn.request("GET", '/piwebapi/assetservers', headers=headers)
+        res = conn.getresponse()
+        r = json.loads(res.read().decode())
+        dbs = r["Items"][0]["Links"]["Databases"]
+
+        if dbs is not None:
+            conn.request("GET", dbs, headers=headers)
+            res = conn.getresponse()
+            r = json.loads(res.read().decode())
+            for el in r["Items"]:
+                if el["Name"] == pi_database:
+                    element = el["Links"]["Elements"]
+
+        if element is not None:
+            conn.request("GET", element, headers=headers)
+            res = conn.getresponse()
+            r = json.loads(res.read().decode())
+            url_elements_list = r["Items"][0]["Links"]["Elements"]
+
+        if url_elements_list is not None:
+            conn.request("GET", url_elements_list, headers=headers)
+            res = conn.getresponse()
+            r = json.loads(res.read().decode())
+            items = r["Items"]
+            for el in items:
+                if el["Name"] == asset:
+                    url_assets_list = el["Links"]["EndValue"]
+                    web_id = el["WebId"]
+
+        if url_assets_list is not None:
+            conn.request("GET", url_assets_list, headers=headers)
+            res = conn.getresponse()
+            r = json.loads(res.read().decode())
+            _items = r["Items"]
+            for el in _items:
+                if el["Name"] == SENSOR_NAME:
+                    value = el["Value"]["Value"]
+                    # After Value is stored, delete this element
+                    conn.request("DELETE", '/piwebapi/elements/{}'.format(web_id), headers=headers)
+                    res = conn.getresponse()
+                    res.read()
+                    return value
+    except KeyError:
+        return None
+
+
+def test_end_to_end(start_south_north, foglamp_url, pi_host, pi_port, pi_admin, pi_passwd, pi_db, asset_name):
+    """ Test that data is inserted in FogLAMP and sent to PI"""
+    conn = http.client.HTTPConnection(foglamp_url)
+    time.sleep(10)
+    conn.request("GET", '/foglamp/asset')
+    r = conn.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    retval = json.loads(r)
+    assert retval[0]["assetCode"] == asset_name
+    assert retval[0]["count"] == 1
+    conn.request("GET", '/foglamp/asset/{}'.format(asset_name))
+    r = conn.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    retval = json.loads(r)
+    assert retval[0]["reading"] == {'{}'.format(CSV_HEADER): '{}'.format(CSV_DATA)}
+
+    retry_count = 0
+    data_from_pi = None
+    while data_from_pi is None and retry_count < NUM_RETRIES:
+        data_from_pi = _read_data_from_pi(pi_host, pi_port, pi_admin, pi_passwd, pi_db, asset_name)
+        retry_count += 1
+        time.sleep(SLEEP_INTERVAL)
+
+    if data_from_pi is None or retry_count == NUM_RETRIES:
+        assert False, "Failed to read data from PI"
+    assert data_from_pi == str(CSV_DATA)


### PR DESCRIPTION
End to end test with CSV plugin to PI written in pytest.
**Advantages of test over bash test suite:**

- Less lines of code (~190 as compared to existing bash suit > 300)
- Reusable components (conftest.py)
- Assertions at every point
- Cleanup handled, test cleans up csv created and data sent to pi and subsequent test will start with fresh environment (both at FogLAMP side and PI side)
- Execution time ~45 sec as compared to bash test suit (>2 minutes)
- Uses arg parser, test can be configured with different arguments from command line
- Junit style framework, no need for pytest wrapper as compared to bash test suite
- CI friendly (CI expects tests to be written in junit style framework)

**Usage:**
```tests/system/python $ pytest test_end_to_end_csv.py --pi_db=<pi_db_name> --pi_host=<pi_server_host> --pi_admin=<pi_machine_user> --pi_passwd=<pi_machine_password> --pi_token=<pi_producer_token>"```

**Result:**
```====== 1 passed in 45.42 seconds =====```
