### PR TITLE
FOGL-2611 audit system API tests added

### DIFF
--- a/tests/system/python/api/test_audit.py
+++ b/tests/system/python/api/test_audit.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Test Audit REST API """
+
+
+import http.client
+import json
+import time
+from collections import Counter
+import pytest
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2019 Dianomic Systems"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+class TestAudit:
+
+    def test_get_log_codes(self, foglamp_url, reset_and_start_foglamp):
+        expected_code_list = ['PURGE', 'LOGGN', 'STRMN', 'SYPRG', 'START', 'FSTOP',
+                              'CONCH', 'CONAD', 'SCHCH', 'SCHAD', 'SRVRG', 'SRVUN',
+                              'SRVFL', 'NHCOM', 'NHDWN', 'NHAVL', 'UPEXC', 'BKEXC',
+                              'NTFDL', 'NTFAD', 'NTFSN', 'NTFST', 'NTFSD']
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/audit/logcode')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        assert 23 == len(jdoc['logCode'])
+        codes = [key['code'] for key in jdoc['logCode']]
+        assert Counter(expected_code_list) == Counter(codes)
+
+    def test_get_severity(self, foglamp_url):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/audit/severity')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        log_severity = jdoc['logSeverity']
+        assert 4 == len(log_severity)
+        name = [name['name'] for name in log_severity]
+        assert Counter(['SUCCESS', 'FAILURE', 'WARNING', 'INFORMATION']) == Counter(name)
+        index = [idx['index'] for idx in log_severity]
+        assert Counter([0, 1, 2, 4]) == Counter(index)
+
+    @pytest.mark.parametrize("request_params, total_count, audit_count, cat_name", [
+        ('', 8, 8, ''),
+        ('?limit=1', 8, 1, ''),
+        ('?skip=4', 8, 4, 'service'),
+        ('?limit=1&skip=8', 8, 0, ''),
+        ('?source=START', 1, 1, ''),
+        ('?source=CONAD', 7, 7, 'Utilities'),
+        ('?source=CONAD&limit=1', 7, 1, 'Utilities'),
+        ('?source=CONAD&skip=1', 7, 6, 'Advanced'),
+        ('?source=CONAD&skip=6&limit=1', 7, 1, 'SCHEDULER'),
+        ('?severity=INFORMATION', 8, 8, ''),
+        ('?severity=failure', 0, 0, ''),
+        ('?source=CONAD&severity=failure', 0, 0, ''),
+        ('?source=START&severity=INFORMATION', 1, 1, ''),
+        ('?source=START&severity=information&limit=1', 1, 1, ''),
+        ('?source=START&severity=information&limit=1&skip=1', 1, 0, '')
+    ])
+    def test_default_get_audit(self, foglamp_url, wait_time, request_params, total_count, audit_count, cat_name):
+        if request_params == '':
+            time.sleep(wait_time)
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/audit{}'.format(request_params))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        assert total_count == jdoc['totalCount']
+        assert audit_count == len(jdoc['audit'])
+        if audit_count:
+            if jdoc['audit'][0]['details']:
+                assert cat_name == jdoc['audit'][0]['details']['name']
+
+    @pytest.mark.parametrize("payload, total_count", [
+        ({"source": "LMTR", "severity": "warning", "details": {"message": "Engine oil pressure low"}}, 9),
+        ({"source": "LMTR", "severity": "success", "details": {}}, 10),
+        ({"source": "START", "severity": "information", "details": {"message": "foglamp started"}}, 11),
+        ({"source": "CONCH", "severity": "failure", "details": {"message": "Scheduler configuration failed"}}, 12)
+    ])
+    def test_create_audit_entry(self, foglamp_url, payload, total_count):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request('POST', '/foglamp/audit', body=json.dumps(payload))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        assert payload['source'] == jdoc['source']
+        assert payload['severity'] == jdoc['severity']
+        assert payload['details'] == jdoc['details']
+
+        # Verify new audit log entries
+        conn.request("GET", '/foglamp/audit')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        assert total_count == jdoc['totalCount']


### PR DESCRIPTION
**O/P**

```
$ pytest -s -vv test_audit.py 
============================================================= test session starts =============================================================
platform linux -- Python 3.5.3, pytest-3.6.0, py-1.7.0, pluggy-0.6.0 -- /usr/local/bin/python3.5
cachedir: ../.pytest_cache
rootdir: /home/foglamp/Development/FogLAMP/tests/system/python, inifile: pytest.ini
plugins: mock-1.10.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 21 items                                                                                                                            

../TestAudit test_get_log_codes <- api/test_audit.py FogLAMP killed.
This script will remove all data stored in the SQLite3 datafile '/home/foglamp/Development/FogLAMP/data/foglamp.db'
Enter YES if you want to continue: Starting FogLAMP v1.5.1......
FogLAMP started.
FogLAMP v1.5.1 running.
FogLAMP Uptime:  6 seconds.
FogLAMP records: 0 read, 0 sent, 0 purged.
FogLAMP does not require authentication.
=== FogLAMP services:
foglamp.services.core
=== FogLAMP tasks:
PASSED
../TestAudit test_get_severity <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_get_audit <- api/test_audit.py PASSED
../TestAudit test_create_audit_entry <- api/test_audit.py PASSED
../TestAudit test_create_audit_entry <- api/test_audit.py PASSED
../TestAudit test_create_audit_entry <- api/test_audit.py PASSED
../TestAudit test_create_audit_entry <- api/test_audit.py PASSED

=== 21 passed in 26.43 seconds ===
```

- [x] single execution okay
- [x] suite run okay