### PR TITLE
FOGL-2396 Part A

### DIFF
--- a/tests/system/python/README.rst
+++ b/tests/system/python/README.rst
@@ -72,7 +72,7 @@ Some tests, like ``test_e2e_coap_PI.py`` , requires some information to be provi
 for example the PI-Server or the OCS account that should be used. This information can be passed though command
 like during test execution. For e.g., ::
 
-    /FogLAMP/tests/system/python $ pytest test_e2e_coap_PI.py
+    /FogLAMP/tests/system/python/e2e/ $ pytest test_e2e_coap_PI.py
     --pi-db=<PI DB name>
     --pi-host=<Hostname/IP of PI Server>
     --pi-admin=<Login of PI Machine>
@@ -85,6 +85,7 @@ custom options ::
     $ pytest --help
     ...
     custom options:
+
     --south-branch=SOUTH_BRANCH
                         south branch name
     --north-branch=NORTH_BRANCH
@@ -118,19 +119,16 @@ custom options ::
     --ocs-token=OCS_TOKEN
                         Token of OCS account
 
-    --south-plugin=SOUTH_PLUGIN
-                        Name of the South Plugin
+
     --south-service-name=SOUTH_SERVICE_NAME
                         Name of the South Service
-    --north-plugin=NORTH_PLUGIN
-                        Name of the North Plugin
     --asset-name=ASSET_NAME
                         Name of asset
 
     --wait-time=WAIT_TIME
                         Generic wait time between processes to run
     --retries=RETRIES
-                        Number of tries to make to fetch data from PI web api
+                        Number of tries for polling
 
     --kafka-host=KAFKA_HOST
                         Kafka Server Host Name/IP
@@ -236,7 +234,7 @@ Console displays the docstring of the test that tells a user what test is runnin
     plugins:
     collected 1 item
 
-    Test system/python/test_smoke.py Test that data is inserted in FogLAMP
+    Test system/python/smoke/test_smoke.py Test that data is inserted in FogLAMP
         start_south_coap: Fixture that starts FogLAMP with south coap plugin
         Assertions:
             on endpoint GET /foglamp/asset

--- a/tests/system/python/e2e/test_e2e_coap_OCS.py
+++ b/tests/system/python/e2e/test_e2e_coap_OCS.py
@@ -30,26 +30,25 @@ def prepare_template_reading_from_fogbench():
         """ Define the template file for fogbench readings """
         fogbench_template_path = os.path.join(
             os.path.expandvars('${FOGLAMP_ROOT}'), 'data/{}'.format(FOGBENCH_TEMPLATE))
-        f = open(fogbench_template_path, "w")
-        f.write(
-            '[{"name": "%s", "sensor_values": '
-            '[{"name": "sensor", "type": "number", "min": %d, "max": %d, "precision": 0}]}]' % (
-                ASSET_NAME, SENSOR_VALUE, SENSOR_VALUE))
-        f.close()
+        with open(fogbench_template_path, "w") as f:
+            f.write(
+                '[{"name": "%s", "sensor_values": '
+                '[{"name": "sensor", "type": "number", "min": %d, "max": %d, "precision": 0}]}]' % (
+                    ASSET_NAME, SENSOR_VALUE, SENSOR_VALUE))
         return fogbench_template_path
 
     return _prepare_template_reading_from_fogbench
 
 
 @pytest.fixture
