### PR TITLE
FOGL-1121 - FoglampProcess should properly handle improper argument values and throw the correct exceptions

### DIFF
--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -9,6 +9,7 @@
 from abc import ABC, abstractmethod
 import argparse
 import time
+import re
 from foglamp.common.storage_client.storage_client import StorageClientAsync, ReadingsStorageClientAsync
 from foglamp.common import logger
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient
@@ -84,6 +85,12 @@ class FoglampProcess(ABC):
             self._name = getattr(namespace, 'name')
             self._core_management_host = getattr(namespace, 'address')
             self._core_management_port = getattr(namespace, 'port')
+            if (re.match(
+                    "(^[2][0-5][0-5]|^[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})$",
+                    self._core_management_host) is None):
+                raise ArgumentParserError("Invalid Host: {}".format(self._core_management_host))
+            if self._core_management_port < 1 or self._core_management_port > 65535:
+                raise ArgumentParserError("Invalid Port: {}".format(self._core_management_port))
         except ArgumentParserError as ex:
             _logger.error("Arg parser error: %s", str(ex))
             raise

--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -85,10 +85,11 @@ class FoglampProcess(ABC):
             self._name = getattr(namespace, 'name')
             self._core_management_host = getattr(namespace, 'address')
             self._core_management_port = getattr(namespace, 'port')
-            if (re.match(
-                    "(^[2][0-5][0-5]|^[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})$",
-                    self._core_management_host) is None):
-                raise ArgumentParserError("Invalid Host: {}".format(self._core_management_host))
+            if self._core_management_host.strip() != 'localhost':
+                if (re.match(
+                        "(^[2][0-5][0-5]|^[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})$",
+                        self._core_management_host) is None):
+                    raise ArgumentParserError("Invalid Host: {}".format(self._core_management_host))
             if self._core_management_port < 1 or self._core_management_port > 65535:
                 raise ArgumentParserError("Invalid Port: {}".format(self._core_management_port))
         except ArgumentParserError as ex:

--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -28,8 +28,8 @@ class ArgumentParserError(Exception):
         self.message = message
 
     def __str__(self):
-        format = '%(message)s'
-        return format % dict(message=self.message)
+        fmt = '%(message)s'
+        return fmt % dict(message=self.message)
 
 
 class SilentArgParse(argparse.ArgumentParser):

--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -85,13 +85,15 @@ class FoglampProcess(ABC):
             self._name = getattr(namespace, 'name')
             self._core_management_host = getattr(namespace, 'address')
             self._core_management_port = getattr(namespace, 'port')
-            if self._core_management_host.strip() != 'localhost':
-                if (re.match(
-                        "(^[2][0-5][0-5]|^[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})\.([0-2][0-5][0-5]|[1]{0,1}[0-9]{1,2})$",
-                        self._core_management_host) is None):
-                    raise ArgumentParserError("Invalid Host: {}".format(self._core_management_host))
             if self._core_management_port < 1 or self._core_management_port > 65535:
                 raise ArgumentParserError("Invalid Port: {}".format(self._core_management_port))
+            for item in args:
+                if item.startswith('--'):
+                    kv = item.split('=')
+                    if len(kv) == 2:
+                        if len(kv[1].strip()) == 0:
+                            raise ArgumentParserError("Invalid value {} for optional arg {}".format(kv[1], kv[0]))
+
         except ArgumentParserError as ex:
             _logger.error("Arg parser error: %s", str(ex))
             raise

--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -18,25 +18,24 @@ __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
-
 _logger = logger.setup(__name__)
 
 
 class ArgumentParserError(Exception):
     """ Override default exception to not terminate application """
-    pass
+
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        format = '%(message)s'
+        return format % dict(message=self.message)
 
 
 class SilentArgParse(argparse.ArgumentParser):
-
     def error(self, message):
         """ Override default error functionality to not terminate application """
         raise ArgumentParserError(message)
-
-    def silent_arg_parse(self, argument_name):
-        self.add_argument(argument_name)
-        parser_result = self.parse_known_args()
-        return list(vars(parser_result[0]).values())[0]
 
 
 class FoglampProcess(ABC):
