### PR TITLE
FOGL-2571: Add missing assertion of verify statistics and ping in system tests

### DIFF
--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -9,6 +9,7 @@
 """
 import subprocess
 import os
+import sys
 import fnmatch
 import http.client
 import json
@@ -22,6 +23,8 @@ __author__ = "Vaibhav Singhal"
 __copyright__ = "Copyright (c) 2019 Dianomic Systems"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
 @pytest.fixture
@@ -292,8 +295,8 @@ def pytest_addoption(parser):
     parser.addoption("--retries", action="store", default=3, type=int,
                      help="Number of tries for polling")
     # TODO: Temporary fixture, to be used with value False for environments where PI Web API is not stable
-    parser.addoption("--verify-north-data", action="store", default='true',
-                     help="Verify data from north side api")
+    parser.addoption("--skip-verify-north-interface", action="store_false",
+                     help="Verify data from external north system api")
 
     parser.addoption("--remote-user", action="store", default="ubuntu",
                      help="Username on remote machine where FogLAMP will run")
@@ -385,12 +388,8 @@ def remote_foglamp_path(request):
 
 
 @pytest.fixture
-def verify_north_data(request):
-    v = request.config.getoption("--verify-north-data")
-    if v.lower() in ('no', 'false', 'f', 'n', '0'):
-        return False
-    else:
-        return True
+def skip_verify_north_interface(request):
+    return request.config.getoption("--skip-verify-north-interface")
 
 
 @pytest.fixture

--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -291,6 +291,9 @@ def pytest_addoption(parser):
                      help="Generic wait time between processes to run")
     parser.addoption("--retries", action="store", default=3, type=int,
                      help="Number of tries for polling")
+    # TODO: Temporary fixture, to be used with value False for environments where PI Web API is not stable
+    parser.addoption("--verify-north-data", action="store", default='true',
+                     help="Verify data from north side api")
 
     parser.addoption("--remote-user", action="store", default="ubuntu",
                      help="Username on remote machine where FogLAMP will run")
@@ -379,6 +382,15 @@ def key_path(request):
 @pytest.fixture
 def remote_foglamp_path(request):
     return request.config.getoption("--remote-foglamp-path")
+
+
+@pytest.fixture
+def verify_north_data(request):
+    v = request.config.getoption("--verify-north-data")
+    if v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        return True
 
 
 @pytest.fixture

--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -389,7 +389,7 @@ def remote_foglamp_path(request):
 
 @pytest.fixture
 def skip_verify_north_interface(request):
-    return request.config.getoption("--skip-verify-north-interface")
+    return not request.config.getoption("--skip-verify-north-interface")
 
 
 @pytest.fixture

--- a/tests/system/python/e2e/test_e2e_coap_PI.py
+++ b/tests/system/python/e2e/test_e2e_coap_PI.py
@@ -24,6 +24,43 @@ TEMPLATE_NAME = "template.json"
 SENSOR_VALUE = 20
 
 
+def get_ping_status(foglamp_url):
+    _connection = http.client.HTTPConnection(foglamp_url)
+    _connection.request("GET", '/foglamp/ping')
+    r = _connection.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    jdoc = json.loads(r)
+    return jdoc
+
+
+def get_statistics_map(foglamp_url):
+    _connection = http.client.HTTPConnection(foglamp_url)
+    _connection.request("GET", '/foglamp/statistics')
+    r = _connection.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    jdoc = json.loads(r)
+    actual_stats_map = {}
+    for itm in jdoc:
+        actual_stats_map[itm['key']] = itm['value']
+    return actual_stats_map
+
+
+def _verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name):
+    retry_count = 0
+    data_from_pi = None
+    while (data_from_pi is None or data_from_pi == []) and retry_count < retries:
+        data_from_pi = read_data_from_pi(pi_host, pi_admin, pi_passwd, pi_db, asset_name, {"sensor"})
+        retry_count += 1
+        time.sleep(wait_time*2)
+
+    if data_from_pi is None or retry_count == retries:
+        assert False, "Failed to read data from PI"
+
+    assert data_from_pi["sensor"][-1] == SENSOR_VALUE
+
+
 @pytest.fixture
 def start_south_north(reset_and_start_foglamp, add_south, start_north_pi_server_c, remove_data_file,
                       remove_directories, south_branch, foglamp_url, pi_host, pi_port, pi_token,
@@ -56,10 +93,11 @@ def start_south_north(reset_and_start_foglamp, add_south, start_north_pi_server_
 
 
 def test_end_to_end(start_south_north, read_data_from_pi, foglamp_url, pi_host, pi_admin, pi_passwd, pi_db,
-                    wait_time, retries, asset_name="end_to_end_coap"):
+                    wait_time, retries, verify_north_data, asset_name="end_to_end_coap"):
     """ Test that data is inserted in FogLAMP and sent to PI
         start_south_north: Fixture that starts FogLAMP with south and north instance
         read_data_from_pi: Fixture to read data from PI
+        verify_north_data: Flag for assertion of data from Pi web API
         Assertions:
             on endpoint GET /foglamp/asset
             on endpoint GET /foglamp/asset/<asset_name>
