### PR TITLE
FOGL-2560 GET endpoint added to return list of notification types

### DIFF
--- a/python/foglamp/services/core/api/notification.py
+++ b/python/foglamp/services/core/api/notification.py
@@ -59,6 +59,15 @@ async def get_plugin(request):
         return web.json_response({'rules': rule_plugins, 'delivery': delivery_plugins})
 
 
+async def get_type(request):
+    """ GET the list of available notification types
+
+    :Example:
+        curl -X GET http://localhost:8081/foglamp/notification/type
+    """
+    return web.json_response({'notification_type': NOTIFICATION_TYPE})
+
+
 async def get_notification(request):
     """ GET an existing notification
 

--- a/python/foglamp/services/core/routes.py
+++ b/python/foglamp/services/core/routes.py
@@ -168,6 +168,7 @@ def setup(app):
     # Notification
     app.router.add_route('GET', '/foglamp/notification', notification.get_notifications)
     app.router.add_route('GET', '/foglamp/notification/plugin', notification.get_plugin)
+    app.router.add_route('GET', '/foglamp/notification/type', notification.get_type)
     app.router.add_route('GET', '/foglamp/notification/{notification_name}', notification.get_notification)
     app.router.add_route('POST', '/foglamp/notification', notification.post_notification)
     app.router.add_route('PUT', '/foglamp/notification/{notification_name}', notification.put_notification)

--- a/tests/unit/python/foglamp/services/core/api/test_notification.py
+++ b/tests/unit/python/foglamp/services/core/api/test_notification.py
@@ -316,6 +316,14 @@ class TestNotification:
         json_response = json.loads(result)
         assert rules_and_delivery == json_response
 
+    async def test_get_type(self, client):
+        notification_type = {'notification_type': NOTIFICATION_TYPE}
+        resp = await client.get('/foglamp/notification/type')
+        assert 200 == resp.status
+        result = await resp.text()
+        json_response = json.loads(result)
+        assert notification_type == json_response
+
     async def test_get_notification(self, mocker, client):
         r = list(filter(lambda rules: rules['name'] == notification_config['rule']['value'], rule_config))
         c = list(filter(lambda channels: channels['name'] == notification_config['channel']['value'], delivery_config))


### PR DESCRIPTION
```
$ curl -sX GET http://localhost:8081/foglamp/notification/type | jq
{
  "notification_type": [
    "one shot",
    "retriggered",
    "toggled"
  ]
}

```