### PR TITLE
FOGL-2616 system tests added for ping, restart, shutdown added (admin api)

### DIFF
--- a/tests/system/python/api/test_common.py
+++ b/tests/system/python/api/test_common.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Test Common (ping, shutdown, restart) REST API """
+
+import socket
+import subprocess
+import http.client
+import time
+import json
+import pytest
+
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2019 Dianomic Systems"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+@pytest.fixture
+def get_machine_detail():
+    host_name = socket.gethostname()
+    # all addresses for the host
+    all_ip_addresses_cmd_res = subprocess.run(['hostname', '-I'], stdout=subprocess.PIPE)
+    ip_addresses = all_ip_addresses_cmd_res.stdout.decode('utf-8').replace("\n", "").strip().split(" ")
+    return host_name, ip_addresses
+
+
+class TestCommon:
+
+    def test_ping_default(self, reset_and_start_foglamp, foglamp_url):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/ping')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        host_name, ip_addresses = get_machine_detail()
+        assert 1 < jdoc['uptime']
+        assert isinstance(jdoc['uptime'], int)
+        assert 0 == jdoc['dataRead']
+        assert 0 == jdoc['dataSent']
+        assert 0 == jdoc['dataPurged']
+        assert 'FogLAMP' == jdoc['serviceName']
+        assert host_name == jdoc['hostName']
+        assert ip_addresses == jdoc['ipAddresses']
+        assert 'green' == jdoc['health']
+        assert jdoc['authenticationOptional'] is True
+        assert jdoc['safeMode'] is False
+
+    @pytest.mark.skip(reason='Not Implemented yet')
+    def test_ping_when_auth_mandatory(self):
+        # TODO: Its a bit tricky to automate user input on shell when foglamp start
+        pass
+
+    def test_restart(self, foglamp_url, wait_time):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("PUT", '/foglamp/restart')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        assert 'FogLAMP restart has been scheduled.' == jdoc['message']
+
+        time.sleep(wait_time * 2)
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/ping')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        assert 1 < jdoc['uptime']
+        assert isinstance(jdoc['uptime'], int)
+
+    def test_shutdown(self, foglamp_url, wait_time):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("PUT", '/foglamp/shutdown')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        assert 'FogLAMP shutdown has been scheduled. Wait for few seconds for process cleanup.' == jdoc['message']
+
+        time.sleep(wait_time * 2)
+        stat = subprocess.run(["$FOGLAMP_ROOT/scripts/foglamp status"], shell=True, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
+        assert "FogLAMP not running." == stat.stderr.decode("utf-8").replace("\n", "").strip()

--- a/tests/system/python/api/test_common.py
+++ b/tests/system/python/api/test_common.py
@@ -31,6 +31,16 @@ def get_machine_detail():
 
 class TestCommon:
 
+    def do_restart(self, foglamp_url):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("PUT", '/foglamp/restart')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        assert 'FogLAMP restart has been scheduled.' == jdoc['message']
+
     def test_ping_default(self, reset_and_start_foglamp, foglamp_url):
         conn = http.client.HTTPConnection(foglamp_url)
         conn.request("GET", '/foglamp/ping')
@@ -52,20 +62,17 @@ class TestCommon:
         assert jdoc['authenticationOptional'] is True
         assert jdoc['safeMode'] is False
 
-    @pytest.mark.skip(reason='Not Implemented yet')
-    def test_ping_when_auth_mandatory(self):
-        # TODO: Its a bit tricky to automate user input on shell when foglamp start
-        pass
-
-    def test_restart(self, foglamp_url, wait_time):
+    def test_ping_when_auth_mandatory_allow_ping_true(self, foglamp_url, wait_time):
         conn = http.client.HTTPConnection(foglamp_url)
-        conn.request("PUT", '/foglamp/restart')
+        payload = {"allowPing": "true", "authentication": "mandatory"}
+        conn.request("PUT", '/foglamp/category/rest_api', body=json.dumps(payload))
         r = conn.getresponse()
         assert 200 == r.status
         r = r.read().decode()
         jdoc = json.loads(r)
         assert len(jdoc), "No data found"
-        assert 'FogLAMP restart has been scheduled.' == jdoc['message']
+
+        self.do_restart(foglamp_url)
 
         time.sleep(wait_time * 2)
         conn = http.client.HTTPConnection(foglamp_url)
@@ -78,7 +85,31 @@ class TestCommon:
         assert 1 < jdoc['uptime']
         assert isinstance(jdoc['uptime'], int)
 
-    def test_shutdown(self, foglamp_url, wait_time):
+    def test_ping_when_auth_mandatory_allow_ping_false(self, reset_and_start_foglamp, foglamp_url, wait_time):
+        # reset_and_start_foglamp fixture needed to get default settings back
+        conn = http.client.HTTPConnection(foglamp_url)
+        payload = {"allowPing": "false", "authentication": "mandatory"}
+        conn.request("PUT", '/foglamp/category/rest_api', body=json.dumps(payload))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+
+        self.do_restart(foglamp_url)
+
+        time.sleep(wait_time * 2)
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/ping')
+        r = conn.getresponse()
+        assert 403 == r.status
+        assert 'Forbidden' == r.reason
+
+    def test_restart(self):
+        assert 1, "Already verified in test_ping_when_auth_mandatory_allow_ping_true"
+
+    def test_shutdown(self, reset_and_start_foglamp, foglamp_url, wait_time):
+        # reset_and_start_foglamp fixture needed to get default settings back
         conn = http.client.HTTPConnection(foglamp_url)
         conn.request("PUT", '/foglamp/shutdown')
         r = conn.getresponse()


### PR DESCRIPTION
**O/P**
```
$ pytest -s -vv test_common.py 
============================================================= test session starts =============================================================
platform linux -- Python 3.5.3, pytest-3.6.0, py-1.8.0, pluggy-0.6.0 -- /usr/local/bin/python3.5
cachedir: ../.pytest_cache
rootdir: /home/foglamp/Development/FogLAMP/tests/system/python, inifile: pytest.ini
plugins: mock-1.10.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 5 items                                                                                                                             

../TestCommon test_ping_default <- api/test_common.py FogLAMP killed.
This script will remove all data stored in the SQLite3 datafile '/home/foglamp/Development/FogLAMP/data/foglamp.db'
Enter YES if you want to continue: Starting FogLAMP v1.5.1......
FogLAMP started.
FogLAMP v1.5.1 running.
FogLAMP Uptime:  6} seconds.
FogLAMP records: 0 read, 0 sent, 0 purged.
FogLAMP does not require authentication.
=== FogLAMP services:
foglamp.services.core
=== FogLAMP tasks:
PASSED
../TestCommon test_ping_when_auth_mandatory_allow_ping_true <- api/test_common.py PASSED
../TestCommon test_ping_when_auth_mandatory_allow_ping_false <- api/test_common.py FogLAMP killed.
This script will remove all data stored in the SQLite3 datafile '/home/foglamp/Development/FogLAMP/data/foglamp.db'
Enter YES if you want to continue: Starting FogLAMP v1.5.1......
FogLAMP started.
FogLAMP v1.5.1 running.
FogLAMP Uptime:  6,"dataRead" seconds.
FogLAMP records: 0 read, 0 sent, 0 purged.
FogLAMP does not require authentication.
=== FogLAMP services:
foglamp.services.core
=== FogLAMP tasks:

PASSED
../TestCommon test_restart <- api/test_common.py PASSED
../TestCommon test_shutdown <- api/test_common.py FogLAMP killed.
This script will remove all data stored in the SQLite3 datafile '/home/foglamp/Development/FogLAMP/data/foglamp.db'
Enter YES if you want to continue: Starting FogLAMP v1.5.1......
FogLAMP started.
FogLAMP v1.5.1 running.
FogLAMP Uptime:  6,"dataRead" seconds.
FogLAMP records: 0 read, 0 sent, 0 purged.
FogLAMP does not require authentication.
=== FogLAMP services:
foglamp.services.core
=== FogLAMP tasks:
PASSED

=== 5 passed in 85.71 seconds ==
```