### PR TITLE
FOGL-2272 Ability to start the notification service via add_service REST API call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ STORAGE_SERVICE_SCRIPT_SRC  := scripts/services/storage
 STORAGE_SCRIPT_SRC          := scripts/storage
 NORTH_SCRIPT_SRC            := scripts/tasks/north
 NORTH_C_SCRIPT_SRC          := scripts/tasks/north_c
+NOTIFICATION_C_SCRIPT_SRC   := scripts/services/notification_c
 PURGE_SCRIPT_SRC            := scripts/tasks/purge
 STATISTICS_SCRIPT_SRC       := scripts/tasks/statistics
 BACKUP_SRC                  := scripts/tasks/backup
@@ -267,6 +268,7 @@ scripts_install : $(SCRIPTS_INSTALL_DIR) \
 	install_storage_service_script \
 	install_north_script \
 	install_north_c_script \
+	install_notification_c_script \
 	install_purge_script \
 	install_statistics_script \
 	install_storage_script \
@@ -312,6 +314,9 @@ install_north_script : $(SCRIPT_TASKS_INSTALL_DIR) $(NORTH_SCRIPT_SRC)
 
 install_north_c_script : $(SCRIPT_TASKS_INSTALL_DIR) $(NORTH_C_SCRIPT_SRC)
 	$(CP) $(NORTH_C_SCRIPT_SRC) $(SCRIPT_TASKS_INSTALL_DIR)
+
+install_notification_c_script: $(SCRIPT_SERVICES_INSTALL_DIR) $(NOTIFICATION_C_SCRIPT_SRC)
+	$(CP) $(NOTIFICATION_C_SCRIPT_SRC) $(SCRIPT_SERVICES_INSTALL_DIR)
 
 install_purge_script : $(SCRIPT_TASKS_INSTALL_DIR) $(PURGE_SCRIPT_SRC)
 	$(CP) $(PURGE_SCRIPT_SRC) $(SCRIPT_TASKS_INSTALL_DIR)

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -177,6 +177,9 @@ async def add_service(request):
             try:
                 plugin_info = load_python_plugin(plugin_module_path, plugin, service_type)
                 plugin_config = plugin_info['config']
+                if not plugin_config:
+                    _logger.exception("Plugin %s import problem from path %s", plugin, plugin_module_path)
+                    raise web.HTTPNotFound(reason='Plugin "{}" import problem from path "{}".'.format(plugin, plugin_module_path))
                 process_name = 'south_c' if plugin_info['mode'] == 'poll' else 'south'
                 script = '["services/south_c"]' if plugin_info['mode'] == 'poll' else '["services/south"]'
             except ImportError as ex:

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -173,8 +173,8 @@ async def add_service(request):
             # "plugin_module_path" is fixed by design. It is MANDATORY to keep the plugin in the exactly similar named
             # folder, within the plugin_module_path.
             # if multiple plugin with same name are found, then python plugin import will be tried first
+            plugin_module_path = "foglamp.plugins.south"
             try:
-                plugin_module_path = "foglamp.plugins.south"
                 plugin_info = load_python_plugin(plugin_module_path, plugin, service_type)
                 plugin_config = plugin_info['config']
                 process_name = 'south_c' if plugin_info['mode'] == 'poll' else 'south'
@@ -188,7 +188,7 @@ async def add_service(request):
 
                 process_name = 'south_c'
                 script = '["services/south_c"]'
-            except ValueError as ex:
+            except TypeError as ex:
                 _logger.exception(str(ex))
                 raise web.HTTPBadRequest(reason=str(ex))
             except Exception as ex:
@@ -231,8 +231,6 @@ async def add_service(request):
             for ps in res['rows']:
                 if 'notification_c' in ps['process_name']:
                     raise web.HTTPBadRequest(reason='A Notification service schedule already exists.')
-
-        # If successful then create a configuration entry from plugin configuration
         elif service_type == 'south':
             try:
                 # Create a configuration category from the configuration defined in the plugin
@@ -293,7 +291,7 @@ def load_python_plugin(plugin_module_path: str, plugin: str, service_type: str) 
     plugin_info = _plugin.plugin_info()
     if plugin_info['type'] != service_type:
         msg = "Plugin of {} type is not supported".format(plugin_info['type'])
-        raise ValueError(msg)
+        raise TypeError(msg)
     return plugin_info
 
 
