### PR TITLE
FOGL-1511: Variable for installing python requirements with/without no-cache-dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ LN := ln -sf
 CMAKE := cmake
 PIP_USER_FLAG = --user
 PIP_INSTALL_REQUIREMENTS := pip3 install -Ir
+NO_CACHE_DIR := --no-cache-dir
 PYTHON_BUILD_PACKAGE = python3 setup.py build -b ../$(PYTHON_BUILD_DIR)
 RM_DIR := rm -r
 RM_FILE := rm
@@ -237,11 +238,11 @@ python_build : $(PYTHON_SETUP_FILE)
 
 # install python requirements without --user 
 python_requirements : $(PYTHON_REQUIREMENTS_FILE)
-	$(PIP_INSTALL_REQUIREMENTS) $(PYTHON_REQUIREMENTS_FILE) --no-cache-dir
+	$(PIP_INSTALL_REQUIREMENTS) $(PYTHON_REQUIREMENTS_FILE) $(NO_CACHE_DIR)
 
 # install python requirements for user
 python_requirements_user : $(PYTHON_REQUIREMENTS_FILE)
-	$(PIP_INSTALL_REQUIREMENTS) $(PYTHON_REQUIREMENTS_FILE) $(PIP_USER_FLAG) --no-cache-dir
+	$(PIP_INSTALL_REQUIREMENTS) $(PYTHON_REQUIREMENTS_FILE) $(PIP_USER_FLAG) $(NO_CACHE_DIR)
 
 # create python install dir
 $(PYTHON_INSTALL_DIR) :

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LN := ln -sf
 CMAKE := cmake
 PIP_USER_FLAG = --user
 PIP_INSTALL_REQUIREMENTS := pip3 install -Ir
-USE_PY_CACHE := no
+USE_PIP_CACHE := no
 PYTHON_BUILD_PACKAGE = python3 setup.py build -b ../$(PYTHON_BUILD_DIR)
 RM_DIR := rm -r
 RM_FILE := rm
@@ -144,8 +144,8 @@ else
 endif
 	@echo "$(ACTION) $(PACKAGE_NAME) version $(FOGLAMP_VERSION), DB schema $(FOGLAMP_SCHEMA)"
 
-# Use cache for python requirements depending on the value of USE_PY_CACHE
-ifeq ($(USE_PY_CACHE), yes)
+# Use cache for python requirements depending on the value of USE_PIP_CACHE
+ifeq ($(USE_PIP_CACHE), yes)
     $(eval NO_CACHE_DIR=)
 else
     $(eval NO_CACHE_DIR= --no-cache-dir)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LN := ln -sf
 CMAKE := cmake
 PIP_USER_FLAG = --user
 PIP_INSTALL_REQUIREMENTS := pip3 install -Ir
-NO_CACHE_DIR := --no-cache-dir
+USE_PY_CACHE := no
 PYTHON_BUILD_PACKAGE = python3 setup.py build -b ../$(PYTHON_BUILD_DIR)
 RM_DIR := rm -r
 RM_FILE := rm
@@ -143,6 +143,13 @@ else
 	$(eval ACTION="Building")
 endif
 	@echo "$(ACTION) $(PACKAGE_NAME) version $(FOGLAMP_VERSION), DB schema $(FOGLAMP_SCHEMA)"
+
+# Use cache for python requirements depending on the value of USE_PY_CACHE
+ifeq ($(USE_PY_CACHE), yes)
+    $(eval NO_CACHE_DIR=)
+else
+    $(eval NO_CACHE_DIR= --no-cache-dir)
+endif
 
 # Check where this FogLAMP can be installed over an existing one:
 schema_check : apply_version


### PR DESCRIPTION
Default targets remain same, no change.
If you want to build foglamp keeping cache, then use:
`make USE_PIP_CACHE=yes`