### PR TITLE
FOGL-2413 - Fixed python_plugin_interface.cpp -> logErrorMessage() to correctly display exception messages

### DIFF
--- a/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
+++ b/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
@@ -613,10 +613,6 @@ static void logErrorMessage()
 	PyErr_Fetch(&pType, &pValue, &pTraceback);
 	PyErr_NormalizeException(&pType, &pValue, &pTraceback);
 
-	PyObject* str_exc_type = PyObject_Repr(pType);
-	PyObject* pyStr = PyUnicode_AsEncodedString(str_exc_type, "utf-8", "Error ~");
-	const char *strExcType =  PyBytes_AS_STRING(pyStr);
-
 	PyObject* str_exc_value = PyObject_Repr(pValue);
 	PyObject* pyExcValueStr = PyUnicode_AsEncodedString(str_exc_value, "utf-8", "Error ~");
 	const char *pErrorMessage =  PyBytes_AS_STRING(pyExcValueStr);

--- a/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
+++ b/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
@@ -611,15 +611,15 @@ static void logErrorMessage()
 	//Get error message
 	PyObject *pType, *pValue, *pTraceback;
 	PyErr_Fetch(&pType, &pValue, &pTraceback);
+	PyErr_NormalizeException(&pType, &pValue, &pTraceback);
 
-	// NOTE from :
-	// https://docs.python.org/2/c-api/exceptions.html
-	//
-	// The value and traceback object may be NULL
-	// even when the type object is not.	
-	const char* pErrorMessage = pValue ?
-				    PyBytes_AsString(pValue) :
-				    "no error description.";
+	PyObject* str_exc_type = PyObject_Repr(pType);
+	PyObject* pyStr = PyUnicode_AsEncodedString(str_exc_type, "utf-8", "Error ~");
+	const char *strExcType =  PyBytes_AS_STRING(pyStr);
+
+	PyObject* str_exc_value = PyObject_Repr(pValue);
+	PyObject* pyExcValueStr = PyUnicode_AsEncodedString(str_exc_value, "utf-8", "Error ~");
+	const char *pErrorMessage =  PyBytes_AS_STRING(pyExcValueStr);
 
 	Logger::getLogger()->fatal("logErrorMessage: Error '%s' ",
 				   pErrorMessage ?

--- a/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
+++ b/C/services/south-plugin-interfaces/python/python_plugin_interface.cpp
@@ -615,12 +615,10 @@ static void logErrorMessage()
 
 	PyObject* str_exc_value = PyObject_Repr(pValue);
 	PyObject* pyExcValueStr = PyUnicode_AsEncodedString(str_exc_value, "utf-8", "Error ~");
-	const char *pErrorMessage =  PyBytes_AS_STRING(pyExcValueStr);
-
-	Logger::getLogger()->fatal("logErrorMessage: Error '%s' ",
-				   pErrorMessage ?
-				   pErrorMessage :
-				   "no description");
+	const char* pErrorMessage = pValue ?
+				    PyBytes_AsString(pyExcValueStr) :
+				    "no error description.";
+	Logger::getLogger()->fatal("logErrorMessage: Error '%s' ", pErrorMessage);
 
 	// Reset error
 	PyErr_Clear();
@@ -629,6 +627,8 @@ static void logErrorMessage()
 	Py_CLEAR(pType);
 	Py_CLEAR(pValue);
 	Py_CLEAR(pTraceback);
+	Py_CLEAR(str_exc_value);
+	Py_CLEAR(pyExcValueStr);
 }
 };
 


### PR DESCRIPTION
Tested with modbustcp FOGL-2476 branch. Below errors now appear:
```
Feb 21 15:35:17 asinha-ThinkPad-E450 FogLAMP[20689] ERROR: modbustcp: foglamp.plugins.south.modbustcp.modbustcp: Failed to read data from modbus device. Got error the JSON object must be str, not 'dict'
Feb 21 15:35:17 asinha-ThinkPad-E450 Modbus TCP[20689]: ERROR: Called python script method plugin_poll : error while getting result object
Feb 21 15:35:17 asinha-ThinkPad-E450 Modbus TCP[20689]: FATAL: logErrorMessage: Error 'TypeError("the JSON object must be str, not 'dict'",)'
``` 

So we can now replace lines in all Python South Poll plugins containing 
```
    except (Exception, pexpect.exceptions.TIMEOUT) as ex:
        raise exceptions.DataRetrievalError(str(ex))
```

with

```
    except Exception as ex:
        _LOGGER.error('Failed to read data from device. Got error %s', str(ex))
        raise ex
```