@@ -70,6 +108,17 @@ def test_end_to_end(start_south_north, read_data_from_pi, foglamp_url, pi_host, 
     subprocess.run(["cd $FOGLAMP_ROOT/extras/python; python3 -m fogbench -t ../../data/{}; cd -".format(TEMPLATE_NAME)],
                    shell=True, check=True)
     time.sleep(wait_time)
+
+    ping_response = get_ping_status(foglamp_url)
+    assert 1 == ping_response["dataRead"]
+    assert 1 == ping_response["dataSent"]
+
+    actual_stats_map = get_statistics_map(foglamp_url)
+    assert 1 == actual_stats_map[asset_name.upper()]
+    assert 1 == actual_stats_map['NorthReadingsToPI']
+    assert 1 == actual_stats_map['READINGS']
+    assert 1 == actual_stats_map['Readings Sent']
+
     conn.request("GET", '/foglamp/asset')
     r = conn.getresponse()
     assert 200 == r.status
@@ -86,14 +135,6 @@ def test_end_to_end(start_south_north, read_data_from_pi, foglamp_url, pi_host, 
     retval = json.loads(r)
     assert {'sensor': SENSOR_VALUE} == retval[0]["reading"]
 
-    retry_count = 0
-    data_from_pi = None
-    while (data_from_pi is None or data_from_pi == []) and retry_count < retries:
-        data_from_pi = read_data_from_pi(pi_host, pi_admin, pi_passwd, pi_db, asset_name, {"sensor"})
-        retry_count += 1
-        time.sleep(wait_time*2)
+    if verify_north_data:
+        _verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name)
 
-    if data_from_pi is None or retry_count == retries:
-        assert False, "Failed to read data from PI"
-
-    assert data_from_pi["sensor"][-1] == SENSOR_VALUE

--- a/tests/system/python/e2e/test_e2e_coap_PI.py
+++ b/tests/system/python/e2e/test_e2e_coap_PI.py
@@ -13,6 +13,7 @@ import http.client
 import json
 import time
 import pytest
+import utils
 
 
 __author__ = "Vaibhav Singhal"
@@ -41,10 +42,7 @@ def get_statistics_map(foglamp_url):
     assert 200 == r.status
     r = r.read().decode()
     jdoc = json.loads(r)
-    actual_stats_map = {}
-    for itm in jdoc:
-        actual_stats_map[itm['key']] = itm['value']
-    return actual_stats_map
+    return utils.serialize_stats_map(jdoc)
 
 
 def _verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name):
@@ -93,11 +91,11 @@ def start_south_north(reset_and_start_foglamp, add_south, start_north_pi_server_
 
 
 def test_end_to_end(start_south_north, read_data_from_pi, foglamp_url, pi_host, pi_admin, pi_passwd, pi_db,
-                    wait_time, retries, verify_north_data, asset_name="end_to_end_coap"):
+                    wait_time, retries, skip_verify_north_interface, asset_name="end_to_end_coap"):
     """ Test that data is inserted in FogLAMP and sent to PI
         start_south_north: Fixture that starts FogLAMP with south and north instance
         read_data_from_pi: Fixture to read data from PI
-        verify_north_data: Flag for assertion of data from Pi web API
+        skip_verify_north_interface: Flag for assertion of data from Pi web API
         Assertions:
             on endpoint GET /foglamp/asset
             on endpoint GET /foglamp/asset/<asset_name>
@@ -135,6 +133,6 @@ def test_end_to_end(start_south_north, read_data_from_pi, foglamp_url, pi_host, 
     retval = json.loads(r)
     assert {'sensor': SENSOR_VALUE} == retval[0]["reading"]
 
-    if verify_north_data:
+    if skip_verify_north_interface:
         _verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name)
 

--- a/tests/system/python/e2e/test_e2e_coap_PI.py
+++ b/tests/system/python/e2e/test_e2e_coap_PI.py
@@ -133,6 +133,6 @@ def test_end_to_end(start_south_north, read_data_from_pi, foglamp_url, pi_host, 
     retval = json.loads(r)
     assert {'sensor': SENSOR_VALUE} == retval[0]["reading"]
 
-    if skip_verify_north_interface:
+    if not skip_verify_north_interface:
         _verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name)
 

--- a/tests/system/python/e2e/test_e2e_csv_PI.py
+++ b/tests/system/python/e2e/test_e2e_csv_PI.py
@@ -158,5 +158,5 @@ def test_e2e_csv_pi(start_south_north, read_data_from_pi, foglamp_url, pi_host, 
             _actual_read_list.append(_el[_head])
         assert Counter(_actual_read_list) == Counter(_data_str[_head])
 
-    if skip_verify_north_interface:
+    if not skip_verify_north_interface:
         _verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name)

--- a/tests/system/python/e2e/test_e2e_csv_PI.py
+++ b/tests/system/python/e2e/test_e2e_csv_PI.py
@@ -13,6 +13,7 @@ import json
 import time
 import pytest
 from collections import Counter
+import utils
 
 __author__ = "Vaibhav Singhal"
 __copyright__ = "Copyright (c) 2019 Dianomic Systems"
@@ -48,10 +49,7 @@ def get_statistics_map(foglamp_url):
     assert 200 == r.status
     r = r.read().decode()
     jdoc = json.loads(r)
-    actual_stats_map = {}
-    for itm in jdoc:
-        actual_stats_map[itm['key']] = itm['value']
-    return actual_stats_map
+    return utils.serialize_stats_map(jdoc)
 
 
 @pytest.fixture
@@ -117,11 +115,11 @@ def _verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_
 
 
 def test_e2e_csv_pi(start_south_north, read_data_from_pi, foglamp_url, pi_host, pi_admin, pi_passwd, pi_db,
-                    wait_time, retries, verify_north_data, asset_name="end_to_end_csv"):
+                    wait_time, retries, skip_verify_north_interface, asset_name="end_to_end_csv"):
     """ Test that data is inserted in FogLAMP and sent to PI
         start_south_north: Fixture that starts FogLAMP with south and north instance
         read_data_from_pi: Fixture to read data from PI