@@ -301,7 +299,7 @@ def load_c_plugin(plugin: str, service_type: str) -> Dict:
     plugin_info = apiutils.get_plugin_info(plugin, dir=service_type)
     if plugin_info['type'] != service_type:
         msg = "Plugin of {} type is not supported".format(plugin_info['type'])
-        raise ValueError(msg)
+        raise TypeError(msg)
     plugin_config = plugin_info['config']
     return plugin_config
 

--- a/scripts/foglamp
+++ b/scripts/foglamp
@@ -415,6 +415,7 @@ foglamp_status() {
                 ps -ef | grep "foglamp.services.south" |grep python3| grep -v 'grep' | awk '{print "foglamp.services.south " $11 " " $12 " " $13}' || true
                 ps -ef | grep "foglamp.services.south" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{print "foglamp.services.south " $9 " " $10 " " $11}' || true
                 ps -ef | grep "foglamp.services.north" | grep -v 'grep' | grep -v awk | awk '{print "foglamp.services.north " $9 " " $10}' || true
+                ps -ef | grep "foglamp.services.notification" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{print "foglamp.services.notification " $9 " " $10 " " $11}' || true
 
                 # Show Tasks
                 foglamp_log "info" "=== FogLAMP tasks:" "outonly" "pretty"

--- a/scripts/services/notification_c
+++ b/scripts/services/notification_c
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Run a FogLAMP south service written in C/C++
+# Run a FogLAMP notification service written in C/C++
 if [ "${FOGLAMP_ROOT}" = "" ]; then
 	FOGLAMP_ROOT=/usr/local/foglamp
 fi

--- a/scripts/services/notification_c
+++ b/scripts/services/notification_c
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Run a FogLAMP south service written in C/C++
+if [ "${FOGLAMP_ROOT}" = "" ]; then
+	FOGLAMP_ROOT=/usr/local/foglamp
+fi
+
+if [ ! -d "${FOGLAMP_ROOT}" ]; then
+	logger "FogLAMP home directory missing or incorrectly set environment"
+	exit 1
+fi
+
+cd "${FOGLAMP_ROOT}/services"
+
+./foglamp.services.notification "$@"

--- a/tests/unit/python/foglamp/services/core/api/test_service.py
+++ b/tests/unit/python/foglamp/services/core/api/test_service.py
@@ -379,6 +379,105 @@ class TestService:
                         assert {'name': 'south', 'script': '["services/south"]'} == p
                 patch_get_cat_info.assert_called_once_with(category_name='furnace4')
 
+    p1 = '{"name": "NotificationServer", "type": "notification"}'
+    p2 = '{"name": "NotificationServer", "type": "notification", "enabled": false}'
+    p3 = '{"name": "NotificationServer", "type": "notification", "enabled": true}'
+
+    @pytest.mark.parametrize("payload", [p1, p2, p3])
+    async def test_add_notification_service(self, client, payload):
+        data = json.loads(payload)
+        sch_id = '45876056-e04c-4cde-8a82-1d8dbbbe6d72'
+
+        async def async_mock_get_schedule():
+            schedule = StartUpSchedule()
+            schedule.schedule_id = sch_id
+            return schedule
+
+        @asyncio.coroutine
+        def q_result(*arg):
+            table = arg[0]
+            _payload = json.loads(arg[1])
+            if table == 'schedules':
+                if _payload['return'][0] == 'process_name':
+                    assert {"return": ["process_name"]} == _payload
+                    return {'rows': [{'process_name': 'purge'}, {'process_name': 'stats collector'}], 'count': 2}
+                else:
+                    assert {"return": ["schedule_name"], "where": {"column": "schedule_name", "condition": "=",
+                                                                   "value": data['name']}} == _payload
+
+                    return {'count': 0, 'rows': []}
+            if table == 'scheduled_processes':
+                assert {"return": ["name"], "where": {"column": "name", "condition": "=",
+                                                      "value": "notification_c"}} == _payload
+                return {'count': 0, 'rows': []}
+
+        expected_insert_resp = {'rows_affected': 1, "response": "inserted"}
+
+        server.Server.scheduler = Scheduler(None, None)
+        storage_client_mock = MagicMock(StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+            with patch.object(c_mgr, 'get_category_all_items', return_value=self.async_mock(None)) as patch_get_cat_info:
+                with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=q_result):
+                    with patch.object(storage_client_mock, 'insert_into_tbl', return_value=self.async_mock(expected_insert_resp)) as insert_table_patch:
+                        with patch.object(server.Server.scheduler, 'save_schedule', return_value=self.async_mock("")) as patch_save_schedule:
+                            with patch.object(server.Server.scheduler, 'get_schedule_by_name', return_value=async_mock_get_schedule()) as patch_get_schedule:
+                                resp = await client.post('/foglamp/service', data=payload)
+                                server.Server.scheduler = None
+                                assert 200 == resp.status
+                                result = await resp.text()
+                                json_response = json.loads(result)
+                                assert {'id': sch_id, 'name': data['name']} == json_response
+                            patch_get_schedule.assert_called_once_with(data['name'])
+                        patch_save_schedule.called_once_with()
+                    args, kwargs = insert_table_patch.call_args
+                    assert 'scheduled_processes' == args[0]
+                    p = json.loads(args[1])
+                    assert {'name': 'notification_c', 'script': '["services/notification_c"]'} == p
+            patch_get_cat_info.assert_called_once_with(category_name=data['name'])
+
+    async def test_dupe_notification_service_schedule(self, client):
+        payload = '{"name": "NotificationServer", "type": "notification"}'
+        data = json.loads(payload)
+
+        @asyncio.coroutine
+        def q_result(*arg):
+            table = arg[0]
+            _payload = json.loads(arg[1])
+            if table == 'schedules':
+                if _payload['return'][0] == 'process_name':
+                    assert {"return": ["process_name"]} == _payload
+                    return {'rows': [{'process_name': 'stats collector'}, {'process_name': 'notification_c'}], 'count': 2}
+
+                else:
+                    assert {"return": ["schedule_name"], "where": {"column": "schedule_name", "condition": "=",
+                                                                   "value": data['name']}} == _payload
+
+                    return {'count': 0, 'rows': []}
+            if table == 'scheduled_processes':
+                assert {"return": ["name"], "where": {"column": "name", "condition": "=",
+                                                      "value": "notification_c"}} == _payload
+                return {'count': 0, 'rows': []}
+
+        expected_insert_resp = {'rows_affected': 1, "response": "inserted"}
+
+        server.Server.scheduler = Scheduler(None, None)
+        storage_client_mock = MagicMock(StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+            with patch.object(c_mgr, 'get_category_all_items', return_value=self.async_mock(None)) as patch_get_cat_info:
+                with patch.object(storage_client_mock, 'query_tbl_with_payload', side_effect=q_result):
+                    with patch.object(storage_client_mock, 'insert_into_tbl', return_value=self.async_mock(expected_insert_resp)) as insert_table_patch:
+                        resp = await client.post('/foglamp/service', data=payload)
+                        server.Server.scheduler = None
+                        assert 400 == resp.status
+                        assert 'A Notification service schedule already exists.' == resp.reason
+                    args, kwargs = insert_table_patch.call_args
+                    assert 'scheduled_processes' == args[0]
+                    p = json.loads(args[1])
+                    assert {'name': 'notification_c', 'script': '["services/notification_c"]'} == p
+            patch_get_cat_info.assert_called_once_with(category_name=data['name'])
+
     async def test_add_service_with_config(self, client):
         payload = '{"name": "Sine", "type": "south", "plugin": "sinusoid", "enabled": "false",' \
                   ' "config": {"dataPointsPerSec": {"value": "10"}}}'

--- a/tests/unit/python/foglamp/services/core/api/test_service.py
+++ b/tests/unit/python/foglamp/services/core/api/test_service.py
@@ -125,7 +125,7 @@ class TestService:
     @pytest.mark.parametrize("payload, code, message", [
         ('"blah"', 400, "Data payload must be a valid JSON"''),
         ('{}', 400, "Missing name property in payload."),
-        ('{"name": "test"}', 400, "Missing plugin property in payload."),
+        ('{"name": "test"}', 400, "Missing type property in payload."),
         ('{"name": "a;b", "plugin": "dht11", "type": "south"}', 400, "Invalid name property in payload."),
         ('{"name": "test", "plugin": "dht@11", "type": "south"}', 400, "Invalid plugin property in payload."),
         ('{"name": "test", "plugin": "dht11", "type": "south", "enabled": "blah"}', 400,
@@ -141,8 +141,9 @@ class TestService:
         ('{"name": "test", "plugin": "dht11", "type": "south", "enabled": "0"}', 400,
          'Only "true", "false", true, false are allowed for value of enabled.'),
         ('{"name": "test", "plugin": "dht11"}', 400, "Missing type property in payload."),
-        ('{"name": "test", "plugin": "dht11", "type": "blah"}', 400, "Only south type is supported."),
-        ('{"name": "test", "plugin": "dht11", "type": "North"}', 406, "north type is not supported for the time being.")
+        ('{"name": "test", "plugin": "dht11", "type": "blah"}', 400, "Only south and notification type are supported."),
+        ('{"name": "test", "plugin": "dht11", "type": "North"}', 406, "north type is not supported for the time being."),
+        ('{"name": "test", "type": "south"}', 400, "Missing plugin property for type south in payload.")
     ])
     async def test_add_service_with_bad_params(self, client, code, payload, message):
         resp = await client.post('/foglamp/service', data=payload)


### PR DESCRIPTION
~**Pending items**~
~- [x] make install~
~- [x] Unit tests~
~- [x] Exception handling~

**NOTE**: Notification service LIMITS to 1

**How to test?**
1) Install **foglamp-service-notification**
2) foglamp start
3) Add_service
```
curl -sX POST http://localhost:8081/foglamp/service -d '{"name": "NotificationServer", "type": "notification", "enabled": true}' | jq
{
  "name": "NotificationServer",
  "id": "45876056-e04c-4cde-8a82-1d8dbbbe6d72"
}


**Syslogs**

Jan  9 16:02:50 nerd-034 FogLAMP[23643] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'NotificationServer' to start at 2019-01-09 16:02:50.378303
Jan  9 16:02:50 nerd-034 FogLAMP[23643] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Enabled Schedule 'NotificationServer/45876056-e04c-4cde-8a82-1d8dbbbe6d72' process 'notification_c'
Jan  9 16:02:50 nerd-034 FogLAMP[23643] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'NotificationServer' process 'notification_c'

```

