### PR TITLE
FOGL-2366: Migrate end_to_end_OCS test from bash to pytest 

### DIFF
--- a/tests/system/python/README.rst
+++ b/tests/system/python/README.rst
@@ -93,13 +93,20 @@ custom options ::
                         FogLAMP client api url
     --use-pip-cache=USE_PIP_CACHE
                         use pip cache is requirement is available
-    --pi-host=PI_HOST     PI Server Host Name/IP
-    --pi-port=PI_PORT     PI Server Port
-    --pi-db=PI_DB         PI Server database
-    --pi-admin=PI_ADMIN   PI Server user login
+
+    --pi-host=PI_HOST
+                        PI Server Host Name/IP
+    --pi-port=PI_PORT
+                        PI Server Port
+    --pi-db=PI_DB
+                        PI Server database
+    --pi-admin=PI_ADMIN
+                        PI Server user login
     --pi-passwd=PI_PASSWD
                         PI Server user login password
-    --pi-token=PI_TOKEN   OMF Producer Token
+    --pi-token=PI_TOKEN
+                        OMF Producer Token
+
     --ocs-tenant=OCS_TENANT
                         Tenant id of OCS
     --ocs-client-id=OCS_CLIENT_ID
@@ -110,7 +117,7 @@ custom options ::
                         OCS namespace where the information are stored
     --ocs-token=OCS_TOKEN
                         Token of OCS account
-    --ocs-url=OCS_URL     URL of OCS, used in North Instance
+
     --south-plugin=SOUTH_PLUGIN
                         Name of the South Plugin
     --south-service-name=SOUTH_SERVICE_NAME
@@ -119,9 +126,12 @@ custom options ::
                         Name of the North Plugin
     --asset-name=ASSET_NAME
                         Name of asset
+
     --wait-time=WAIT_TIME
                         Generic wait time between processes to run
-    --retries=RETRIES     Number of tries to make to fetch data from PI web api
+    --retries=RETRIES
+                        Number of tries to make to fetch data from PI web api
+
     --kafka-host=KAFKA_HOST
                         Kafka Server Host Name/IP
     --kafka-port=KAFKA_PORT
@@ -129,7 +139,7 @@ custom options ::
     --kafka-topic=KAFKA_TOPIC
                         Kafka topic
     --kafka-rest-port=KAFKA_REST_PORT
-                        Kafka Rest Proxy Port
+                        Kafka REST Proxy Port
 
 
 
@@ -187,7 +197,7 @@ The minimum required parameters to run ::
     --kafka-host=<Hostname/IP of Kafka Server>
     --kafka-port=<Kafka Server Port>
     --kafka-topic=<Kafka topic>
-    --kafka-rest-port=<Kafka Rest Port>
+    --kafka-rest-port=<Kafka REST Proxy Port>
 
 
 Execute all the System tests
@@ -202,15 +212,17 @@ and running pytest without the test name::
     --pi-admin=<Login of PI Machine>
     --pi-passwd=<Password of PI Machine>
     --pi-token=<PI Producer token>
+
     --ocs-tenant=<Tenant id of OCS>
     --ocs-client-id=<Client id of OCS account>
     --ocs-client-secret=<Client Secret of OCS account>
     --ocs-namespace=<OCS namespace where the information are stored>
     --ocs-token=<Token of OCS account>
+
     --kafka-host=<Hostname/IP of Kafka Server>
     --kafka-port=<Kafka Server Port>
     --kafka-topic=<Kafka topic>
-    --kafka-rest-port=<Kafka Rest Port>
+    --kafka-rest-port=<Kafka REST Proxy Port>
 
 Console output
 ++++++++++++++

--- a/tests/system/python/README.rst
+++ b/tests/system/python/README.rst
@@ -97,8 +97,20 @@ custom options ::
     --pi-port=PI_PORT     PI Server Port
     --pi-db=PI_DB         PI Server database
     --pi-admin=PI_ADMIN   PI Server user login
-    --pi-passwd=PI_PASSWD PI Server user login password
+    --pi-passwd=PI_PASSWD
+                        PI Server user login password
     --pi-token=PI_TOKEN   OMF Producer Token
+    --ocs-tenant=OCS_TENANT
+                        Tenant id of OCS
+    --ocs-client-id=OCS_CLIENT_ID
+                        Client id of OCS account
+    --ocs-client-secret=OCS_CLIENT_SECRET
+                        Client Secret of OCS account
+    --ocs-namespace=OCS_NAMESPACE
+                        OCS namespace where the information are stored
+    --ocs-token=OCS_TOKEN
+                        Token of OCS account
+    --ocs-url=OCS_URL     URL of OCS, used in North Instance
     --south-plugin=SOUTH_PLUGIN
                         Name of the South Plugin
     --south-service-name=SOUTH_SERVICE_NAME
