### PR TITLE
FOGL-2480 FogLAMP refused to start in https mode with ssl certificate expiration time

### DIFF
--- a/python/foglamp/services/core/server.py
+++ b/python/foglamp/services/core/server.py
@@ -704,7 +704,7 @@ class Server:
 
                     if cls.running_in_safe_mode:
                         cls.is_rest_server_http_enabled = True
-                        # TODO: Should we also run on configured https port or default http port?
+                        # TODO: Should cls.rest_server_port be set to configured http port, as is_rest_server_http_enabled has been set to True?
                         msg = "Running in safe mode withOUT https on port {}".format(cls.rest_server_port)
                         _logger.info(msg)
                     else:

--- a/python/foglamp/services/core/server.py
+++ b/python/foglamp/services/core/server.py
@@ -696,11 +696,11 @@ class Server:
                     _logger.info('Loading certificates %s and key %s', cert, key)
 
                     # Verification handling of a cert
-                    with open(cert, 'r') as content_file:
-                        server_cert = content_file.read()
-                    SSLVerifier.set_user_cert(server_cert)
+                    with open(cert, 'r') as tls_cert_content:
+                        tls_cert = tls_cert_content.read()
+                    SSLVerifier.set_user_cert(tls_cert)
                     if SSLVerifier.is_expired():
-                        msg = 'Certificate expired on {}. Start in safe-mode to fix this problem'.format(SSLVerifier.get_enddate())
+                        msg = 'Certificate `{}` expired on {}. Start in safe-mode to fix this problem!'.format(cls.cert_file_name, SSLVerifier.get_enddate())
                         _logger.error(msg)
                         raise SSLVerifier.VerificationError(msg)
                     ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)

--- a/scripts/plugins/storage/sqlite.sh
+++ b/scripts/plugins/storage/sqlite.sh
@@ -164,6 +164,7 @@ sqlite_reset() {
         rm ${DEFAULT_SQLITE_DB_FILE} ||
         sqlite_log "err" "Cannot drop database '${DEFAULT_SQLITE_DB_FILE}' for the FogLAMP Plugin '${PLUGIN}'" "all" "pretty"
     fi
+    rm -f ${DEFAULT_SQLITE_DB_FILE}-journal ${DEFAULT_SQLITE_DB_FILE}-wal ${DEFAULT_SQLITE_DB_FILE}-shm
     # 2- Create new datafile an apply init file
     INIT_OUTPUT=`${SQLITE_SQL} "${DEFAULT_SQLITE_DB_FILE}" 2>&1 <<EOF
 PRAGMA page_size = 4096;


### PR DESCRIPTION
- [x] SSL cert expiration
- [x] Safe mode handling; See the logs
```
Mar 19 13:28:52 nerd-034 FogLAMP[32427] INFO: server: foglamp.services.core.server: Loading certificates /home/foglamp/Development/FogLAMP/data/etc/certs/foglamp.cert and key /home/foglamp/Development/FogLAMP/data/etc/certs/foglamp.key
Mar 19 13:28:52 nerd-034 FogLAMP[32427] ERROR: server: foglamp.services.core.server: Certificate `foglamp` expired on Mar 18 07:44:55 2019 GMT
Mar 19 13:28:52 nerd-034 FogLAMP[32427] INFO: server: foglamp.services.core.server: Running in safe mode withOUT https on port 1995
Mar 19 13:28:52 nerd-034 FogLAMP[32427] INFO: server: foglamp.services.core.server: Announce management API service
Mar 19 13:28:52 nerd-034 FogLAMP[32427] WARNING: server: foglamp.services.core.server: A FogLAMP PID file has been found: [/home/foglamp/Development/FogLAMP/data/var/run/foglamp.core.pid] found, ignoring it.
Mar 19 13:28:52 nerd-034 FogLAMP[32427] INFO: server: foglamp.services.core.server: PID [32427] written in [/home/foglamp/Development/FogLAMP/data/var/run/foglamp.core.pid]
Mar 19 13:28:52 nerd-034 FogLAMP[32427] INFO: server: foglamp.services.core.server: REST API Server started on http://0.0.0.0:1995
Mar 19 13:28:52 nerd-034 FogLAMP[32427] ERROR: server: foglamp.services.core.server: A...#012NoneType: None
Mar 19 13:28:52 nerd-034 FogLAMP[32427] INFO: service_registry: foglamp.services.core.service_registry.service_registry: Registered service instance id=9593d260-772e-4ad8-a917-93f7a4f90145: <FogLAMP Core, type=Core, protocol=http, address=0.0.0.0, service port=1995, management port=36443, status=1>
Mar 19 13:28:53 nerd-034 FogLAMP [32371] INFO: script.foglamp: FogLAMP started.
Mar 19 13:28:54 nerd-034 FogLAMP Storage[32432]: INFO: Registered configuration category STORAGE, registration id ff736fd8-bf32-4ae1-81b1-5748abb35e21.

```

- [x] related DB files are removed on reset As its needed
