### PR TITLE
FOGL-2451 Make no data to purge a log message and not an error return

### DIFF
--- a/C/plugins/storage/sqlite/connection.cpp
+++ b/C/plugins/storage/sqlite/connection.cpp
@@ -2202,8 +2202,8 @@ int blocks = 0;
 
 	result = "{ \"removed\" : 0, ";
 	result += " \"unsentPurged\" : 0, ";
-	result += " \"unsentRetained\", 0, ";
-    	result += " \"readings\" 0 }";
+	result += " \"unsentRetained\" : 0, ";
+    	result += " \"readings\" : 0 }";
 
 
 	logger->info("Purge starting...");
@@ -2292,7 +2292,7 @@ int blocks = 0;
 
 		if (rowidLimit == 0)
 		{
- 			raiseError("purge", "No data to purge");
+ 			logger->info("No data to purge");
 			return 0;
 		}
 


### PR DESCRIPTION
from the service

Note, the error message about lack of support for purge by size remains as this is an error from the plugin and is the only way this information can be communicated back to the caller.