4) GET service

```
curl -sX GET http://localhost:8081/foglamp/service | jq{
  "services": [
    {
      "protocol": "http",
      "type": "Storage",
      "service_port": 39337,
      "address": "localhost",
      "management_port": 37217,
      "status": "running",
      "name": "FogLAMP Storage"
    },
    {
      "protocol": "http",
      "type": "Core",
      "service_port": 8081,
      "address": "0.0.0.0",
      "management_port": 34611,
      "status": "running",
      "name": "FogLAMP Core"
    },
    {
      "protocol": "http",
      "type": "Notification",
      "service_port": 35199,
      "address": "localhost",
      "management_port": 38821,
      "status": "running",
      "name": "NotificationServer"
    }
  ]
}
```
5) foglamp status
```
 $ ./scripts/foglamp status
FogLAMP v1.4.1 running.
FogLAMP Uptime:  89 seconds.
FogLAMP records: 0 read, 0 sent, 0 purged.
FogLAMP does not require authentication.
=== FogLAMP services:
foglamp.services.core
foglamp.services.storage --address=0.0.0.0 --port=34611
foglamp.services.notification --port=34611 --address=127.0.0.1 --name=NotificationServer
=== FogLAMP tasks:
```
6) Disable NotificationService schedule and check service info and foglamp status