@@ -120,6 +132,7 @@ custom options ::
                         Kafka Rest Proxy Port
 
 
+
 Test test_e2e_coap_PI and test_e2e_csv_PI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -131,6 +144,18 @@ The minimum required parameters to run these tests are ::
     --pi-admin=<Login of PI Machine>
     --pi-passwd=<Password of PI Machine>
     --pi-token="<PI Producer token>"
+
+
+Test test_e2e_coap_OCS
+~~~~~~~~~~~~~~~~~~~~~~
+
+The minimum required parameters to run these tests are ::
+
+    --ocs-tenant=<Tenant id of OCS>
+    --ocs-client-id=<Client id of OCS account>
+    --ocs-client-secret=<Client Secret of OCS account>
+    --ocs-namespace=<OCS namespace where the information are stored>
+    --ocs-token=<Token of OCS account>
 
 
 Test test_e2e_kafka
@@ -177,6 +202,15 @@ and running pytest without the test name::
     --pi-admin=<Login of PI Machine>
     --pi-passwd=<Password of PI Machine>
     --pi-token=<PI Producer token>
+    --ocs-tenant=<Tenant id of OCS>
+    --ocs-client-id=<Client id of OCS account>
+    --ocs-client-secret=<Client Secret of OCS account>
+    --ocs-namespace=<OCS namespace where the information are stored>
+    --ocs-token=<Token of OCS account>
+    --kafka-host=<Hostname/IP of Kafka Server>
+    --kafka-port=<Kafka Server Port>
+    --kafka-topic=<Kafka topic>
+    --kafka-rest-port=<Kafka Rest Port>
 
 Console output
 ++++++++++++++

--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -222,9 +222,6 @@ def pytest_addoption(parser):
                      help="OCS namespace where the information are stored")
     parser.addoption("--ocs-token", action="store", default="ocs_north_0001",
                      help="Token of OCS account")
-    parser.addoption("--ocs-url", action="store", default="https://dat-a.osisoft.com/api/tenants/TENANT_ID_PLACEHOLDER/namespaces/NAMESPACE_ID_PLACEHOLDER/omf",
-                     help="URL of OCS, used in North Instance")
-
 
     parser.addoption("--south-plugin", action="store", default="playback",
                      help="Name of the South Plugin")
@@ -331,11 +328,6 @@ def ocs_namespace(request):
 @pytest.fixture
 def ocs_token(request):
     return request.config.getoption("--ocs-token")
-
-
-@pytest.fixture
-def ocs_url(request):
-    return request.config.getoption("--ocs-url")
 
 
 @pytest.fixture

--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -211,6 +211,21 @@ def pytest_addoption(parser):
     parser.addoption("--pi-token", action="store", default="omf_north_0001",
                      help="OMF Producer Token")
 