-        verify_north_data: Flag for assertion of data from Pi web API
+        skip_verify_north_interface: Flag for assertion of data from Pi web API
         Assertions:
             on endpoint GET /foglamp/asset
             on endpoint GET /foglamp/asset/<asset_name>
@@ -160,5 +158,5 @@ def test_e2e_csv_pi(start_south_north, read_data_from_pi, foglamp_url, pi_host, 
             _actual_read_list.append(_el[_head])
         assert Counter(_actual_read_list) == Counter(_data_str[_head])
 
-    if verify_north_data:
+    if skip_verify_north_interface:
         _verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name)

--- a/tests/system/python/e2e/test_e2e_csv_PI.py
+++ b/tests/system/python/e2e/test_e2e_csv_PI.py
@@ -31,6 +31,29 @@ NORTH_TASK_NAME = "NorthReadingsTo_PI"
 _data_str = {}
 
 
+def get_ping_status(foglamp_url):
+    _connection = http.client.HTTPConnection(foglamp_url)
+    _connection.request("GET", '/foglamp/ping')
+    r = _connection.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    jdoc = json.loads(r)
+    return jdoc
+
+
+def get_statistics_map(foglamp_url):
+    _connection = http.client.HTTPConnection(foglamp_url)
+    _connection.request("GET", '/foglamp/statistics')
+    r = _connection.getresponse()
+    assert 200 == r.status
+    r = r.read().decode()
+    jdoc = json.loads(r)
+    actual_stats_map = {}
+    for itm in jdoc:
+        actual_stats_map[itm['key']] = itm['value']
+    return actual_stats_map
+
+
 @pytest.fixture
 def start_south_north(reset_and_start_foglamp, add_south, start_north_pi_server_c, remove_data_file,
                       remove_directories, south_branch, foglamp_url, pi_host, pi_port, pi_token,
@@ -77,11 +100,28 @@ def start_south_north(reset_and_start_foglamp, add_south, start_north_pi_server_
     remove_directories("/tmp/foglamp-south-{}".format(south_plugin))
 
 
+def _verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name):
+    retry_count = 0
+    data_from_pi = None
+    while (data_from_pi is None or data_from_pi == []) and retry_count < retries:
+        data_from_pi = read_data_from_pi(pi_host, pi_admin, pi_passwd, pi_db, asset_name,
+                                         CSV_HEADERS.split(","))
+        retry_count += 1
+        time.sleep(wait_time*2)
+
+    if data_from_pi is None or retry_count == retries:
+        assert False, "Failed to read data from PI"
+
+    for _head in CSV_HEADERS.split(","):
+        assert Counter(data_from_pi[_head][-len(CSV_DATA):]) == Counter(_data_str[_head])
+
+
 def test_e2e_csv_pi(start_south_north, read_data_from_pi, foglamp_url, pi_host, pi_admin, pi_passwd, pi_db,
-                    wait_time, retries, asset_name="end_to_end_csv"):
+                    wait_time, retries, verify_north_data, asset_name="end_to_end_csv"):
     """ Test that data is inserted in FogLAMP and sent to PI
         start_south_north: Fixture that starts FogLAMP with south and north instance
         read_data_from_pi: Fixture to read data from PI
+        verify_north_data: Flag for assertion of data from Pi web API
         Assertions:
             on endpoint GET /foglamp/asset
             on endpoint GET /foglamp/asset/<asset_name>
@@ -89,6 +129,17 @@ def test_e2e_csv_pi(start_south_north, read_data_from_pi, foglamp_url, pi_host, 
 
     conn = http.client.HTTPConnection(foglamp_url)
     time.sleep(wait_time)
+
+    ping_response = get_ping_status(foglamp_url)
+    assert len(CSV_DATA) == ping_response["dataRead"]
+    assert len(CSV_DATA) == ping_response["dataSent"]
+
+    actual_stats_map = get_statistics_map(foglamp_url)
+    assert len(CSV_DATA) == actual_stats_map[asset_name.upper()]
+    assert len(CSV_DATA) == actual_stats_map['NorthReadingsToPI']
+    assert len(CSV_DATA) == actual_stats_map['READINGS']
+    assert len(CSV_DATA) == actual_stats_map['Readings Sent']
+
     conn.request("GET", '/foglamp/asset')
     r = conn.getresponse()
     assert 200 == r.status
@@ -109,16 +160,5 @@ def test_e2e_csv_pi(start_south_north, read_data_from_pi, foglamp_url, pi_host, 
             _actual_read_list.append(_el[_head])
         assert Counter(_actual_read_list) == Counter(_data_str[_head])
 
-    retry_count = 0
-    data_from_pi = None
-    while (data_from_pi is None or data_from_pi == []) and retry_count < retries:
-        data_from_pi = read_data_from_pi(pi_host, pi_admin, pi_passwd, pi_db, asset_name,
-                                         CSV_HEADERS.split(","))
-        retry_count += 1
-        time.sleep(wait_time*2)
-
-    if data_from_pi is None or retry_count == retries:
-        assert False, "Failed to read data from PI"
-
-    for _head in CSV_HEADERS.split(","):
-        assert Counter(data_from_pi[_head][-len(CSV_DATA):]) == Counter(_data_str[_head])
+    if verify_north_data:
+        _verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name)

--- a/tests/system/python/e2e/test_e2e_csv_multi_filter_pi.py
+++ b/tests/system/python/e2e/test_e2e_csv_multi_filter_pi.py
@@ -152,7 +152,7 @@ class TestE2eCsvMultiFltrPi:
         assert 1 == actual_stats_map['READINGS']
         assert 1 == actual_stats_map['Readings Sent']
 
-        if skip_verify_north_interface:
+        if not skip_verify_north_interface:
             self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries)
 
     def _verify_ingest(self, conn):

--- a/tests/system/python/e2e/test_e2e_expr_pi.py
+++ b/tests/system/python/e2e/test_e2e_expr_pi.py
@@ -31,6 +31,26 @@ ASSET_NAME = "Expression"
 
 
 class TestE2eExprPi:
+    def get_ping_status(self, foglamp_url):
+        _connection = http.client.HTTPConnection(foglamp_url)
+        _connection.request("GET", '/foglamp/ping')
+        r = _connection.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        return jdoc
+
+    def get_statistics_map(self, foglamp_url):
+        _connection = http.client.HTTPConnection(foglamp_url)
+        _connection.request("GET", '/foglamp/statistics')
+        r = _connection.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        actual_stats_map = {}
+        for itm in jdoc:
+            actual_stats_map[itm['key']] = itm['value']
+        return actual_stats_map
 
     @pytest.fixture
     def start_south_north(self, reset_and_start_foglamp, add_south, enable_schedule, remove_directories,
@@ -63,22 +83,34 @@ class TestE2eExprPi:
         remove_directories("/tmp/foglamp-filter-{}".format(filter_plugin))
 
     def test_end_to_end(self, start_south_north, disable_schedule, foglamp_url, read_data_from_pi, pi_host, pi_admin,
-                        pi_passwd, pi_db, wait_time, retries):
+                        pi_passwd, pi_db, wait_time, retries, verify_north_data):
         """ Test that data is inserted in FogLAMP using expression south plugin & metadata filter, and sent to PI
             start_south_north: Fixture that starts FogLAMP with south service, add filter and north instance
