### PR TITLE
FOGL-2251 discovery of rule plugins added with their unit tests

### DIFF
--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -33,13 +33,15 @@ class PluginDiscovery(object):
             plugins_list_c_south = cls.fetch_c_plugins_installed("south", is_config)
             plugins_list_c_filter = cls.fetch_c_plugins_installed("filter", is_config)
             plugins_list_c_notify = cls.fetch_c_plugins_installed("notify", is_config)
+            plugins_list_c_rule = cls.fetch_c_plugins_installed("rule", is_config)
             plugins_list.extend(plugins_list_north)
             plugins_list.extend(plugins_list_c_north)
             plugins_list.extend(plugins_list_south)
             plugins_list.extend(plugins_list_c_south)
             plugins_list.extend(plugins_list_c_filter)
             plugins_list.extend(plugins_list_c_notify)
-        elif plugin_type == 'filter' or plugin_type == 'notify':
+            plugins_list.extend(plugins_list_c_rule)
+        elif plugin_type == 'filter' or plugin_type == 'notify' or plugin_type == 'rule':
             plugins_list = cls.fetch_c_plugins_installed(plugin_type, is_config)
         else:
             plugins_list = cls.fetch_plugins_installed(plugin_type, is_config)

--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -41,7 +41,7 @@ class PluginDiscovery(object):
             plugins_list.extend(plugins_list_c_filter)
             plugins_list.extend(plugins_list_c_notify)
             plugins_list.extend(plugins_list_c_rule)
-        elif plugin_type == 'filter' or plugin_type == 'notify' or plugin_type == 'rule':
+        elif plugin_type in ['filter', 'notify', 'rule']:
             plugins_list = cls.fetch_c_plugins_installed(plugin_type, is_config)
         else:
             plugins_list = cls.fetch_plugins_installed(plugin_type, is_config)

--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -26,7 +26,7 @@ async def get_plugins_installed(request):
     :Example:
         curl -X GET http://localhost:8081/foglamp/plugins/installed
         curl -X GET http://localhost:8081/foglamp/plugins/installed?config=true
