### PR TITLE
FOGL-2303: stats thread was not joining main thread at service shutdown

### DIFF
--- a/C/services/south/ingest.cpp
+++ b/C/services/south/ingest.cpp
@@ -295,6 +295,7 @@ Ingest::~Ingest()
 	m_cv.notify_one();
 	m_thread->join();
 	processQueue();
+	m_statsCv.notify_one();
 	m_statsThread->join();
 	updateStats();
 	delete m_queue;


### PR DESCRIPTION
stats thread was not joining main thread as it kept waiting on its condition variable even during south service shutdown.