-def start_south_north(reset_and_start_foglamp, start_south, start_north_ocs_server_c,
+def start_south_north(reset_and_start_foglamp, add_south, start_north_ocs_server_c,
                       prepare_template_reading_from_fogbench, remove_data_file,
                       remove_directories, south_branch, foglamp_url,
                       ocs_tenant, ocs_client_id, ocs_client_secret, ocs_namespace, ocs_token,
                       north_plugin="ocs_V2", south_plugin="coap", asset_name="end_to_end_coap"):
     """ This fixture clone a south repo and starts both south and north instance
         reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
-        start_south: Fixture that starts any south service with given configuration
+        add_south: Fixture that add a south service with given configuration
         start_north_ocs_server_c: Fixture that starts OCS north task
         remove_data_file: Fixture that remove data file created during the tests
         remove_directories: Fixture that remove directories created during the tests"""
@@ -57,14 +56,10 @@ def start_south_north(reset_and_start_foglamp, start_south, start_north_ocs_serv
     # fogbench template path for readings
     fogbench_template_path = prepare_template_reading_from_fogbench(TEMPLATE_NAME, asset_name)
 
-    # Call the start south service fixture
-    start_south(south_plugin, south_branch, foglamp_url, service_name="coap")
-
-    # Call the start north task fixture
+    add_south(south_plugin, south_branch, foglamp_url, service_name="coap")
     start_north_ocs_server_c(foglamp_url, north_plugin, ocs_tenant, ocs_client_id, ocs_client_secret,
                              ocs_namespace, ocs_token)
 
-    # Provide the fixture value
     yield start_south_north
 
     # Cleanup code that runs after the caller test is over

--- a/tests/system/python/e2e/test_e2e_coap_OCS.py
+++ b/tests/system/python/e2e/test_e2e_coap_OCS.py
@@ -45,7 +45,7 @@ def start_south_north(reset_and_start_foglamp, add_south, start_north_ocs_server
                       prepare_template_reading_from_fogbench, remove_data_file,
                       remove_directories, south_branch, foglamp_url,
                       ocs_tenant, ocs_client_id, ocs_client_secret, ocs_namespace, ocs_token,
-                      north_plugin="ocs_V2", south_plugin="coap", asset_name="end_to_end_coap"):
+                      asset_name="endToEndCoAP"):
     """ This fixture clone a south repo and starts both south and north instance
         reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
         add_south: Fixture that add a south service with given configuration
@@ -56,8 +56,9 @@ def start_south_north(reset_and_start_foglamp, add_south, start_north_ocs_server
     # fogbench template path for readings
     fogbench_template_path = prepare_template_reading_from_fogbench(TEMPLATE_NAME, asset_name)
 
-    add_south(south_plugin, south_branch, foglamp_url, service_name="coap")
-    start_north_ocs_server_c(foglamp_url, north_plugin, ocs_tenant, ocs_client_id, ocs_client_secret,
+    south_plugin = "coap"
+    add_south(south_plugin, south_branch, foglamp_url, service_name="CoAP #1")
+    start_north_ocs_server_c(foglamp_url, ocs_tenant, ocs_client_id, ocs_client_secret,
                              ocs_namespace, ocs_token)
 
     yield start_south_north
@@ -69,12 +70,12 @@ def start_south_north(reset_and_start_foglamp, add_south, start_north_ocs_server
 
 @pytest.fixture
 def start_north_ocs_v2():
-    def _start_north_ocs_server_c(foglamp_url, north_plugin, ocs_tenant, ocs_client_id, ocs_client_secret,
-                                  ocs_namespace, ocs_token, taskname="North_Readings_to_OCS"):
+    def _start_north_ocs_server_c(foglamp_url, ocs_tenant, ocs_client_id, ocs_client_secret,
+                                  ocs_namespace, ocs_token, taskname="NorthReadingsToOCS"):
         """Start north task"""
         conn = http.client.HTTPConnection(foglamp_url)
         data = {"name": taskname,
-                "plugin": "{}".format(north_plugin),
+                "plugin": "{}".format("ocs_V2"),
                 "type": "north",
                 "schedule_type": 3,
                 "schedule_day": 0,
@@ -95,6 +96,8 @@ def start_north_ocs_v2():
         return retval
 
     return _start_north_ocs_server_c
+
+
 start_north_ocs_server_c = start_north_ocs_v2
 
 
@@ -102,7 +105,9 @@ start_north_ocs_server_c = start_north_ocs_v2
 def read_data_from_ocs():
     def _read_data_from_ocs(ocs_client_id, ocs_client_secret, ocs_tenant, ocs_namespace, sensor):
         """ This method reads data from OCS web api """
+
         # TODO: use http.client instead of requests library
+
         ocs_type_id = 1
         ocs_stream = "{}measurement_{}".format(ocs_type_id, sensor)
         start_timestamp = "2019-01-01T00:00:00.000000Z"
@@ -150,7 +155,7 @@ def read_data_from_ocs():
 
 class TestE2EOCS:
     def test_end_to_end(self, start_south_north, read_data_from_ocs, foglamp_url, wait_time, retries,
-                        ocs_client_id, ocs_client_secret, ocs_tenant, ocs_namespace, asset_name="end_to_end_coap"):
+                        ocs_client_id, ocs_client_secret, ocs_tenant, ocs_namespace, asset_name="endToEndCoAP"):
         """ Test that data is inserted in FogLAMP and sent to OCS
             start_south_north: Fixture that starts FogLAMP with south and north instance
             read_data_from_ocs: Fixture to read data from OCS

--- a/tests/system/python/e2e/test_e2e_coap_PI.py
+++ b/tests/system/python/e2e/test_e2e_coap_PI.py
@@ -4,7 +4,7 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-""" Test system/python/test_smoke.py
+""" Test system/python/test_e2e_coap_PI.py
 
 """
 import os
@@ -21,46 +21,48 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 TEMPLATE_NAME = "template.json"
-SENSOR_VALUE = 10
+SENSOR_VALUE = 20
 
 
 @pytest.fixture
-def start_south_coap(reset_and_start_foglamp, start_south, remove_data_file, remove_directories, south_branch,
-                     foglamp_url, south_plugin="coap", asset_name="smoke"):
+def start_south_north(reset_and_start_foglamp, add_south, start_north_pi_server_c, remove_data_file,
+                      remove_directories, south_branch, foglamp_url, pi_host, pi_port,
+                      north_plugin, pi_token, south_plugin="coap", asset_name="end_to_end_coap"):
     """ This fixture clone a south repo and starts both south and north instance
         reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
-        start_south: Fixture that starts any south service with given configuration
+        add_south: Fixture that adds a south service with given configuration
+        start_north_pi_server_c: Fixture that starts PI north task
         remove_data_file: Fixture that remove data file created during the tests
         remove_directories: Fixture that remove directories created during the tests"""
 
     # Define the template file for fogbench
     fogbench_template_path = os.path.join(
         os.path.expandvars('${FOGLAMP_ROOT}'), 'data/{}'.format(TEMPLATE_NAME))
-    f = open(fogbench_template_path, "w")
-    f.write(
-        '[{"name": "%s", "sensor_values": '
-        '[{"name": "sensor", "type": "number", "min": %d, "max": %d, "precision": 0}]}]' % (
-            asset_name, SENSOR_VALUE, SENSOR_VALUE))
-    f.close()
+    with open(fogbench_template_path, "w") as f:
+        f.write(
+            '[{"name": "%s", "sensor_values": '
+            '[{"name": "sensor", "type": "number", "min": %d, "max": %d, "precision": 0}]}]' % (
+                asset_name, SENSOR_VALUE, SENSOR_VALUE))
 
-    # Call the start south service fixture
-    start_south(south_plugin, south_branch, foglamp_url, service_name="coap")
+    add_south(south_plugin, south_branch, foglamp_url, service_name="coap")
+    start_north_pi_server_c(foglamp_url, pi_host, pi_port, north_plugin, pi_token)
 
-    # Provide the fixture value
-    yield start_south_coap
+    yield start_south_north
 
     # Cleanup code that runs after the caller test is over
     remove_data_file(fogbench_template_path)
     remove_directories("/tmp/foglamp-south-{}".format(south_plugin))
 
 
-def test_smoke(start_south_coap, foglamp_url, wait_time, asset_name="smoke"):
-    """ Test that data is inserted in FogLAMP
-        start_south_coap: Fixture that starts FogLAMP with south coap plugin
+def test_end_to_end(start_south_north, read_data_from_pi, foglamp_url, pi_host, pi_admin, pi_passwd, pi_db,
+                    wait_time, retries, asset_name="end_to_end_coap"):
+    """ Test that data is inserted in FogLAMP and sent to PI
+        start_south_north: Fixture that starts FogLAMP with south and north instance
+        read_data_from_pi: Fixture to read data from PI
         Assertions:
             on endpoint GET /foglamp/asset
             on endpoint GET /foglamp/asset/<asset_name>
-    """
+            data received from PI is same as data sent"""
 
     conn = http.client.HTTPConnection(foglamp_url)
     time.sleep(wait_time)
@@ -69,7 +71,6 @@ def test_smoke(start_south_coap, foglamp_url, wait_time, asset_name="smoke"):
     time.sleep(wait_time)
     conn.request("GET", '/foglamp/asset')
     r = conn.getresponse()
-
     assert 200 == r.status
     r = r.read().decode()
     retval = json.loads(r)
@@ -83,3 +84,15 @@ def test_smoke(start_south_coap, foglamp_url, wait_time, asset_name="smoke"):
     r = r.read().decode()
     retval = json.loads(r)
     assert {'sensor': SENSOR_VALUE} == retval[0]["reading"]
+
+    retry_count = 0
+    data_from_pi = None
+    while (data_from_pi is None or data_from_pi == []) and retry_count < retries:
+        data_from_pi = read_data_from_pi(pi_host, pi_admin, pi_passwd, pi_db, asset_name, {"sensor"})
+        retry_count += 1
+        time.sleep(wait_time*2)
+
+    if data_from_pi is None or retry_count == retries:
+        assert False, "Failed to read data from PI"
+
+    assert data_from_pi["sensor"][-1] == SENSOR_VALUE

--- a/tests/system/python/e2e/test_e2e_coap_PI.py
+++ b/tests/system/python/e2e/test_e2e_coap_PI.py
@@ -26,8 +26,8 @@ SENSOR_VALUE = 20
 
 @pytest.fixture
 def start_south_north(reset_and_start_foglamp, add_south, start_north_pi_server_c, remove_data_file,
-                      remove_directories, south_branch, foglamp_url, pi_host, pi_port,
-                      north_plugin, pi_token, south_plugin="coap", asset_name="end_to_end_coap"):
+                      remove_directories, south_branch, foglamp_url, pi_host, pi_port, pi_token,
+                      asset_name="end_to_end_coap"):
     """ This fixture clone a south repo and starts both south and north instance
         reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
         add_south: Fixture that adds a south service with given configuration
@@ -44,8 +44,9 @@ def start_south_north(reset_and_start_foglamp, add_south, start_north_pi_server_
             '[{"name": "sensor", "type": "number", "min": %d, "max": %d, "precision": 0}]}]' % (
                 asset_name, SENSOR_VALUE, SENSOR_VALUE))
 
+    south_plugin = "coap"
     add_south(south_plugin, south_branch, foglamp_url, service_name="coap")
-    start_north_pi_server_c(foglamp_url, pi_host, pi_port, north_plugin, pi_token)
+    start_north_pi_server_c(foglamp_url, pi_host, pi_port, pi_token)
 
     yield start_south_north
 

--- a/tests/system/python/e2e/test_e2e_csv_PI.py
+++ b/tests/system/python/e2e/test_e2e_csv_PI.py
@@ -26,15 +26,14 @@ CSV_DATA = [{'ivalue': 1, 'fvalue': 1.1, 'svalue': 'abc'},
             {'ivalue': 0, 'fvalue': 0.0, 'svalue': 'def'},
             {'ivalue': -1, 'fvalue': -1.1, 'svalue': 'ghi'}]
 
-# Name of the North Task
-NORTH_TASK_NAME = "North_Readings_to_PI"
+NORTH_TASK_NAME = "NorthReadingsTo_PI"
 
 _data_str = {}
 
 
 @pytest.fixture
 def start_south_north(reset_and_start_foglamp, add_south, start_north_pi_server_c, remove_data_file,
-                      remove_directories, south_branch, foglamp_url, pi_host, pi_port, pi_token, south_plugin="playback",
+                      remove_directories, south_branch, foglamp_url, pi_host, pi_port, pi_token,
                       asset_name="end_to_end_csv"):
     """ This fixture clone a south repo and starts both south and north instance
         reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
@@ -67,6 +66,7 @@ def start_south_north(reset_and_start_foglamp, add_south, start_north_pi_server_
             tmp_list.append(c_data[_head])
         _data_str[_head] = tmp_list
 
+    south_plugin = "playback"
     add_south(south_plugin, south_branch, foglamp_url, config=south_config)
     start_north_pi_server_c(foglamp_url, pi_host, pi_port, pi_token)
 

--- a/tests/system/python/e2e/test_e2e_csv_PI.py
+++ b/tests/system/python/e2e/test_e2e_csv_PI.py
@@ -33,12 +33,12 @@ _data_str = {}
 
 
 @pytest.fixture
-def start_south_north(reset_and_start_foglamp, start_south, start_north_pi_server_c, remove_data_file,
+def start_south_north(reset_and_start_foglamp, add_south, start_north_pi_server_c, remove_data_file,
                       remove_directories, south_branch, foglamp_url, pi_host, pi_port, pi_token, south_plugin="playback",
                       asset_name="end_to_end_csv"):
     """ This fixture clone a south repo and starts both south and north instance
         reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
-        start_south: Fixture that starts any south service with given configuration
+        add_south: Fixture that starts any south service with given configuration
         start_north_pi_server_c: Fixture that starts PI north task
         remove_data_file: Fixture that remove data file created during the tests
         remove_directories: Fixture that remove directories created during the tests"""
@@ -67,13 +67,9 @@ def start_south_north(reset_and_start_foglamp, start_south, start_north_pi_serve
             tmp_list.append(c_data[_head])
         _data_str[_head] = tmp_list
 
-    # Call the start south service fixture
-    start_south(south_plugin, south_branch, foglamp_url, config=south_config)
-
-    # Call the start north task fixture
+    add_south(south_plugin, south_branch, foglamp_url, config=south_config)
     start_north_pi_server_c(foglamp_url, pi_host, pi_port, pi_token)
 
-    # Provide the fixture value
     yield start_south_north
 
     # Cleanup code that runs after the caller test is over

--- a/tests/system/python/e2e/test_e2e_expr_pi.py
+++ b/tests/system/python/e2e/test_e2e_expr_pi.py
@@ -4,8 +4,7 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-""" Test end to end flow with,
-
+""" Test end to end flow with:
         Expression south plugin
         Metadata filter plugin
         PI Server (C) plugin
@@ -31,43 +30,33 @@ SVC_NAME = "Expr #1"
 ASSET_NAME = "Expression"
 
 
-class TestE2E_ExprPi:
+class TestE2eExprPi:
 
     @pytest.fixture
-    def start_south_north(self, reset_and_start_foglamp, start_south, remove_directories,
+    def start_south_north(self, reset_and_start_foglamp, add_south, enable_schedule, remove_directories,
                           south_branch, foglamp_url, add_filter, filter_branch, filter_name,
                           start_north_pi_server_c, pi_host, pi_port, pi_token):
         """ This fixture clone a south and north repo and starts both south and north instance
 
             reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
-            start_south: Fixture that add a south service with given configuration with enabled or disabled mode
+            add_south: Fixture that adds a south service with given configuration with enabled or disabled mode
             remove_directories: Fixture that remove directories created during the tests
         """
 
         cfg = {"expression": {"value": "tan(x)"}, "minimumX": {"value": "45"}, "maximumX": {"value": "45"},
                "stepX": {"value": "0"}}
 
-        # TODO: start_south fixture should be renamed to add_south
-        start_south(SOUTH_PLUGIN, south_branch, foglamp_url, service_name=SVC_NAME, config=cfg,
-                    plugin_lang=SOUTH_PLUGIN_LANGUAGE, start_service=False)
+        add_south(SOUTH_PLUGIN, south_branch, foglamp_url, service_name=SVC_NAME, config=cfg,
+                  plugin_lang=SOUTH_PLUGIN_LANGUAGE, start_service=False)
 
         filter_cfg = {"enable": "true"}
         filter_plugin = "metadata"
         add_filter(filter_plugin, filter_branch, filter_name, filter_cfg, foglamp_url, SVC_NAME)
 
-        # enable schedule to start service (TODO: move to conftest fixture)
-        def enable_sch(sch_name):
-            conn = http.client.HTTPConnection(foglamp_url)
-            conn.request("PUT", '/foglamp/schedule/enable', json.dumps({"schedule_name": sch_name}))
-            r = conn.getresponse()
-            assert 200 == r.status
-            r = r.read().decode()
-            jdoc = json.loads(r)
-            assert "scheduleId" in jdoc
+        enable_schedule(foglamp_url, SVC_NAME)
 
-        enable_sch(SVC_NAME)
-
-        # FIXME: We need to make north PI sending process to handle the case, to send and retrieve applied filter data
+        # FIXME: FOGL-2417
+        # We need to make north PI sending process to handle the case, to send and retrieve applied filter data
         # in running service, so that we don't need to add south service in disabled mode And enable after applying
         # filter pipeline
         start_north_pi_server_c(foglamp_url, pi_host, pi_port, pi_token)
@@ -77,30 +66,21 @@ class TestE2E_ExprPi:
         remove_directories("/tmp/foglamp-south-{}".format(SOUTH_PLUGIN.lower()))
         remove_directories("/tmp/foglamp-filter-{}".format(filter_plugin))
 
-    def test_end_to_end(self, start_south_north, foglamp_url, read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db,
-                    wait_time, retries):
-        """ Test that data is inserted in FogLAMP and sent to PI
-            start_south_north: Fixture that starts FogLAMP with south and north instance
+    def test_end_to_end(self, start_south_north, disable_schedule, foglamp_url, read_data_from_pi, pi_host, pi_admin,
+                        pi_passwd, pi_db, wait_time, retries):
+        """ Test that data is inserted in FogLAMP using expression south plugin & metadata filter, and sent to PI
+            start_south_north: Fixture that starts FogLAMP with south service, add filter and north instance
             Assertions:
                 on endpoint GET /foglamp/asset
-                on endpoint GET /foglamp/asset/<asset_name>
+                on endpoint GET /foglamp/asset/<asset_name> with applied data processing filter value
                 data received from PI is same as data sent"""
 
         time.sleep(wait_time)
         conn = http.client.HTTPConnection(foglamp_url)
         self._verify_ingest(conn)
 
-        # disable schedule to stop service to send more data (TODO: move to conftest fixture)
-        def disable_sch(sch_name):
-            conn = http.client.HTTPConnection(foglamp_url)
-            conn.request("PUT", '/foglamp/schedule/disable', json.dumps({"schedule_name": sch_name}))
-            r = conn.getresponse()
-            assert 200 == r.status
-            r = r.read().decode()
-            jdoc = json.loads(r)
-            assert jdoc["status"]
-
-        disable_sch(SVC_NAME)
+        # disable schedule to stop the service and sending data
+        disable_schedule(foglamp_url, SVC_NAME)
 
         self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries)
 