+    # OCS Config
+    parser.addoption("--ocs-tenant", action="store", default="ocs_tenant_id",
+                     help="Tenant id of OCS")
+    parser.addoption("--ocs-client-id", action="store", default="ocs_client_id",
+                     help="Client id of OCS account")
+    parser.addoption("--ocs-client-secret", action="store", default="ocs_client_secret",
+                     help="Client Secret of OCS account")
+    parser.addoption("--ocs-namespace", action="store", default="ocs_namespace_0001",
+                     help="OCS namespace where the information are stored")
+    parser.addoption("--ocs-token", action="store", default="ocs_north_0001",
+                     help="Token of OCS account")
+    parser.addoption("--ocs-url", action="store", default="https://dat-a.osisoft.com/api/tenants/TENANT_ID_PLACEHOLDER/namespaces/NAMESPACE_ID_PLACEHOLDER/omf",
+                     help="URL of OCS, used in North Instance")
+
+
     parser.addoption("--south-plugin", action="store", default="playback",
                      help="Name of the South Plugin")
     parser.addoption("--south-service-name", action="store", default="play",
@@ -291,6 +306,36 @@ def pi_passwd(request):
 @pytest.fixture
 def pi_token(request):
     return request.config.getoption("--pi-token")
+
+
+@pytest.fixture
+def ocs_tenant(request):
+    return request.config.getoption("--ocs-tenant")
+
+
+@pytest.fixture
+def ocs_client_id(request):
+    return request.config.getoption("--ocs-client-id")
+
+
+@pytest.fixture
+def ocs_client_secret(request):
+    return request.config.getoption("--ocs-client-secret")
+
+
+@pytest.fixture
+def ocs_namespace(request):
+    return request.config.getoption("--ocs-namespace")
+
+
+@pytest.fixture
+def ocs_token(request):
+    return request.config.getoption("--ocs-token")
+
+
+@pytest.fixture
+def ocs_url(request):
+    return request.config.getoption("--ocs-url")
 
 
 @pytest.fixture

--- a/tests/system/python/test_e2e_coap_OCS.py
+++ b/tests/system/python/test_e2e_coap_OCS.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Test system/python/test_e2e_coap_OCS.py
+
+"""
+import os
+import subprocess
+import http.client
+import json
+import time
+import requests
+import pytest
+
+__author__ = "Vaibhav Singhal"
+__copyright__ = "Copyright (c) 2019 Dianomic Systems"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+TEMPLATE_NAME = "template.json"
+SENSOR_VALUE = 20
+
+
+@pytest.fixture
+def prepare_template_reading_from_fogbench():
+    def _prepare_template_reading_from_fogbench(FOGBENCH_TEMPLATE, ASSET_NAME):
+        """ Define the template file for fogbench readings """
+        fogbench_template_path = os.path.join(
+            os.path.expandvars('${FOGLAMP_ROOT}'), 'data/{}'.format(FOGBENCH_TEMPLATE))
+        f = open(fogbench_template_path, "w")
+        f.write(
+            '[{"name": "%s", "sensor_values": '
+            '[{"name": "sensor", "type": "number", "min": %d, "max": %d, "precision": 0}]}]' % (
+                ASSET_NAME, SENSOR_VALUE, SENSOR_VALUE))
+        f.close()
+        return fogbench_template_path
+
+    return _prepare_template_reading_from_fogbench
+
+
+@pytest.fixture
+def start_south_north(reset_and_start_foglamp, start_south, start_north_ocs_server_c,
+                      prepare_template_reading_from_fogbench, remove_data_file,
+                      remove_directories, south_branch, foglamp_url,
+                      ocs_tenant, ocs_client_id, ocs_client_secret, ocs_namespace, ocs_token,
+                      north_plugin="ocs_V2", south_plugin="coap", asset_name="end_to_end_coap"):
+    """ This fixture clone a south repo and starts both south and north instance
+        reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
+        start_south: Fixture that starts any south service with given configuration
+        start_north_ocs_server_c: Fixture that starts OCS north task
+        remove_data_file: Fixture that remove data file created during the tests
+        remove_directories: Fixture that remove directories created during the tests"""
+
+    # fogbench template path for readings
+    fogbench_template_path = prepare_template_reading_from_fogbench(TEMPLATE_NAME, asset_name)
+
+    # Call the start south service fixture
+    start_south(south_plugin, south_branch, foglamp_url, service_name="coap")
+
+    # Call the start north task fixture
+    start_north_ocs_server_c(foglamp_url, north_plugin, ocs_tenant, ocs_client_id, ocs_client_secret,
+                             ocs_namespace, ocs_token)
+
+    # Provide the fixture value
+    yield start_south_north
+
+    # Cleanup code that runs after the caller test is over
+    remove_data_file(fogbench_template_path)
+    remove_directories("/tmp/foglamp-south-{}".format(south_plugin))
+
+
+@pytest.fixture
+def start_north_ocs_v2():
+    def _start_north_ocs_server_c(foglamp_url, north_plugin, ocs_tenant, ocs_client_id, ocs_client_secret,
+                                  ocs_namespace, ocs_token, taskname="North_Readings_to_OCS"):
+        """Start north task"""
+        conn = http.client.HTTPConnection(foglamp_url)
+        data = {"name": taskname,
+                "plugin": "{}".format(north_plugin),
+                "type": "north",
+                "schedule_type": 3,
+                "schedule_day": 0,
+                "schedule_time": 0,
+                "schedule_repeat": 30,
+                "schedule_enabled": "true",
+                "config": {"tenant_id": {"value": ocs_tenant},
+                           "client_id": {"value": ocs_client_id},
+                           "client_secret": {"value": ocs_client_secret},
+                           "namespace": {"value": ocs_namespace},
+                           "producerToken": {"value": ocs_token},
+                           }
+                }
+        conn.request("POST", '/foglamp/scheduled/task', json.dumps(data))
+        r = conn.getresponse()
+        assert 200 == r.status
+        retval = r.read().decode()
+        return retval
+
+    return _start_north_ocs_server_c
+start_north_ocs_server_c = start_north_ocs_v2
+
+
+@pytest.fixture
+def read_data_from_ocs():
+    def _read_data_from_ocs(ocs_client_id, ocs_client_secret, ocs_tenant, ocs_namespace, sensor):
+        """ This method reads data from OCS web api """
+        # TODO: use http.client instead of requests library
+        ocs_type_id = 1
+        ocs_stream = "{}measurement_{}".format(ocs_type_id, sensor)
+        start_timestamp = "2019-01-01T00:00:00.000000Z"
+        values_count = 1
+
+        url = 'https://login.windows.net/{0}/oauth2/token'.format(ocs_tenant)
+
+        # Get the access token first
+        authorization = requests.post(
+            url,
+            data={
+                'grant_type': 'client_credentials',
+                'client_id': ocs_client_id,
+                'client_secret': ocs_client_secret,
+                'resource': 'https://qihomeprod.onmicrosoft.com/ocsapi'
+            }
+        )
+
+        # Generate the header using access token
+        header = {
+            'Authorization': 'bearer %s' % authorization.json()['access_token'],
+            'Content-type': 'application/json',
+            'Accept': 'text/plain'
+        }
+
+        # OCS Cleanup, Delete streams and types if they exist
+        streams_url = "https://dat-a.osisoft.com/api/Tenants/{}/Namespaces/{}/{}" \
+            .format(ocs_tenant, ocs_namespace, "Streams")
+        requests.delete(streams_url, headers=header)
+        types_url = "https://dat-a.osisoft.com/api/Tenants/{}/Namespaces/{}/{}" \
+            .format(ocs_tenant, ocs_namespace, "Types")
+        requests.delete(types_url, headers=header)
+
+        # Get data for stream
+        stream_url = "https://dat-a.osisoft.com/api/Tenants/{}/Namespaces/{}/" \
+                     "Streams/{}/Data/GetRangeValues?startIndex={}&count={}" \
+            .format(ocs_tenant, ocs_namespace, ocs_stream, start_timestamp, values_count)
+
+        response = requests.get(stream_url, headers=header)
+        api_output = response.json()
+        return api_output
+
+    return _read_data_from_ocs
+
+
+class TestE2EOCS:
+    def test_end_to_end(self, start_south_north, read_data_from_ocs, foglamp_url, wait_time, retries,
+                        ocs_client_id, ocs_client_secret, ocs_tenant, ocs_namespace, asset_name="end_to_end_coap"):
+        """ Test that data is inserted in FogLAMP and sent to OCS
+            start_south_north: Fixture that starts FogLAMP with south and north instance
+            read_data_from_ocs: Fixture to read data from OCS
+            Assertions:
+                on endpoint GET /foglamp/asset
+                on endpoint GET /foglamp/asset/<asset_name>
+                data received from OCS is same as data sent"""
+
+        conn = http.client.HTTPConnection(foglamp_url)
+        time.sleep(wait_time)
+        subprocess.run(["cd $FOGLAMP_ROOT/extras/python; python3 -m fogbench -t ../../data/{}; cd -".format(TEMPLATE_NAME)],
+                       shell=True, check=True)
+        time.sleep(wait_time)
+        conn.request("GET", '/foglamp/asset')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        retval = json.loads(r)
+        assert len(retval) == 1
+        assert asset_name == retval[0]["assetCode"]
+        assert 1 == retval[0]["count"]
+
+        conn.request("GET", '/foglamp/asset/{}'.format(asset_name))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        retval = json.loads(r)
+        assert {'sensor': SENSOR_VALUE} == retval[0]["reading"]
+
+        retry_count = 0
+        data_from_ocs = None
+        while (data_from_ocs is None or data_from_ocs == []) and retry_count < retries:
+            data_from_ocs = read_data_from_ocs(ocs_client_id, ocs_client_secret, ocs_tenant, ocs_namespace, asset_name)
+            retry_count += 1
+            time.sleep(wait_time * 2)
+
+        if data_from_ocs is None or retry_count == retries:
+            assert False, "Failed to read data from OCS"
+
+        assert data_from_ocs[-1]['sensor'] == SENSOR_VALUE


### PR DESCRIPTION
To test:
```
FogLAMP/tests/system/python $ pytest test_e2e_coap_OCS.py --ocs-client-id="<ocs-client-id>" --ocs-client-secret="ocs-client-secret" --ocs-tenant="ocs-tenant-id" --ocs-namespace=<ocs-namespace> --ocs-token="ocs-token"
```
Console output:
```
==== test session starts =====
collected 1 item                                                                                                                                                                       

Test system/python/test_e2e_coap_OCS.py Test that data is inserted in FogLAMP and sent to OCS
        start_south_north: Fixture that starts FogLAMP with south and north instance
        read_data_from_ocs: Fixture to read data from OCS
        Assertions:
            on endpoint GET /foglamp/asset
            on endpoint GET /foglamp/asset/<asset_name>
            data received from OCS is same as data sent .                                                                                                                        [100%]

==== 1 passed in 69.49 seconds ====
```

This pull will be rebased when FOGL-2322 is in