+            verify_north_data: Flag for assertion of data from Pi web API
             Assertions:
                 on endpoint GET /foglamp/asset
                 on endpoint GET /foglamp/asset/<asset_name> with applied data processing filter value
                 data received from PI is same as data sent"""
 
         time.sleep(wait_time)
+
+        ping_response = self.get_ping_status(foglamp_url)
+        assert 0 < ping_response["dataRead"]
+        assert 0 < ping_response["dataSent"]
+
+        actual_stats_map = self.get_statistics_map(foglamp_url)
+        assert 0 < actual_stats_map[ASSET_NAME.upper()]
+        assert 0 < actual_stats_map['NorthReadingsToPI']
+        assert 0 < actual_stats_map['READINGS']
+        assert 0 < actual_stats_map['Readings Sent']
+
         conn = http.client.HTTPConnection(foglamp_url)
         self._verify_ingest(conn)
 
         # disable schedule to stop the service and sending data
         disable_schedule(foglamp_url, SVC_NAME)
-
-        self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries)
+        if verify_north_data:
+            self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries)
 
     def _verify_ingest(self, conn):
 

--- a/tests/system/python/e2e/test_e2e_expr_pi.py
+++ b/tests/system/python/e2e/test_e2e_expr_pi.py
@@ -107,7 +107,7 @@ class TestE2eExprPi:
 
         # disable schedule to stop the service and sending data
         disable_schedule(foglamp_url, SVC_NAME)
-        if skip_verify_north_interface:
+        if not skip_verify_north_interface:
             self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries)
 
     def _verify_ingest(self, conn):

--- a/tests/system/python/e2e/test_e2e_expr_pi.py
+++ b/tests/system/python/e2e/test_e2e_expr_pi.py
@@ -15,6 +15,7 @@ import http.client
 import json
 import time
 import pytest
+import utils
 
 
 __author__ = "Praveen Garg"
@@ -47,10 +48,7 @@ class TestE2eExprPi:
         assert 200 == r.status
         r = r.read().decode()
         jdoc = json.loads(r)
-        actual_stats_map = {}
-        for itm in jdoc:
-            actual_stats_map[itm['key']] = itm['value']
-        return actual_stats_map
+        return utils.serialize_stats_map(jdoc)
 
     @pytest.fixture
     def start_south_north(self, reset_and_start_foglamp, add_south, enable_schedule, remove_directories,
@@ -83,10 +81,10 @@ class TestE2eExprPi:
         remove_directories("/tmp/foglamp-filter-{}".format(filter_plugin))
 
     def test_end_to_end(self, start_south_north, disable_schedule, foglamp_url, read_data_from_pi, pi_host, pi_admin,
-                        pi_passwd, pi_db, wait_time, retries, verify_north_data):
+                        pi_passwd, pi_db, wait_time, retries, skip_verify_north_interface):
         """ Test that data is inserted in FogLAMP using expression south plugin & metadata filter, and sent to PI
             start_south_north: Fixture that starts FogLAMP with south service, add filter and north instance