--- a/tests/system/python/e2e/test_e2e_kafka.py
+++ b/tests/system/python/e2e/test_e2e_kafka.py
@@ -38,12 +38,12 @@ class TestE2EKafka:
 
         fogbench_template_path = os.path.join(
             os.path.expandvars('${FOGLAMP_ROOT}'), 'data/{}'.format(FOGBENCH_TEMPLATE))
-        f = open(fogbench_template_path, "w")
-        f.write(
-            '[{"name": "%s", "sensor_values": '
-            '[{"name": "sensor", "type": "number", "min": %d, "max": %d, "precision": 0}]}]' % (
-                ASSET_NAME, SENSOR_VALUE, SENSOR_VALUE))
-        f.close()
+        with open(fogbench_template_path, "w") as f:
+            f.write(
+                '[{"name": "%s", "sensor_values": '
+                '[{"name": "sensor", "type": "number", "min": %d, "max": %d, "precision": 0}]}]' % (
+                    ASSET_NAME, SENSOR_VALUE, SENSOR_VALUE))
+
         return fogbench_template_path
 
     def _configure_and_start_north_kafka(self, north_branch, foglamp_url, host, port, topic, task_name="NorthReadingsTo{}"
@@ -77,17 +77,17 @@ class TestE2EKafka:
         assert task_name == val['name']
 
     @pytest.fixture
-    def start_south_north(self, reset_and_start_foglamp, start_south, remove_data_file,
+    def start_south_north(self, reset_and_start_foglamp, add_south, remove_data_file,
                           remove_directories, south_branch, foglamp_url, north_branch, kafka_host, kafka_port, kafka_topic):
         """ This fixture clone a south and north repo and starts both south and north instance
             reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
-            start_south: Fixture that starts any south service with given configuration
+            add_south: Fixture that starts any south service with given configuration
             remove_data_file: Fixture that remove data file created during the tests
             remove_directories: Fixture that remove directories created during the tests """
 
         fogbench_template_path = self._prepare_template_reading_from_fogbench()
 
-        start_south(SOUTH_PLUGIN_NAME, south_branch, foglamp_url, service_name=SOUTH_PLUGIN_NAME)
+        add_south(SOUTH_PLUGIN_NAME, south_branch, foglamp_url, service_name=SOUTH_PLUGIN_NAME)
 
         self._configure_and_start_north_kafka(north_branch, foglamp_url, kafka_host, kafka_port, kafka_topic)
 

--- a/tests/system/python/scripts/install_c_plugin
+++ b/tests/system/python/scripts/install_c_plugin
@@ -36,6 +36,9 @@ clone_repo () {
    git clone -b ${BRANCH_NAME} --single-branch https://github.com/foglamp/${REPO_NAME}.git /tmp/${REPO_NAME}
 }
 
+req_file=$(find . -name requirement*.sh)
+[[ ! -z "${req_file}" ]] && ./${req_file} || echo "No external dependency needed for ${PLUGIN_NAME} plugin."
+
 install_binary_file () {
    mkdir -p /tmp/${REPO_NAME}/build; cd /tmp/${REPO_NAME}/build; cmake -DFOGLAMP_INSTALL=${FOGLAMP_ROOT} ..; make -j4 && make install; cd -
 }

--- a/tests/system/python/smoke/test_smoke.py
+++ b/tests/system/python/smoke/test_smoke.py
@@ -4,7 +4,7 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-""" Test system/python/test_e2e_coap_PI.py
+""" Test system/python/test_smoke.py
 
 """
 import os
@@ -21,53 +21,43 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 TEMPLATE_NAME = "template.json"
-SENSOR_VALUE = 20
+SENSOR_VALUE = 10
 
 
 @pytest.fixture
-def start_south_north(reset_and_start_foglamp, start_south, start_north_pi_server_c, remove_data_file,
-                      remove_directories, south_branch, foglamp_url, pi_host, pi_port,
-                      north_plugin, pi_token, south_plugin="coap", asset_name="end_to_end_coap"):
+def start_south_coap(reset_and_start_foglamp, add_south, remove_data_file, remove_directories, south_branch,
+                     foglamp_url, south_plugin="coap", asset_name="smoke"):
     """ This fixture clone a south repo and starts both south and north instance
         reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
-        start_south: Fixture that starts any south service with given configuration
-        start_north_pi_server_c: Fixture that starts PI north task
+        add_south: Fixture that adds a south service with given configuration
         remove_data_file: Fixture that remove data file created during the tests
         remove_directories: Fixture that remove directories created during the tests"""
 
     # Define the template file for fogbench
     fogbench_template_path = os.path.join(
         os.path.expandvars('${FOGLAMP_ROOT}'), 'data/{}'.format(TEMPLATE_NAME))
-    f = open(fogbench_template_path, "w")
-    f.write(
-        '[{"name": "%s", "sensor_values": '
-        '[{"name": "sensor", "type": "number", "min": %d, "max": %d, "precision": 0}]}]' % (
-            asset_name, SENSOR_VALUE, SENSOR_VALUE))
-    f.close()
+    with open(fogbench_template_path, "w") as f:
+        f.write(
+            '[{"name": "%s", "sensor_values": '
+            '[{"name": "sensor", "type": "number", "min": %d, "max": %d, "precision": 0}]}]' % (
+                asset_name, SENSOR_VALUE, SENSOR_VALUE))
 
-    # Call the start south service fixture
-    start_south(south_plugin, south_branch, foglamp_url, service_name="coap")
+    add_south(south_plugin, south_branch, foglamp_url, service_name="coap")
 
-    # Call the start north task fixture
-    start_north_pi_server_c(foglamp_url, pi_host, pi_port, north_plugin, pi_token)
-
-    # Provide the fixture value
-    yield start_south_north
+    yield start_south_coap
 
     # Cleanup code that runs after the caller test is over
     remove_data_file(fogbench_template_path)
     remove_directories("/tmp/foglamp-south-{}".format(south_plugin))
 
 
-def test_end_to_end(start_south_north, read_data_from_pi, foglamp_url, pi_host, pi_admin, pi_passwd, pi_db,
-                    wait_time, retries, asset_name="end_to_end_coap"):
-    """ Test that data is inserted in FogLAMP and sent to PI
-        start_south_north: Fixture that starts FogLAMP with south and north instance
-        read_data_from_pi: Fixture to read data from PI
+def test_smoke(start_south_coap, foglamp_url, wait_time, asset_name="smoke"):
+    """ Test that data is inserted in FogLAMP
+        start_south_coap: Fixture that starts FogLAMP with south coap plugin
         Assertions:
             on endpoint GET /foglamp/asset
             on endpoint GET /foglamp/asset/<asset_name>
-            data received from PI is same as data sent"""
+    """
 
     conn = http.client.HTTPConnection(foglamp_url)
     time.sleep(wait_time)
@@ -76,6 +66,7 @@ def test_end_to_end(start_south_north, read_data_from_pi, foglamp_url, pi_host, 
     time.sleep(wait_time)
     conn.request("GET", '/foglamp/asset')
     r = conn.getresponse()
+
     assert 200 == r.status
     r = r.read().decode()
     retval = json.loads(r)
@@ -89,15 +80,3 @@ def test_end_to_end(start_south_north, read_data_from_pi, foglamp_url, pi_host, 
     r = r.read().decode()
     retval = json.loads(r)
     assert {'sensor': SENSOR_VALUE} == retval[0]["reading"]
-
-    retry_count = 0
-    data_from_pi = None
-    while (data_from_pi is None or data_from_pi == []) and retry_count < retries:
-        data_from_pi = read_data_from_pi(pi_host, pi_admin, pi_passwd, pi_db, asset_name, {"sensor"})
-        retry_count += 1
-        time.sleep(wait_time*2)
-
-    if data_from_pi is None or retry_count == retries:
-        assert False, "Failed to read data from PI"
-
-    assert data_from_pi["sensor"][-1] == SENSOR_VALUE


### PR DESCRIPTION
added directories for better organization of tests, removed plugin args from argparser as those are specific to tests, other fixes for pending TODO and FIXME

```
$ tree
.
|-- README.rst
|-- api
|-- conftest.py
|-- e2e
|   |-- test_e2e_coap_OCS.py
|   |-- test_e2e_coap_PI.py
|   |-- test_e2e_csv_PI.py
|   |-- test_e2e_expr_pi.py
|   `-- test_e2e_kafka.py
|-- pytest.ini
|-- scripts
|   |-- install_c_plugin
|   `-- install_python_plugin
`-- smoke
    `-- test_smoke.py

```