@@ -73,25 +72,27 @@ class FoglampProcess(ABC):
         --port [core microservice management port]
         --name [process name]
         """
-        
+
         self._start_time = time.time()
 
-        try:    
-            self._core_management_host = self.get_arg_value("--address")
-            self._core_management_port = self.get_arg_value("--port")
-            self._name = self.get_arg_value("--name")
-        except ArgumentParserError:
+        try:
+            parser = SilentArgParse()
+            parser.add_argument("--name", required=True)
+            parser.add_argument("--address", required=True)
+            parser.add_argument("--port", required=True, type=int)
+            namespace, args = parser.parse_known_args()
+            self._name = getattr(namespace, 'name')
+            self._core_management_host = getattr(namespace, 'address')
+            self._core_management_port = getattr(namespace, 'port')
+        except ArgumentParserError as ex:
+            _logger.error("Arg parser error: %s", str(ex))
             raise
-        if self._core_management_host is None:
-            raise ValueError("--address is not specified")
-        elif self._core_management_port is None:
-            raise ValueError("--port is not specified")
-        elif self._name is None:
-            raise ValueError("--name is not specified")
 
-        self._core_microservice_management_client = MicroserviceManagementClient(self._core_management_host,self._core_management_port)
+        self._core_microservice_management_client = MicroserviceManagementClient(self._core_management_host,
+                                                                                 self._core_management_port)
 
-        self._readings_storage_async = ReadingsStorageClientAsync(self._core_management_host, self._core_management_port)
+        self._readings_storage_async = ReadingsStorageClientAsync(self._core_management_host,
+                                                                  self._core_management_port)
         self._storage_async = StorageClientAsync(self._core_management_host, self._core_management_port)
 
     # pure virtual method run() to be implemented by child class
@@ -99,25 +100,6 @@ class FoglampProcess(ABC):
     def run(self):
         pass
 
-    def get_arg_value(self, argument_name):
-        """ Parses command line arguments for a single argument of name argument_name. Returns the value of the argument specified or None if argument was not specified.
-
-        Keyword Arguments:
-        argument_name -- name of command line argument to retrieve value for
-    
-        Return Values:
-            Argument value (as a string)
-            None (if argument was not passed)
-    
-            Side Effects:
-            None
-    
-            Known Exceptions:
-            ArgumentParserError
-        """
-        parser = SilentArgParse()
-        return parser.silent_arg_parse(argument_name)
-        
     def get_services_from_core(self, name=None, _type=None):
         return self._core_microservice_management_client.get_services(name, _type)
 

--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -84,7 +84,8 @@ class FoglampProcess(ABC):
             self._name = getattr(namespace, 'name')
             self._core_management_host = getattr(namespace, 'address')
             self._core_management_port = getattr(namespace, 'port')
-            if self._core_management_port < 1 or self._core_management_port > 65535:
+            r = range(1, 65536)
+            if self._core_management_port not in r:
                 raise ArgumentParserError("Invalid Port: {}".format(self._core_management_port))
             for item in args:
                 if item.startswith('--'):

--- a/python/foglamp/common/process.py
+++ b/python/foglamp/common/process.py
@@ -9,7 +9,6 @@
 from abc import ABC, abstractmethod
 import argparse
 import time
-import re
 from foglamp.common.storage_client.storage_client import StorageClientAsync, ReadingsStorageClientAsync
 from foglamp.common import logger
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient

--- a/tests/unit/python/foglamp/common/test_process.py
+++ b/tests/unit/python/foglamp/common/test_process.py
@@ -6,7 +6,7 @@ import sys
 from unittest.mock import patch
 
 from foglamp.common.storage_client.storage_client import ReadingsStorageClientAsync, StorageClientAsync
-from foglamp.common.process import FoglampProcess, SilentArgParse, ArgumentParserError
+from foglamp.common.process import FoglampProcess, ArgumentParserError
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient
 
 

--- a/tests/unit/python/foglamp/common/test_process.py
+++ b/tests/unit/python/foglamp/common/test_process.py
@@ -31,7 +31,7 @@ class TestFoglampProcess:
     @pytest.mark.parametrize('argslist',
                              [(['pytest']),
                               (['pytest, ''--address', 'corehost']),
-                              (['pytest', '--address', 'corehost', '--port', 0])
+                              (['pytest', '--address', 'corehost', '--port', '32333'])
                               ])
     def test_constructor_missing_args(self, argslist):
         class FoglampProcessImp(FoglampProcess):
@@ -47,16 +47,16 @@ class TestFoglampProcess:
         class FoglampProcessImp(FoglampProcess):
             def run(self):
                 pass
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
                         fp = FoglampProcessImp()
-        mmc_patch.assert_called_once_with('corehost', 0)
-        rsc_async_patch.assert_called_once_with('corehost', 0)
-        sc_async_patch.assert_called_once_with('corehost', 0)
+        mmc_patch.assert_called_once_with('corehost', 32333)
+        rsc_async_patch.assert_called_once_with('corehost', 32333)
+        sc_async_patch.assert_called_once_with('corehost', 32333)
         assert fp._core_management_host is 'corehost'
-        assert fp._core_management_port is 0
+        assert fp._core_management_port == 32333
         assert fp._name is 'sname'
         assert hasattr(fp, '_core_microservice_management_client')
         assert hasattr(fp, '_readings_storage_async')
@@ -67,7 +67,7 @@ class TestFoglampProcess:
         class FoglampProcessImp(FoglampProcess):
             def run(self):
                 pass
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(MicroserviceManagementClient, 'get_services', return_value=None) as get_patch:
                     with patch.object(ReadingsStorageClientAsync, '__init__',
@@ -81,7 +81,7 @@ class TestFoglampProcess:
         class FoglampProcessImp(FoglampProcess):
             def run(self):
                 pass
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(MicroserviceManagementClient, 'register_service', return_value=None) as register_patch:
                     with patch.object(ReadingsStorageClientAsync, '__init__',
@@ -95,7 +95,7 @@ class TestFoglampProcess:
         class FoglampProcessImp(FoglampProcess):
             def run(self):
                 pass
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(MicroserviceManagementClient, 'unregister_service', return_value=None) as unregister_patch:
                     with patch.object(ReadingsStorageClientAsync, '__init__',

--- a/tests/unit/python/foglamp/common/test_process.py
+++ b/tests/unit/python/foglamp/common/test_process.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+import sys
 
 from unittest.mock import patch
 
@@ -28,15 +29,15 @@ class TestFoglampProcess:
             fp = FoglampProcessImp()
 
     @pytest.mark.parametrize('argslist',
-                             [([ArgumentParserError()]),
-                              (['corehost', ArgumentParserError()]),
-                              (['corehost', 0, ArgumentParserError()])
+                             [(['pytest']),
+                              (['pytest, ''--address', 'corehost']),
+                              (['pytest', '--address', 'corehost', '--port', 0])
                               ])
     def test_constructor_missing_args(self, argslist):
         class FoglampProcessImp(FoglampProcess):
             def run(self):
                 pass
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=argslist):
+        with patch.object(sys, 'argv', argslist):
             with pytest.raises(ArgumentParserError) as excinfo:
                 fp = FoglampProcessImp()
         assert '' in str(
@@ -46,7 +47,7 @@ class TestFoglampProcess:
         class FoglampProcessImp(FoglampProcess):
             def run(self):
                 pass
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -66,7 +67,7 @@ class TestFoglampProcess:
         class FoglampProcessImp(FoglampProcess):
             def run(self):
                 pass
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(MicroserviceManagementClient, 'get_services', return_value=None) as get_patch:
                     with patch.object(ReadingsStorageClientAsync, '__init__',
@@ -80,7 +81,7 @@ class TestFoglampProcess:
         class FoglampProcessImp(FoglampProcess):
             def run(self):
                 pass
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(MicroserviceManagementClient, 'register_service', return_value=None) as register_patch:
                     with patch.object(ReadingsStorageClientAsync, '__init__',
@@ -94,7 +95,7 @@ class TestFoglampProcess:
         class FoglampProcessImp(FoglampProcess):
             def run(self):
                 pass
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(MicroserviceManagementClient, 'unregister_service', return_value=None) as unregister_patch:
                     with patch.object(ReadingsStorageClientAsync, '__init__',

--- a/tests/unit/python/foglamp/services/common/test_microservice.py
+++ b/tests/unit/python/foglamp/services/common/test_microservice.py
@@ -92,7 +92,7 @@ class TestFoglampMicroservice:
                 pass
 
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
-            with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+            with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                     with patch.object(MicroserviceManagementClient, 'create_configuration_category', return_value=None):
                         with patch.object(MicroserviceManagementClient, 'create_child_category',
@@ -109,7 +109,7 @@ class TestFoglampMicroservice:
                                                         fm = FoglampMicroserviceImp()
         # from FoglampProcess
         assert fm._core_management_host is 'corehost'
-        assert fm._core_management_port is 0
+        assert fm._core_management_port == 32333
         assert fm._name is 'sname'
         assert hasattr(fm, '_core_microservice_management_client')
         assert hasattr(fm, '_readings_storage_async')
@@ -146,7 +146,7 @@ class TestFoglampMicroservice:
                 pass
 
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
-            with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+            with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                     with patch.object(MicroserviceManagementClient, 'create_configuration_category', return_value=None):
                         with patch.object(MicroserviceManagementClient, 'create_child_category',
@@ -184,7 +184,7 @@ class TestFoglampMicroservice:
                 pass
 
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
-            with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+            with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                     with patch.object(MicroserviceManagementClient, 'create_configuration_category', return_value=None):
                         with patch.object(MicroserviceManagementClient, 'create_child_category',

--- a/tests/unit/python/foglamp/services/common/test_microservice.py
+++ b/tests/unit/python/foglamp/services/common/test_microservice.py
@@ -2,7 +2,7 @@
 
 import pytest
 import time
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from aiohttp import web
 import asyncio
 import sys

--- a/tests/unit/python/foglamp/services/common/test_microservice.py
+++ b/tests/unit/python/foglamp/services/common/test_microservice.py
@@ -5,6 +5,7 @@ import time
 from unittest.mock import patch, MagicMock
 from aiohttp import web
 import asyncio
+import sys
 from foglamp.common.storage_client.storage_client import ReadingsStorageClientAsync, StorageClientAsync
 from foglamp.common.process import FoglampProcess, SilentArgParse, ArgumentParserError
 from foglamp.services.common.microservice import FoglampMicroservice, _logger
@@ -91,7 +92,7 @@ class TestFoglampMicroservice:
                 pass
 
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
-            with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+            with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                     with patch.object(MicroserviceManagementClient, 'create_configuration_category', return_value=None):
                         with patch.object(MicroserviceManagementClient, 'create_child_category',
@@ -145,7 +146,7 @@ class TestFoglampMicroservice:
                 pass
 
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
-            with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+            with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                     with patch.object(MicroserviceManagementClient, 'create_configuration_category', return_value=None):
                         with patch.object(MicroserviceManagementClient, 'create_child_category',
@@ -183,7 +184,7 @@ class TestFoglampMicroservice:
                 pass
 
         with patch.object(asyncio, 'get_event_loop', return_value=loop):
-            with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+            with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
                 with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                     with patch.object(MicroserviceManagementClient, 'create_configuration_category', return_value=None):
                         with patch.object(MicroserviceManagementClient, 'create_child_category',

--- a/tests/unit/python/foglamp/services/common/test_microservice.py
+++ b/tests/unit/python/foglamp/services/common/test_microservice.py
@@ -7,7 +7,7 @@ from aiohttp import web
 import asyncio
 import sys
 from foglamp.common.storage_client.storage_client import ReadingsStorageClientAsync, StorageClientAsync
-from foglamp.common.process import FoglampProcess, SilentArgParse, ArgumentParserError
+from foglamp.common.process import FoglampProcess
 from foglamp.services.common.microservice import FoglampMicroservice, _logger
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient
 

--- a/tests/unit/python/foglamp/tasks/north/test_sending_process.py
+++ b/tests/unit/python/foglamp/tasks/north/test_sending_process.py
@@ -55,7 +55,7 @@ async def mock_audit_failure():
 def fixture_sp(event_loop):
     """"  Configures the sending process instance for the tests """
 