-            verify_north_data: Flag for assertion of data from Pi web API
+            skip_verify_north_interface: Flag for assertion of data from Pi web API
             Assertions:
                 on endpoint GET /foglamp/asset
                 on endpoint GET /foglamp/asset/<asset_name> with applied data processing filter value
@@ -109,7 +107,7 @@ class TestE2eExprPi:
 
         # disable schedule to stop the service and sending data
         disable_schedule(foglamp_url, SVC_NAME)
-        if verify_north_data:
+        if skip_verify_north_interface:
             self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries)
 
     def _verify_ingest(self, conn):

--- a/tests/system/python/e2e/test_e2e_foglamp_pair.py
+++ b/tests/system/python/e2e/test_e2e_foglamp_pair.py
@@ -17,6 +17,7 @@ import json
 import time
 import pytest
 from collections import Counter
+import utils
 
 
 __author__ = "Vaibhav Singhal"
@@ -62,10 +63,7 @@ class TestE2eFogPairPi:
         assert 200 == r.status
         r = r.read().decode()
         jdoc = json.loads(r)
-        actual_stats_map = {}
-        for itm in jdoc:
-            actual_stats_map[itm['key']] = itm['value']
-        return actual_stats_map
+        return utils.serialize_stats_map(jdoc)
 
     @pytest.fixture
     def reset_and_start_foglamp_remote(self, storage_plugin, remote_user, remote_ip, key_path, remote_foglamp_path):
@@ -267,7 +265,7 @@ class TestE2eFogPairPi:
 
     def test_end_to_end(self, start_south_north_remote, start_south_north_local,
                         read_data_from_pi, retries, pi_host, pi_admin, pi_passwd, pi_db,
-                        foglamp_url, remote_ip, wait_time, verify_north_data):
+                        foglamp_url, remote_ip, wait_time, skip_verify_north_interface):
         """ Test that data is inserted in FogLAMP (local instance) using playback south plugin,
             sinusoid south plugin and expression south plugin and sent to http north (filter only playback data),
             FogLAMP (remote instance) receive this data via http south and send to PI
@@ -282,7 +280,7 @@ class TestE2eFogPairPi:
             foglamp_url: Local FogLAMP URL
             remote_ip: IP address where 2 FogLAMP is running (Remote)
             wait_time: time to wait in sec before making assertions
-            verify_north_data: Flag for assertion of data from Pi web API
+            skip_verify_north_interface: Flag for assertion of data from Pi web API
             Assertions:
                 on endpoint GET /foglamp/asset
                 on endpoint GET /foglamp/asset/<asset_name> with applied data processing filter value
@@ -343,6 +341,6 @@ class TestE2eFogPairPi:
             actual_read_values.append(itm['reading'][CSV_HEADERS])
         assert expected_read_values == actual_read_values
 
-        if verify_north_data:
+        if skip_verify_north_interface:
             self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
                                 expected_read_values)

--- a/tests/system/python/e2e/test_e2e_foglamp_pair.py
+++ b/tests/system/python/e2e/test_e2e_foglamp_pair.py
@@ -267,7 +267,7 @@ class TestE2eFogPairPi:
 
     def test_end_to_end(self, start_south_north_remote, start_south_north_local,
                         read_data_from_pi, retries, pi_host, pi_admin, pi_passwd, pi_db,
-                        foglamp_url, remote_ip, wait_time):
+                        foglamp_url, remote_ip, wait_time, verify_north_data):
         """ Test that data is inserted in FogLAMP (local instance) using playback south plugin,
             sinusoid south plugin and expression south plugin and sent to http north (filter only playback data),
             FogLAMP (remote instance) receive this data via http south and send to PI