-        curl -X GET http://localhost:8081/foglamp/plugins/installed?type=north|south|filter|notify
+        curl -X GET http://localhost:8081/foglamp/plugins/installed?type=north|south|filter|notify|rule
         curl -X 'GET http://localhost:8081/foglamp/plugins/installed?type=north&config=true'
     """
 
@@ -35,8 +35,8 @@ async def get_plugins_installed(request):
     if 'type' in request.query and request.query['type'] != '':
         plugin_type = request.query['type'].lower()
 
-    if plugin_type is not None and plugin_type not in ['north', 'south', 'filter', 'notify']:
-        raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify'.")
+    if plugin_type is not None and plugin_type not in ['north', 'south', 'filter', 'notify', 'rule']:
+        raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'.")
 
     if 'config' in request.query:
         config = request.query['config']

--- a/tests/unit/python/foglamp/common/test_plugin_discovery.py
+++ b/tests/unit/python/foglamp/common/test_plugin_discovery.py
@@ -28,6 +28,7 @@ class TestPluginDiscovery:
     mock_c_south_folders = ["dummy"]
     mock_c_filter_folders = ["scale"]
     mock_c_notify_folders = ["email"]
+    mock_c_rule_folders = ["OverMaxRule"]
     mock_all_folders = ["OMF", "foglamp-north", "modbus", "http"]
     mock_plugins_config = [
         {
@@ -122,6 +123,13 @@ class TestPluginDiscovery:
          "config": {"plugin": {"type": "string", "description": "Email notification plugin", "default": "email"}}}
     ]
 
+    mock_c_rule_config = [
+        {"name": "OverMaxRule",
+         "version": "1.0.0",
+         "type": "rule",
+         "description": "The OverMaxRule notification rule",
+         "config": {"plugin": {"type": "string", "description": "The OverMaxRule notification rule plugin", "default": "OverMaxRule"}}}
+    ]
     mock_c_plugins_config = [
         {"interface": "1.0.0",
          "version": "1.0.0",
@@ -150,7 +158,13 @@ class TestPluginDiscovery:
          "config": {"plugin": {
              "type": "string",
              "description": "Email notification plugin",
-             "default": "email"}}}
+             "default": "email"}}},
+        {"name": "OverMaxRule",
+         "version": "1.0.0",
+         "type": "rule",
+         "description": "The OverMaxRule notification rule",
+         "config": {"plugin": {"type": "string", "description": "The OverMaxRule notification rule plugin",
+                               "default": "OverMaxRule"}}}
     ]
 
     def test_get_plugins_installed_type_none(self, mocker):
@@ -165,6 +179,7 @@ class TestPluginDiscovery:
             yield TestPluginDiscovery.mock_c_south_folders
             yield TestPluginDiscovery.mock_c_filter_folders
             yield TestPluginDiscovery.mock_c_notify_folders
+            yield TestPluginDiscovery.mock_c_rule_folders
 
         mock_get_folders = mocker.patch.object(PluginDiscovery, "get_plugin_folders", return_value=next(mock_folders()))
         mock_get_c_folders = mocker.patch.object(utils, "find_c_plugin_libs", return_value=next(mock_c_folders()))
@@ -180,8 +195,8 @@ class TestPluginDiscovery:
         # assert expected_plugin == plugins
         assert 2 == mock_get_folders.call_count
         assert 4 == mock_get_plugin_config.call_count
-        assert 4 == mock_get_c_folders.call_count
-        assert 4 == mock_get_c_plugin_config.call_count
+        assert 5 == mock_get_c_folders.call_count
+        assert 5 == mock_get_c_plugin_config.call_count
 
     def test_get_plugins_installed_type_north(self, mocker):
         @asyncio.coroutine
@@ -265,6 +280,21 @@ class TestPluginDiscovery:
         assert 1 == mock_get_c_notify_folders.call_count
         assert 1 == mock_get_c_notify_plugin_config.call_count
 
+    def test_get_c_rules_plugins_installed(self, mocker):
+        @asyncio.coroutine
+        def mock_rule_folders():
+            yield TestPluginDiscovery.mock_c_rule_folders
+
+        mock_get_c_rule_folders = mocker.patch.object(utils, "find_c_plugin_libs", return_value=next(mock_rule_folders()))
+        mock_get_c_rule_plugin_config = mocker.patch.object(utils, "get_plugin_info", side_effect=TestPluginDiscovery.mock_c_rule_config)
+
+        plugins = PluginDiscovery.get_plugins_installed("rule")
+        # expected_plugin = TestPluginDiscovery.mock_c_plugins_config[4]
+        # FIXME: ordering issue
+        # assert expected_plugin == plugins
+        assert 1 == mock_get_c_rule_folders.call_count
+        assert 1 == mock_get_c_rule_plugin_config.call_count
+
     def test_fetch_plugins_installed(self, mocker):
         @asyncio.coroutine
         def mock_folders():
@@ -337,14 +367,15 @@ class TestPluginDiscovery:
         (mock_c_plugins_config[0], "south"),
         (mock_c_plugins_config[1], "north"),
         (mock_c_plugins_config[2], "filter"),
-        (mock_c_plugins_config[3], "notify")
+        (mock_c_plugins_config[3], "notify"),
+        (mock_c_plugins_config[4], "rule")
     ])
-    def test_fetch_c_plugins_installed(self, info, dir):
+    def test_fetch_c_plugins_installed(self, info, dir_name):
         with patch.object(utils, "find_c_plugin_libs", return_value=[info['name']]) as patch_plugin_lib:
             with patch.object(utils, "get_plugin_info", return_value=info) as patch_plugin_info:
-                PluginDiscovery.fetch_c_plugins_installed(dir, True)
-            patch_plugin_info.assert_called_once_with(info['name'], dir=dir)
-        patch_plugin_lib.assert_called_once_with(dir)
+                PluginDiscovery.fetch_c_plugins_installed(dir_name, True)
+            patch_plugin_info.assert_called_once_with(info['name'], dir=dir_name)
+        patch_plugin_lib.assert_called_once_with(dir_name)
 
     @pytest.mark.parametrize("info, exc_count", [
         ({}, 0),

--- a/tests/unit/python/foglamp/common/test_plugin_discovery.py
+++ b/tests/unit/python/foglamp/common/test_plugin_discovery.py
@@ -363,7 +363,7 @@ class TestPluginDiscovery:
                 assert actual is None
         patch_log_warn.assert_called_once_with('Plugin http-north is discarded due to invalid type')
 
-    @pytest.mark.parametrize("info, dir", [
+    @pytest.mark.parametrize("info, dir_name", [
         (mock_c_plugins_config[0], "south"),
         (mock_c_plugins_config[1], "north"),
         (mock_c_plugins_config[2], "filter"),

--- a/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
@@ -8,6 +8,7 @@ import json
 from unittest.mock import patch
 import pytest
 from aiohttp import web
+
 from foglamp.services.core import routes
 from foglamp.common.plugin_discovery import PluginDiscovery
 
@@ -55,7 +56,10 @@ class TestPluginDiscoveryApi:
         "Filter",
         "FILTER",
         "notify",
-        "NOTIFY"
+        "NOTIFY",
+        "rule",
+        "Rule",
+        "RULE"
     ])
     async def test_get_plugins_installed_by_params(self, client, param):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value={}) as patch_get_plugin_installed:
@@ -71,6 +75,7 @@ class TestPluginDiscoveryApi:
         ("?type=south&config=false", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin"}, False),
         ("?type=filter&config=false", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin"}, False),
         ("?type=notify&config=false", "notify", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin"}, False),
+        ("?type=rule&config=false", "rule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin"}, False),
         ("?type=north&config=true", "north", {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin",
                                               "config": {"plugin": {"description": "HTTP North-C plugin", "type": "string", "default": "http-north"}}}, True),
         ("?type=south&config=true", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin",
@@ -78,7 +83,9 @@ class TestPluginDiscoveryApi:
         ("?type=filter&config=true", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin",
                                                 "config": {"offset": {"default": "0.0", "type": "float", "description": "A constant offset"}, "factor": {"default": "100.0", "type": "float", "description": "Scale factor for a reading."}, "plugin": {"default": "scale", "type": "string", "description": "Scale filter plugin"}, "enable": {"default": "false", "type": "boolean", "description": "A switch that can be used to enable or disable."}}}, True),
         ("?type=notify&config=true", "notify", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin",
-                                                "config": {"plugin": {"type": "string", "description": "Email notification plugin", "default": "email"}}}, True)
+                                                "config": {"plugin": {"type": "string", "description": "Email notification plugin", "default": "email"}}}, True),
+        ("?type=rule&config=true", "rule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin",
+                                            "config": {"plugin": {"type": "string", "description": "The OverMaxRule notification rule plugin", "default": "OverMaxRule"}}}, True)
     ])
     async def test_get_plugins_installed_by_type_and_config(self, client, param, direction, result, is_config):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value=result) as patch_get_plugin_installed:
@@ -90,7 +97,7 @@ class TestPluginDiscoveryApi:
         patch_get_plugin_installed.assert_called_once_with(direction, is_config)
 
     @pytest.mark.parametrize("param, message", [
-        ("?type=blah", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify'."),
+        ("?type=blah", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'."),
         ("?config=blah", 'Only "true", "false", true, false are allowed for value of config.'),
         ("?config=False", 'Only "true", "false", true, false are allowed for value of config.'),
         ("?config=True", 'Only "true", "false", true, false are allowed for value of config.'),


### PR DESCRIPTION
>  curl -sX GET http://localhost:8081/foglamp/plugins/installed?type=notify | jq
```
{
  "plugins": [
    {
      "name": "python35",
      "description": "Python 3.5 notification plugin",
      "type": "notify",
      "version": "1.0.0"
    },
    {
      "name": "email",
      "description": "Email notification plugin",
      "type": "notify",
      "version": "1.0.0"
    }
  ]
}
```

> curl -sX GET http://localhost:8081/foglamp/plugins/installed?type=rule | jq
```
{
  "plugins": [
    {
      "name": "OverMaxRule",
      "description": "OverMaxRule  plugin",
      "type": "rule",
      "version": "1.0.0"
    }
  ]
}
```


> curl -sX GET http://localhost:8081/foglamp/plugins/installed | jq
```
{
  "plugins": [
    {
      "name": "pi_server",
      "description": "PI Server North Plugin",
      "type": "north",
      "version": "1.0.0"
    },
    {
      "name": "sinusoid",
      "description": "Sinusoid Plugin",
      "type": "south",
      "version": "1.0"
    },
    {
      "name": "scale",
      "description": "Scale filter plugin",
      "type": "filter",
      "version": "1.0.0"
    },
    {
      "name": "python35",
      "description": "Python 3.5 notification plugin",
      "type": "notify",
      "version": "1.0.0"
    },
    {
      "name": "OverMaxRule",
      "description": "OverMaxRule  plugin",
      "type": "rule",
      "version": "1.0.0"
    }
  ]
}
```