```
curl -sX PUT http://localhost:8081/foglamp/schedule/45876056-e04c-4cde-8a82-1d8dbbbe6d72/disable


curl -sX GET http://localhost:8081/foglamp/service | jq
{
  "services": [
    {
      "protocol": "http",
      "type": "Storage",
      "service_port": 39337,
      "address": "localhost",
      "management_port": 37217,
      "status": "running",
      "name": "FogLAMP Storage"
    },
    {
      "protocol": "http",
      "type": "Core",
      "service_port": 8081,
      "address": "0.0.0.0",
      "management_port": 34611,
      "status": "running",
      "name": "FogLAMP Core"
    },
    {
      "protocol": "http",
      "type": "Notification",
      "service_port": 35199,
      "address": "localhost",
      "management_port": 38821,
      "status": "shutdown",
      "name": "NotificationServer"
    }
  ]
}


./scripts/foglamp status
FogLAMP v1.4.1 running.
FogLAMP Uptime:  586 seconds.
FogLAMP records: 0 read, 0 sent, 0 purged.
FogLAMP does not require authentication.
=== FogLAMP services:
foglamp.services.core
foglamp.services.storage --address=0.0.0.0 --port=34611
=== FogLAMP tasks:


**Syslogs**
Jan  9 16:22:46 nerd-034 FogLAMP[25016] INFO: utils: foglamp.services.common.utils: Ping received for Service NotificationServer id e37d7689-8b8b-41f6-835b-b63527ff4f75 at url http://localhost:38821/foglamp/service/ping
Jan  9 16:22:46 nerd-034 FogLAMP[25016] INFO: utils: foglamp.services.common.utils: Shutting down the Notification service NotificationServer ...
Jan  9 16:22:46 nerd-034 NotificationServer[25084]: INFO: Notification service 'NotificationServer' shutdown in progress ...
Jan  9 16:22:46 nerd-034 NotificationServer[25084]: INFO: Stopping Notification service 'NotificationServer' ...
Jan  9 16:22:46 nerd-034 FogLAMP[25016] INFO: utils: foglamp.services.common.utils: Service NotificationServer, id e37d7689-8b8b-41f6-835b-b63527ff4f75 at url http://localhost:38821/foglamp/service/shutdown successfully shutdown
Jan  9 16:22:46 nerd-034 FogLAMP[25016] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Disabled Schedule 'NotificationServer/45876056-e04c-4cde-8a82-1d8dbbbe6d72' process 'notification_c'
Jan  9 16:22:46 nerd-034 FogLAMP[25016] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Stopped service instance id=e37d7689-8b8b-41f6-835b-b63527ff4f75: <NotificationServer, type=Notification, protocol=http, address=localhost, service port=35199, management port=38821, status=2>
Jan  9 16:22:46 nerd-034 FogLAMP[25016] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Service NotificationServer records successfully removed
Jan  9 16:22:47 nerd-034 NotificationServer[25084]: INFO: Unregistered service e37d7689-8b8b-41f6-835b-b63527ff4f75.
Jan  9 16:22:47 nerd-034 NotificationServer[25084]: INFO: Notification service 'NotificationServer' shutdown completed
```