@@ -282,6 +282,7 @@ class TestE2eFogPairPi:
             foglamp_url: Local FogLAMP URL
             remote_ip: IP address where 2 FogLAMP is running (Remote)
             wait_time: time to wait in sec before making assertions
+            verify_north_data: Flag for assertion of data from Pi web API
             Assertions:
                 on endpoint GET /foglamp/asset
                 on endpoint GET /foglamp/asset/<asset_name> with applied data processing filter value
@@ -342,5 +343,6 @@ class TestE2eFogPairPi:
             actual_read_values.append(itm['reading'][CSV_HEADERS])
         assert expected_read_values == actual_read_values
 
-        self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
-                            expected_read_values)
+        if verify_north_data:
+            self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
+                                expected_read_values)

--- a/tests/system/python/e2e/test_e2e_foglamp_pair.py
+++ b/tests/system/python/e2e/test_e2e_foglamp_pair.py
@@ -341,6 +341,6 @@ class TestE2eFogPairPi:
             actual_read_values.append(itm['reading'][CSV_HEADERS])
         assert expected_read_values == actual_read_values
 
-        if skip_verify_north_interface:
+        if not skip_verify_north_interface:
             self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries,
                                 expected_read_values)

--- a/tests/system/python/e2e/test_e2e_kafka.py
+++ b/tests/system/python/e2e/test_e2e_kafka.py
@@ -13,6 +13,7 @@ import http.client
 import json
 import time
 import pytest
+import utils
 
 
 __author__ = "Ashish Jabble"
@@ -48,10 +49,7 @@ class TestE2EKafka:
         assert 200 == r.status
         r = r.read().decode()
         jdoc = json.loads(r)
-        actual_stats_map = {}
-        for itm in jdoc:
-            actual_stats_map[itm['key']] = itm['value']
-        return actual_stats_map
+        return utils.serialize_stats_map(jdoc)
 
     def _prepare_template_reading_from_fogbench(self):
         """ Define the template file for fogbench readings """