-    with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+    with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
         with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
             with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                 with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -367,7 +367,7 @@ class TestSendingProcess:
     async def test_is_north_valid(self,  plugin_file, plugin_type, plugin_name, expected_result, event_loop):
         """Tests the possible cases of the function is_north_valid """
 
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -392,7 +392,7 @@ class TestSendingProcess:
             return True
 
         # Checks the Readings handling
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -472,7 +472,7 @@ class TestSendingProcess:
             return p_rows
 
         # Checks the Readings handling
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -558,7 +558,7 @@ class TestSendingProcess:
         """ Unit test for - _transform_in_memory_data_readings"""
 
         # Checks the Readings handling
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -729,7 +729,7 @@ class TestSendingProcess:
         """Test _load_data_into_memory handling and transformations for the statistics """
 
         # Checks the Statistics handling
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -822,7 +822,7 @@ class TestSendingProcess:
         """ Unit test for - _transform_in_memory_data_statistics"""
 
         # Checks the Statistics handling
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -860,7 +860,7 @@ class TestSendingProcess:
             rows = {"rows": [{"last_object": 10}, {"last_object": 11}]}
             return rows
 
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -927,7 +927,7 @@ class TestSendingProcess:
 
             return True
 
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1101,7 +1101,7 @@ class TestSendingProcess:
             return p_rows[idx]
 
         # GIVEN
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1289,7 +1289,7 @@ class TestSendingProcess:
             return p_rows[idx]
 
         # GIVEN
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1433,7 +1433,7 @@ class TestSendingProcess:
             return p_rows[idx]
 
         # GIVEN
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1602,7 +1602,7 @@ class TestSendingProcess:
             return p_rows[idx]
 
         # GIVEN
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1786,7 +1786,7 @@ class TestSendingProcess:
             return p_send_result[x]["data_sent"], p_send_result[x]["new_last_object_id"], p_send_result[x]["num_sent"]
 
         # GIVEN
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1968,7 +1968,7 @@ class TestSendingProcess:
             return p_send_result[x]["data_sent"], p_send_result[x]["new_last_object_id"], p_send_result[x]["num_sent"]
 
         # GIVEN
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2204,7 +2204,7 @@ class TestSendingProcess:
             """ Dummy async task """
             return True
 
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2230,7 +2230,7 @@ class TestSendingProcess:
     async def test_standard_plugins(self, plugin_file, plugin_type, plugin_name, event_loop):
         """Tests if the standard plugins are available and loadable and if they have the required methods """
 
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2290,7 +2290,7 @@ class TestSendingProcess:
                                          expected_config):
         """ Unit tests - _retrieve_configuration - tests the transformations """
 
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2313,7 +2313,7 @@ class TestSendingProcess:
     async def test_start_stream_not_valid(self, event_loop):
         """ Unit tests - _start - stream_id is not valid """
 
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2338,7 +2338,7 @@ class TestSendingProcess:
         async def mock_master_stat_key():
             return 'Readings Sent'
 
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2374,7 +2374,7 @@ class TestSendingProcess:
         async def mock_master_stat_key():
             return 'Readings Sent'
 
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2414,7 +2414,7 @@ class TestSendingProcess:
         async def mock_master_stat_key():
             return 'Readings Sent'
 