**DB**
```
sqlite> select * from scheduled_processes where name='notification_c';
name|script
notification_c|["services/notification_c"]



sqlite> select * from schedules where process_name='notification_c';
id|process_name|schedule_name|schedule_type|schedule_interval|schedule_time|schedule_day|exclusive|enabled
45876056-e04c-4cde-8a82-1d8dbbbe6d72|notification_c|NotificationServer|1|0:00:00|00:00:00|0|t|t

```


**Notification API** - Able to communication its API as well
```
curl -sX GET http://localhost:8081/foglamp/notification/plugin | jq
{
  "rules": [
    {
      "version": "1.0.0",
      "interface": "1.0.0",
      "config": {
        "plugin": {
          "readonly": "true",
          "order": "7",
          "displayName": "The OverMaxRule notification rule plugin triggers a notification when reading data exceed an absolute limit value.",
          "type": "string",
          "description": "The OverMaxRule notification rule plugin triggers a notification when reading data exceed an absolute limit value.",
          "default": "The OverMaxRule notification rule plugin triggers a notification when reading data exceed an absolute limit value."
        },
        "time_window": {
          "description": "Duration of the time window, in seconds, for collecting data points except for 'latest' evaluation.",
          "order": "5",
          "displayName": "Duration of the time window, in seconds, for collecting data points except for 'latest' evaluation.",
          "type": "integer",
          "default": "30"
        },
        "trigger_value": {
          "description": "Value at which to trigger a notification.",
          "order": "6",
          "displayName": "Value at which to trigger a notification.",
          "type": "float",
          "default": "0.0"
        },
        "datapoint": {
          "description": "The datapoint within the asset name for which notifications will be generated.",
          "order": "3",
          "displayName": "The datapoint within the asset name for which notifications will be generated.",
          "type": "string",
          "default": ""
        },
        "description": {
          "description": "Generate a notification if the value of a configured datapoint within an asset name exceeds a configured value.",
          "order": "1",
          "displayName": "Generate a notification if the value of a configured datapoint within an asset name exceeds a configured value.",
          "type": "string",
          "default": "Generate a notification if the value of a configured datapoint within an asset name exceeds a configured value."
        },
        "asset": {
          "description": "The asset name for which notifications will be generated.",
          "order": "2",
          "displayName": "The asset name for which notifications will be generated.",
          "type": "string",
          "default": ""
        },
        "evaluation_type": {
          "order": "4",
          "displayName": "The rule evaluation type.",
          "type": "enumeration",
          "description": "The rule evaluation type",
          "options": [
            "window",
            "maximum",
            "minimum",
            "average",
            "latest"
          ],
          "default": "latest"
        }
      },
      "type": "notificationRule",
      "name": "OverMaxRule"
    }
  ],
  "delivery": {}
}

```