@@ -119,10 +117,10 @@ class TestE2EKafka:
         remove_directories("/tmp/foglamp-north-{}".format(NORTH_PLUGIN_NAME.lower()))
 
     def test_end_to_end(self, start_south_north, foglamp_url, wait_time, kafka_host, kafka_rest_port, kafka_topic,
-                        verify_north_data):
+                        skip_verify_north_interface):
         """ Test that data is inserted in FogLAMP and sent to Kafka
             start_south_north: Fixture that starts FogLAMP with south and north instance
-            verify_north_data: Flag for assertion of data from kafka rest
+            skip_verify_north_interface: Flag for assertion of data from kafka rest
             Assertions:
                 on endpoint GET /foglamp/asset
                 on endpoint GET /foglamp/asset/<asset_name>
@@ -161,7 +159,7 @@ class TestE2EKafka:
         assert 1 == len(val)
         assert {'sensor': SENSOR_VALUE} == val[0]["reading"]
 
-        if verify_north_data:
+        if skip_verify_north_interface:
             self._read_from_kafka(kafka_host, kafka_rest_port, kafka_topic)
 
     def _read_from_kafka(self, host, rest_port, topic):

--- a/tests/system/python/e2e/test_e2e_kafka.py
+++ b/tests/system/python/e2e/test_e2e_kafka.py
@@ -159,7 +159,7 @@ class TestE2EKafka:
         assert 1 == len(val)
         assert {'sensor': SENSOR_VALUE} == val[0]["reading"]
 
-        if skip_verify_north_interface:
+        if not skip_verify_north_interface:
             self._read_from_kafka(kafka_host, kafka_rest_port, kafka_topic)
 
     def _read_from_kafka(self, host, rest_port, topic):

--- a/tests/system/python/e2e/test_e2e_vary_asset_http_pi.py
+++ b/tests/system/python/e2e/test_e2e_vary_asset_http_pi.py
@@ -168,7 +168,7 @@ class TestE2EAssetHttpPI:
         assert sensor_data[1] == retval[4]["reading"]
         assert sensor_data[0] == retval[5]["reading"]
 
-        if skip_verify_north_interface:
+        if not skip_verify_north_interface:
             # Allow some buffer so that data is ingested in PI before fetching using PI Web API
             time.sleep(wait_time)
             self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name,

--- a/tests/system/python/e2e/test_e2e_vary_asset_http_pi.py
+++ b/tests/system/python/e2e/test_e2e_vary_asset_http_pi.py
@@ -23,91 +23,35 @@ __version__ = "${VERSION}"
 
 
 class TestE2EAssetHttpPI:
-
-    @pytest.fixture
-    def start_south_north(self, reset_and_start_foglamp, add_south, start_north_pi_server_c, remove_directories,
-                          south_branch, foglamp_url, pi_host, pi_port, pi_token):
-        """ This fixture clone a south repo and starts both south and north instance
-            reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
-            add_south: Fixture that adds a south service with given configuration
-            start_north_pi_server_c: Fixture that starts PI north task
-            remove_directories: Fixture that remove directories created during the tests"""
-
-        south_plugin = "http"
-        add_south("http_south", south_branch, foglamp_url, config={"assetNamePrefix": {"value": ""}},
-                  service_name="http_south")
-        start_north_pi_server_c(foglamp_url, pi_host, pi_port, pi_token)
-
-        yield self.start_south_north
-
-        # Cleanup code that runs after the caller test is over
-        remove_directories("/tmp/foglamp-south-{}".format(south_plugin))
-
-    def test_end_to_end(self, start_south_north, read_data_from_pi, foglamp_url, pi_host, pi_admin, pi_passwd, pi_db,
-                        wait_time, retries):
-        """ Test that data is inserted in FogLAMP and sent to PI
-            start_south_north: Fixture that starts FogLAMP with south and north instance
-            read_data_from_pi: Fixture to read data from PI
-            Assertions:
-                on endpoint GET /foglamp/asset
-                on endpoint GET /foglamp/asset/<asset_name>
-                data received from PI is same as data sent"""
-
-        conn = http.client.HTTPConnection(foglamp_url)
-
-        # Send data to foglamp-south-http
-        conn_http_south = http.client.HTTPConnection("localhost:6683")
-
-        asset_name = "e2e_varying"
-        # 2 list having mixed data simulating different sensors
-        # (sensors coming up and down, sensors throwing int and float data)
-        sensor_data = [{"a": 1}, {"a": 2, "b": 3}, {"b": 4}]
-        sensor_data_2 = [{"b": 1.1}, {"a2": 2, "b2": 3}, {"a": 4.0}]
-        for d in sensor_data + sensor_data_2:
-            tm = str(datetime.now(timezone.utc).astimezone())
-            data = [{"asset": "{}".format(asset_name), "timestamp": "{}".format(tm), "key": str(uuid.uuid4()),
-                     "readings": d}]
-            conn_http_south.request("POST", '/sensor-reading', json.dumps(data))
-            r = conn_http_south.getresponse()
-            assert 200 == r.status
-            r = r.read().decode()
-            jdoc = json.loads(r)
-            assert {'result': 'success'} == jdoc
-
-        # Allow some buffer so that data is ingested before retrieval
-        time.sleep(wait_time)
-
-        conn.request("GET", '/foglamp/asset')
-        r = conn.getresponse()
+    def get_ping_status(self, foglamp_url):
+        _connection = http.client.HTTPConnection(foglamp_url)
+        _connection.request("GET", '/foglamp/ping')
+        r = _connection.getresponse()
         assert 200 == r.status
         r = r.read().decode()
-        retval = json.loads(r)
-        assert len(retval) == 1
-        assert asset_name == retval[0]["assetCode"]
-        assert 6 == retval[0]["count"]
+        jdoc = json.loads(r)
+        return jdoc
 
-        conn.request("GET", '/foglamp/asset/{}'.format(asset_name))
-        r = conn.getresponse()
+    def get_statistics_map(self, foglamp_url):
+        _connection = http.client.HTTPConnection(foglamp_url)
+        _connection.request("GET", '/foglamp/statistics')
+        r = _connection.getresponse()
         assert 200 == r.status
         r = r.read().decode()
-        retval = json.loads(r)
+        jdoc = json.loads(r)
+        actual_stats_map = {}
+        for itm in jdoc:
+            actual_stats_map[itm['key']] = itm['value']
+        return actual_stats_map
 
-        assert sensor_data_2[2] == retval[0]["reading"]
-        assert sensor_data_2[1] == retval[1]["reading"]
-        assert sensor_data_2[0] == retval[2]["reading"]
-        assert sensor_data[2] == retval[3]["reading"]
-        assert sensor_data[1] == retval[4]["reading"]
-        assert sensor_data[0] == retval[5]["reading"]
-
-        # Allow some buffer so that data is ingested in PI before fetching using PI Web API
-        time.sleep(wait_time)
-
+    def _verify_egress(self, read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name,
+                       sensor_data, sensor_data_2):
         retry_count = 0
         data_from_pi = None
         while (data_from_pi is None or data_from_pi == []) and retry_count < retries:
             data_from_pi = read_data_from_pi(pi_host, pi_admin, pi_passwd, pi_db, asset_name, {"a", "b", "a2", "b2"})
             retry_count += 1
-            time.sleep(wait_time*2)
+            time.sleep(wait_time * 2)
 
         if data_from_pi is None or retry_count == retries:
             assert False, "Failed to read data from PI"
@@ -139,6 +83,99 @@ class TestE2EAssetHttpPI:
         assert data_from_pi["a2"][-4] == 0.0
         assert data_from_pi["a2"][-5] == 0.0
         assert data_from_pi["a2"][-6] == 0.0
+
+    @pytest.fixture
+    def start_south_north(self, reset_and_start_foglamp, add_south, start_north_pi_server_c, remove_directories,
+                          south_branch, foglamp_url, pi_host, pi_port, pi_token):
+        """ This fixture clone a south repo and starts both south and north instance
+            reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
+            add_south: Fixture that adds a south service with given configuration
+            start_north_pi_server_c: Fixture that starts PI north task
+            remove_directories: Fixture that remove directories created during the tests"""
+
+        south_plugin = "http"
+        add_south("http_south", south_branch, foglamp_url, config={"assetNamePrefix": {"value": ""}},
+                  service_name="http_south")
+        start_north_pi_server_c(foglamp_url, pi_host, pi_port, pi_token)
+
+        yield self.start_south_north
+
+        # Cleanup code that runs after the caller test is over
+        remove_directories("/tmp/foglamp-south-{}".format(south_plugin))
+
+    def test_end_to_end(self, start_south_north, read_data_from_pi, foglamp_url, pi_host, pi_admin, pi_passwd, pi_db,
+                        wait_time, retries, verify_north_data):
+        """ Test that data is inserted in FogLAMP and sent to PI
+            start_south_north: Fixture that starts FogLAMP with south and north instance
+            read_data_from_pi: Fixture to read data from PI
+            verify_north_data: Flag for assertion of data from Pi web API
+            Assertions:
+                on endpoint GET /foglamp/asset
+                on endpoint GET /foglamp/asset/<asset_name>
+                data received from PI is same as data sent"""
+
+        conn = http.client.HTTPConnection(foglamp_url)
+
+        # Send data to foglamp-south-http
+        conn_http_south = http.client.HTTPConnection("localhost:6683")
+
+        asset_name = "e2e_varying"
+        # 2 list having mixed data simulating different sensors
+        # (sensors coming up and down, sensors throwing int and float data)
+        sensor_data = [{"a": 1}, {"a": 2, "b": 3}, {"b": 4}]
+        sensor_data_2 = [{"b": 1.1}, {"a2": 2, "b2": 3}, {"a": 4.0}]
+        for d in sensor_data + sensor_data_2:
+            tm = str(datetime.now(timezone.utc).astimezone())
+            data = [{"asset": "{}".format(asset_name), "timestamp": "{}".format(tm), "key": str(uuid.uuid4()),
+                     "readings": d}]
+            conn_http_south.request("POST", '/sensor-reading', json.dumps(data))
+            r = conn_http_south.getresponse()
+            assert 200 == r.status
+            r = r.read().decode()
+            jdoc = json.loads(r)
+            assert {'result': 'success'} == jdoc
+
+        # Allow some buffer so that data is ingested before retrieval
+        time.sleep(wait_time)
+
+        ping_response = self.get_ping_status(foglamp_url)
+        assert 6 == ping_response["dataRead"]
+        assert 6 == ping_response["dataSent"]
+
+        actual_stats_map = self.get_statistics_map(foglamp_url)
+        assert 6 == actual_stats_map[asset_name.upper()]
+        assert 6 == actual_stats_map['NorthReadingsToPI']
+        assert 6 == actual_stats_map['READINGS']
+        assert 6 == actual_stats_map['Readings Sent']
+
+        conn.request("GET", '/foglamp/asset')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        retval = json.loads(r)
+        assert len(retval) == 1
+        assert asset_name == retval[0]["assetCode"]
+        assert 6 == retval[0]["count"]
+
+        conn.request("GET", '/foglamp/asset/{}'.format(asset_name))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        retval = json.loads(r)
+
+        assert sensor_data_2[2] == retval[0]["reading"]
+        assert sensor_data_2[1] == retval[1]["reading"]
+        assert sensor_data_2[0] == retval[2]["reading"]
+        assert sensor_data[2] == retval[3]["reading"]
+        assert sensor_data[1] == retval[4]["reading"]
+        assert sensor_data[0] == retval[5]["reading"]
+
+        if verify_north_data:
+            # Allow some buffer so that data is ingested in PI before fetching using PI Web API
+            time.sleep(wait_time)
+            self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, asset_name,
+                                sensor_data, sensor_data_2)
+
 
 
 

--- a/tests/system/python/helpers/utils.py
+++ b/tests/system/python/helpers/utils.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+"""Utility methods"""
+
+
+def serialize_stats_map(jdoc):
+    actual_stats_map = {}
+    for itm in jdoc:
+        actual_stats_map[itm['key']] = itm['value']
+    return actual_stats_map

--- a/tests/system/python/smoke/test_smoke.py
+++ b/tests/system/python/smoke/test_smoke.py
@@ -13,6 +13,7 @@ import http.client
 import json
 import time
 import pytest
+import utils
 
 
 __author__ = "Vaibhav Singhal"
@@ -41,10 +42,7 @@ def get_statistics_map(foglamp_url):
     assert 200 == r.status
     r = r.read().decode()
     jdoc = json.loads(r)
-    actual_stats_map = {}
-    for itm in jdoc:
-        actual_stats_map[itm['key']] = itm['value']
-    return actual_stats_map
+    return utils.serialize_stats_map(jdoc)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes the following:

- [X] Assertion added to verify ping response
- [X] Assertion added to verify statistics response
- [X] verify_egress method added to wrap assertions from north api
- [X] flag added to verify data at north side (default value is true)