-        with patch.object(SilentArgParse, 'silent_arg_parse', side_effect=['corehost', 0, 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:

--- a/tests/unit/python/foglamp/tasks/north/test_sending_process.py
+++ b/tests/unit/python/foglamp/tasks/north/test_sending_process.py
@@ -18,7 +18,6 @@ import foglamp.tasks.north.sending_process as sp_module
 from foglamp.common.audit_logger import AuditLogger
 from foglamp.common.storage_client.storage_client import StorageClientAsync, ReadingsStorageClientAsync
 from foglamp.tasks.north.sending_process import SendingProcess
-from foglamp.common.process import FoglampProcess, SilentArgParse, ArgumentParserError
 from foglamp.common.microservice_management_client.microservice_management_client import MicroserviceManagementClient
 
 __author__ = "Stefano Simonelli"

--- a/tests/unit/python/foglamp/tasks/north/test_sending_process.py
+++ b/tests/unit/python/foglamp/tasks/north/test_sending_process.py
@@ -55,7 +55,7 @@ async def mock_audit_failure():
 def fixture_sp(event_loop):
     """"  Configures the sending process instance for the tests """
 
-    with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+    with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
         with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
             with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                 with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -77,7 +77,7 @@ def fixture_sp(event_loop):
 
     sp._task_fetch_data_sem = asyncio.Semaphore(0)
     sp._task_send_data_sem = asyncio.Semaphore(0)
-    
+
     return sp
 
 
@@ -367,7 +367,7 @@ class TestSendingProcess:
     async def test_is_north_valid(self,  plugin_file, plugin_type, plugin_name, expected_result, event_loop):
         """Tests the possible cases of the function is_north_valid """
 
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -392,7 +392,7 @@ class TestSendingProcess:
             return True
 
         # Checks the Readings handling
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -472,7 +472,7 @@ class TestSendingProcess:
             return p_rows
 
         # Checks the Readings handling
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -558,7 +558,7 @@ class TestSendingProcess:
         """ Unit test for - _transform_in_memory_data_readings"""
 
         # Checks the Readings handling
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -729,7 +729,7 @@ class TestSendingProcess:
         """Test _load_data_into_memory handling and transformations for the statistics """
 
         # Checks the Statistics handling
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -822,7 +822,7 @@ class TestSendingProcess:
         """ Unit test for - _transform_in_memory_data_statistics"""
 
         # Checks the Statistics handling
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -860,7 +860,7 @@ class TestSendingProcess:
             rows = {"rows": [{"last_object": 10}, {"last_object": 11}]}
             return rows
 
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -927,7 +927,7 @@ class TestSendingProcess:
 
             return True
 
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1101,7 +1101,7 @@ class TestSendingProcess:
             return p_rows[idx]
 
         # GIVEN
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1289,7 +1289,7 @@ class TestSendingProcess:
             return p_rows[idx]
 
         # GIVEN
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1433,7 +1433,7 @@ class TestSendingProcess:
             return p_rows[idx]
 
         # GIVEN
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1602,7 +1602,7 @@ class TestSendingProcess:
             return p_rows[idx]
 
         # GIVEN
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1786,7 +1786,7 @@ class TestSendingProcess:
             return p_send_result[x]["data_sent"], p_send_result[x]["new_last_object_id"], p_send_result[x]["num_sent"]
 
         # GIVEN
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -1832,7 +1832,7 @@ class TestSendingProcess:
 
                     # Lets the _task_fetch_data to run for a while
                     await asyncio.sleep(3)
-    
+
                     # Tear down
                     sp._task_send_data_run = False
                     sp._task_fetch_data_sem.release()
@@ -1968,7 +1968,7 @@ class TestSendingProcess:
             return p_send_result[x]["data_sent"], p_send_result[x]["new_last_object_id"], p_send_result[x]["num_sent"]
 
         # GIVEN
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2204,7 +2204,7 @@ class TestSendingProcess:
             """ Dummy async task """
             return True
 
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2230,7 +2230,7 @@ class TestSendingProcess:
     async def test_standard_plugins(self, plugin_file, plugin_type, plugin_name, event_loop):
         """Tests if the standard plugins are available and loadable and if they have the required methods """
 
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2290,7 +2290,7 @@ class TestSendingProcess:
                                          expected_config):
         """ Unit tests - _retrieve_configuration - tests the transformations """
 
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2313,7 +2313,7 @@ class TestSendingProcess:
     async def test_start_stream_not_valid(self, event_loop):
         """ Unit tests - _start - stream_id is not valid """
 
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2338,7 +2338,7 @@ class TestSendingProcess:
         async def mock_master_stat_key():
             return 'Readings Sent'
 
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2374,7 +2374,7 @@ class TestSendingProcess:
         async def mock_master_stat_key():
             return 'Readings Sent'
 
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:
@@ -2414,7 +2414,7 @@ class TestSendingProcess:
         async def mock_master_stat_key():
             return 'Readings Sent'
 
-        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', 0, '--name', 'sname']):
+        with patch.object(sys, 'argv', ['pytest', '--address', 'corehost', '--port', '32333', '--name', 'sname']):
             with patch.object(MicroserviceManagementClient, '__init__', return_value=None) as mmc_patch:
                 with patch.object(ReadingsStorageClientAsync, '__init__', return_value=None) as rsc_async_patch:
                     with patch.object(StorageClientAsync, '__init__', return_value=None) as sc_async_patch:


### PR DESCRIPTION
Check with missing "--address":
```
scheduler.py
...
    async def _start_task(self, schedule: _ScheduleRow) -> None:
        """Starts a task process

        Raises:
            EnvironmentError: If the process could not start
        """

        # This check is necessary only if significant time can elapse between "await" and
        # the start of the awaited coroutine.
        args = self._process_scripts[schedule.process_name]

        # add core management host and port to process script args
        args_to_exec = args.copy()
        args_to_exec.append("--port={}".format(self._core_management_port))
        # args_to_exec.append("--address=127.0.0.1")
        args_to_exec.append("--name={}".format(schedule.name))

        ...
...


syslog:
Feb 13 11:43:25 asinha-ThinkPad-E450 FogLAMP[12124] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collection' process 'stats collector' task 30e6c9f7-12a0-426a-9ef2-b5ec070435b1 pid 12285, 1 running tasks#012['tasks/statistics', '--port=43431', '--name=stats collection']
Feb 13 11:43:25 asinha-ThinkPad-E450 FogLAMP[12286] ERROR: process: foglamp.common.process: Arg parser error: the following arguments are required: --address
Feb 13 11:43:26 asinha-ThinkPad-E450 FogLAMP[12124] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collection' process 'stats collector' task 30e6c9f7-12a0-426a-9ef2-b5ec070435b1 pid 12285 exit 1, 0 running tasks#012['tasks/statistics']
Feb 13 11:43:26 asinha-ThinkPad-E450 FogLAMP[12124] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collection' to start at 2019-02-13 11:43:40.021401
Feb 13 11:43:40 asinha-ThinkPad-E450 FogLAMP[12124] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collection' process 'stats collector' task c4bfe8df-98cc-48f7-80dd-1a1f451e18c6 pid 12315, 1 running tasks#012['tasks/statistics', '--port=43431', '--name=stats collection']
Feb 13 11:43:40 asinha-ThinkPad-E450 FogLAMP[12316] ERROR: process: foglamp.common.process: Arg parser error: the following arguments are required: --address
Feb 13 11:43:40 asinha-ThinkPad-E450 FogLAMP[12124] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collection' process 'stats collector' task c4bfe8df-98cc-48f7-80dd-1a1f451e18c6 pid 12315 exit 1, 0 running tasks#012['tasks/statistics']
Feb 13 11:43:40 asinha-ThinkPad-E450 FogLAMP[12124] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collection' to start at 2019-02-13 11:43:55.021401



foglamp status:
FogLAMP (FOGL-1121 *%) $ scripts/foglamp status
FogLAMP v1.4.1 running.
FogLAMP Uptime:  140 seconds.
FogLAMP records: 0 read, 0 sent, 0 purged.
FogLAMP does not require authentication.
=== FogLAMP services:
foglamp.services.core
foglamp.services.storage --address=0.0.0.0 --port=36129
=== FogLAMP tasks:
```




Check with non-numeric "--port":
```
scheduler.py
...
    async def _start_task(self, schedule: _ScheduleRow) -> None:
        """Starts a task process

        Raises:
            EnvironmentError: If the process could not start
        """

        # This check is necessary only if significant time can elapse between "await" and
        # the start of the awaited coroutine.
        args = self._process_scripts[schedule.process_name]

        # add core management host and port to process script args
        args_to_exec = args.copy()
        args_to_exec.append("--port=xyz{}".format(self._core_management_port))
        args_to_exec.append("--address=127.0.0.1")
        args_to_exec.append("--name={}".format(schedule.name))
        ...
...


syslog:
Feb 13 11:45:58 asinha-ThinkPad-E450 FogLAMP[12625] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collection' process 'stats collector' task c0255aad-8139-4adf-8e4f-b1c8b238db40 pid 12743, 1 running tasks#012['tasks/statistics', '--port=xyz44641', '--address=127.0.0.1', '--name=stats collection']
Feb 13 11:45:59 asinha-ThinkPad-E450 FogLAMP[12744] ERROR: process: foglamp.common.process: Arg parser error: argument --port: invalid int value: 'xyz44641'
Feb 13 11:45:59 asinha-ThinkPad-E450 FogLAMP[12625] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collection' process 'stats collector' task c0255aad-8139-4adf-8e4f-b1c8b238db40 pid 12743 exit 1, 0 running tasks#012['tasks/statistics']
Feb 13 11:45:59 asinha-ThinkPad-E450 FogLAMP[12625] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collection' to start at 2019-02-13 11:46:13.963689
Feb 13 11:46:13 asinha-ThinkPad-E450 FogLAMP[12625] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collection' process 'stats collector' task a7a7a2c8-d22e-45f9-8c23-186c5f1df394 pid 12751, 1 running tasks#012['tasks/statistics', '--port=xyz44641', '--address=127.0.0.1', '--name=stats collection']
Feb 13 11:46:14 asinha-ThinkPad-E450 FogLAMP[12752] ERROR: process: foglamp.common.process: Arg parser error: argument --port: invalid int value: 'xyz44641'
Feb 13 11:46:14 asinha-ThinkPad-E450 FogLAMP[12625] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collection' process 'stats collector' task a7a7a2c8-d22e-45f9-8c23-186c5f1df394 pid 12751 exit 1, 0 running tasks#012['tasks/statistics']
Feb 13 11:46:14 asinha-ThinkPad-E450 FogLAMP[12625] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collection' to start at 2019-02-13 11:46:28.963689


foglamp status:
FogLAMP (FOGL-1121 *%) $ scripts/foglamp status
FogLAMP v1.4.1 running.
FogLAMP Uptime:  140 seconds.
FogLAMP records: 0 read, 0 sent, 0 purged.
FogLAMP does not require authentication.
=== FogLAMP services:
foglamp.services.core
foglamp.services.storage --address=0.0.0.0 --port=36129
=== FogLAMP tasks:
```



Check with extra arguments "--foo=FOO" and "--bar=BAR":
```
scheduler.py
...
    async def _start_task(self, schedule: _ScheduleRow) -> None:
        """Starts a task process

        Raises:
            EnvironmentError: If the process could not start
        """

        # This check is necessary only if significant time can elapse between "await" and
        # the start of the awaited coroutine.
        args = self._process_scripts[schedule.process_name]

        # add core management host and port to process script args
        args_to_exec = args.copy()
        args_to_exec.append("--port={}".format(self._core_management_port))
        args_to_exec.append("--address=127.0.0.1")
        args_to_exec.append("--name={}".format(schedule.name))
        args_to_exec.append("--foo=FOO")
        args_to_exec.append("--bar=BAR")
        ...
...


syslog:
Feb 13 11:48:36 asinha-ThinkPad-E450 FogLAMP[13062] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collection' process 'stats collector' task e97d9f5a-5267-4620-a08c-3ac5e5a04a8c pid 13178, 1 running tasks#012['tasks/statistics', '--port=36129', '--address=127.0.0.1', '--name=stats collection', '--foo=FOO', '--bar=BAR']
Feb 13 11:48:38 asinha-ThinkPad-E450 FogLAMP[13062] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collection' process 'stats collector' task e97d9f5a-5267-4620-a08c-3ac5e5a04a8c pid 13178 exit 0, 0 running tasks#012['tasks/statistics']
Feb 13 11:48:38 asinha-ThinkPad-E450 FogLAMP[13062] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collection' to start at 2019-02-13 11:48:51.844290
Feb 13 11:48:51 asinha-ThinkPad-E450 FogLAMP[13062] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process started: Schedule 'stats collection' process 'stats collector' task 175cbfb2-6c26-458e-81db-e7651d881afd pid 13201, 1 running tasks#012['tasks/statistics', '--port=36129', '--address=127.0.0.1', '--name=stats collection', '--foo=FOO', '--bar=BAR']
Feb 13 11:48:53 asinha-ThinkPad-E450 FogLAMP[13062] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Process terminated: Schedule 'stats collection' process 'stats collector' task 175cbfb2-6c26-458e-81db-e7651d881afd pid 13201 exit 0, 0 running tasks#012['tasks/statistics']
Feb 13 11:48:53 asinha-ThinkPad-E450 FogLAMP[13062] INFO: scheduler: foglamp.services.core.scheduler.scheduler: Scheduled task for schedule 'stats collection' to start at 2019-02-13 11:49:06.844290


foglamp status:
FogLAMP (FOGL-1121 *%) $ scripts/foglamp status
FogLAMP v1.4.1 running.
FogLAMP Uptime:  140 seconds.
FogLAMP records: 0 read, 0 sent, 0 purged.
FogLAMP does not require authentication.
=== FogLAMP services:
foglamp.services.core
foglamp.services.storage --address=0.0.0.0 --port=36129
=== FogLAMP tasks:
foglamp.tasks.statistics --port=36129 --address=127.0.0.1 --name=stats collection --foo=FOO --bar=BAR

```