### PR TITLE
FOGL-2621 plugin discovery system tests added

### DIFF
--- a/tests/system/python/api/test_plugin_discovery.py
+++ b/tests/system/python/api/test_plugin_discovery.py
@@ -32,8 +32,12 @@ def install_plugin(type, plugin, branch="develop", plugin_lang="python", use_pip
         assert False, "{} plugin installation failed".format(plugin)
 
     # Cleanup code
+    if type == "notificationDelivery":
+        type = "notify"
+    if type == "notificationRule":
+        type = "rule"
+        subprocess.run(["rm -rf /tmp/foglamp-service-notification"], shell=True, check=True)
     subprocess.run(["rm -rf /tmp/foglamp-{}-{}".format(type, plugin)], shell=True, check=True)
-    # TODO: FOGL-2642 - Remove notificationDelivery And notificationRule plugins
 
 
 @pytest.fixture
@@ -53,32 +57,42 @@ def reset_plugins():
     subprocess.run(["path=$FOGLAMP_ROOT/plugins/filter; "
                     "find $path -maxdepth 1 | grep -v \"^${path}$\" | "
                     "egrep -v '(common)' | xargs rm -rf"], shell=True, check=True)
-    # TODO: FOGL-2642 - reset notificationDelivery And notificationRule plugins
+    subprocess.run(["rm -rf $FOGLAMP_ROOT/plugins/notificationDelivery"], shell=True, check=True)
+    subprocess.run(["rm -rf $FOGLAMP_ROOT/plugins/notificationRule"], shell=True, check=True)
 
 
 class TestPluginDiscovery:
 
-    def test_default_all_plugins_installed(self, reset_plugins, reset_and_start_foglamp, foglamp_url):
+    def test_cleanup(self, reset_plugins, reset_and_start_foglamp):
+        # TODO: Remove this workaround
+        # This test to reset stuff And especially to avoid multiple fixture calls when parameterized tests
+        pass
+
+    @pytest.mark.parametrize("param, config", [
+        ("", False),
+        ("?config=false", False),
+        ("?config=true", True)
+    ])
+    def test_default_all_plugins_installed(self, foglamp_url, param, config):
         conn = http.client.HTTPConnection(foglamp_url)
-        conn.request("GET", '/foglamp/plugins/installed')
+        conn.request("GET", '/foglamp/plugins/installed{}'.format(param))
         r = conn.getresponse()
         assert 200 == r.status
         r = r.read().decode()
         jdoc = json.loads(r)
+        # Only north plugins (2 north_c and 2 north python) expected by default
         assert 4 == len(jdoc['plugins'])
         for plugin in jdoc['plugins']:
             assert 'north' == plugin['type']
-            assert 'south' not in plugin['type']
-            assert 'filter' not in plugin['type']
-            assert 'notify' not in plugin['type']
-            assert 'rule' not in plugin['type']
-            assert 'config' not in plugin
+            assert plugin['type'] not in ['south', 'filter', 'notificationDelivery', 'notificationRule']
+            # config is not expected by default
+            assert 'config' in plugin if config else 'config' not in plugin
 
     @pytest.mark.parametrize("method, count, config", [
         ("/foglamp/plugins/installed?type=south", 0, None),
         ("/foglamp/plugins/installed?type=filter", 0, None),
-        ("/foglamp/plugins/installed?type=notify", 0, None),
-        ("/foglamp/plugins/installed?type=rule", 0, None),
+        ("/foglamp/plugins/installed?type=notificationDelivery", 0, None),
+        ("/foglamp/plugins/installed?type=notificationRule", 0, None),
         ("/foglamp/plugins/installed?type=north&config=false", 4, False),
         ("/foglamp/plugins/installed?type=north&config=true", 4, True)
     ])
@@ -94,10 +108,11 @@ class TestPluginDiscovery:
         for plugin in jdoc['plugins']:
             assert 'config' in plugin if config else 'config' not in plugin
             name.append(plugin['name'])
+        # Verify only 4 north plugins when type is north
         if count == 4:
             assert Counter(['ocs', 'pi_server', 'PI_Server_V2', 'ocs_V2']) == Counter(name)
 
-    def test_south_plugins_installed(self, reset_plugins, foglamp_url):
+    def test_south_plugins_installed(self, foglamp_url):
         install_plugin(type='south', plugin='sinusoid', plugin_lang='python')
 
         conn = http.client.HTTPConnection(foglamp_url)
@@ -124,9 +139,9 @@ class TestPluginDiscovery:
         assert 'sinusoid' == plugins[0]['name']
         assert 'Random' == plugins[1]['name']
 
-    def test_north_plugins_installed(self, reset_plugins, foglamp_url):
+    def test_north_plugins_installed(self, foglamp_url):
+        # install north plugin (Python version)
         install_plugin(type='north', plugin='http', plugin_lang='python')
-
         conn = http.client.HTTPConnection(foglamp_url)
         conn.request("GET", '/foglamp/plugins/installed?type=north')
         r = conn.getresponse()
@@ -136,12 +151,13 @@ class TestPluginDiscovery:
         assert len(jdoc), "No data found"
         plugins = jdoc['plugins']
         plugin_names = [name['name'] for name in plugins]
+        # verify north plugins which is 4 by default and a new one (http) installed
         assert 5 == len(plugins)
         assert Counter(['ocs', 'http_north', 'pi_server', 'PI_Server_V2',
                         'ocs_V2']) == Counter(plugin_names)
 
-        install_plugin(type='north', plugin='thingspeak', plugin_lang='c')
-
+        # install one more north plugin (C version)
+        install_plugin(type='north', plugin='thingspeak', plugin_lang='C')
         conn.request("GET", '/foglamp/plugins/installed?type=north')
         r = conn.getresponse()
         assert 200 == r.status
@@ -150,13 +166,14 @@ class TestPluginDiscovery:
         assert len(jdoc), "No data found"
         plugins = jdoc['plugins']
         plugin_names = [name['name'] for name in plugins]
+        # verify north plugins which is 4 by default and 2 new one (Python & C version) installed
         assert 6 == len(plugins)
         assert Counter(['ocs', 'http_north', 'pi_server', 'PI_Server_V2', 'ThingSpeak',
                         'ocs_V2']) == Counter(plugin_names)
 
-    def test_filter_plugins_installed(self, reset_plugins, foglamp_url):
-        install_plugin(type='filter', plugin='rms', plugin_lang='c')
-
+    def test_filter_plugins_installed(self, foglamp_url):
+        # install rms filter plugin
+        install_plugin(type='filter', plugin='rms', plugin_lang='C')
         conn = http.client.HTTPConnection(foglamp_url)
         conn.request("GET", '/foglamp/plugins/installed?type=filter')
         r = conn.getresponse()
@@ -168,10 +185,30 @@ class TestPluginDiscovery:
         assert 1 == len(plugins)
         assert 'rms' == plugins[0]['name']
 
-    @pytest.mark.skip(reason='FOGL-2642')
-    def test_delivery_plugins_installed(self, reset_plugins, foglamp_url):
-        pass
+    def test_delivery_plugins_installed(self, foglamp_url):
+        # install slack delivery plugin
+        install_plugin(type='notificationDelivery', plugin='slack', plugin_lang='C')
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/plugins/installed?type=notificationDelivery')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        plugins = jdoc['plugins']
+        assert 1 == len(plugins)
+        assert 'slack' == plugins[0]['name']
 
-    @pytest.mark.skip(reason='FOGL-2642')
-    def test_rule_plugins_installed(self, reset_plugins, foglamp_url):
-        pass
+    def test_rule_plugins_installed(self, foglamp_url):
+        # install outofbound rule plugin
+        install_plugin(type='notificationRule', plugin='outofbound', plugin_lang='C')
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/plugins/installed?type=notificationRule')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        plugins = jdoc['plugins']
+        assert 1 == len(plugins)
+        assert 'OutOfBound' == plugins[0]['name']

--- a/tests/system/python/api/test_plugin_discovery.py
+++ b/tests/system/python/api/test_plugin_discovery.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Test plugin discovery (north, south, filter, notificationDelivery, notificationRule) REST API """
+
+import subprocess
+import http.client
+import json
+from collections import Counter
+import pytest
+
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2019 Dianomic Systems"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+def install_plugin(type, plugin, branch="develop", plugin_lang="python", use_pip_cache=True):
+    if plugin_lang == "python":
+        path = "$FOGLAMP_ROOT/tests/system/python/scripts/install_python_plugin {} {} {} {}".format(
+            branch, type, plugin, use_pip_cache)
+    else:
+        path = "$FOGLAMP_ROOT/tests/system/python/scripts/install_c_plugin {} {} {}".format(
+            branch, type, plugin)
+    try:
+        subprocess.run([path], shell=True, check=True)
+    except subprocess.CalledProcessError:
+        assert False, "{} plugin installation failed".format(plugin)
+
+    # Cleanup code
+    subprocess.run(["rm -rf /tmp/foglamp-{}-{}".format(type, plugin)], shell=True, check=True)
+    # TODO: FOGL-2642 - Remove notificationDelivery And notificationRule plugins
+
+
+@pytest.fixture
+def reset_plugins():
+    subprocess.run(["rm -rf $FOGLAMP_ROOT/plugins/south"], shell=True, check=True)
+    subprocess.run(["path=$FOGLAMP_ROOT/python/foglamp/plugins/south; "
+                    "find $path -maxdepth 1 | grep -v \"^${path}$\" | "
+                    "egrep -v '(__init__.py)' | xargs rm -rf"], shell=True, check=True)
+    subprocess.run(["path=$FOGLAMP_ROOT/python/foglamp/plugins/north; "
+                    "find $path -maxdepth 1 | grep -v \"^${path}$\" | "
+                    "egrep -v '(pi_server|ocs|common|empty|README.rst|__init__.py)' | xargs rm -rf"],
+                   shell=True, check=True)
+    subprocess.run(["path=$FOGLAMP_ROOT/plugins/north; "
+                    "find $path -maxdepth 1 | grep -v \"^${path}$\" | "
+                    "egrep -v '(PI_Server_V2|ocs_V2)' | xargs rm -rf"],
+                   shell=True, check=True)
+    subprocess.run(["path=$FOGLAMP_ROOT/plugins/filter; "
+                    "find $path -maxdepth 1 | grep -v \"^${path}$\" | "
+                    "egrep -v '(common)' | xargs rm -rf"], shell=True, check=True)
+    # TODO: FOGL-2642 - reset notificationDelivery And notificationRule plugins
+
+
+class TestPluginDiscovery:
+
+    def test_default_all_plugins_installed(self, reset_plugins, reset_and_start_foglamp, foglamp_url):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/plugins/installed')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert 4 == len(jdoc['plugins'])
+        for plugin in jdoc['plugins']:
+            assert 'north' == plugin['type']
+            assert 'south' not in plugin['type']
+            assert 'filter' not in plugin['type']
+            assert 'notify' not in plugin['type']
+            assert 'rule' not in plugin['type']
+            assert 'config' not in plugin
+
+    @pytest.mark.parametrize("method, count, config", [
+        ("/foglamp/plugins/installed?type=south", 0, None),
+        ("/foglamp/plugins/installed?type=filter", 0, None),
+        ("/foglamp/plugins/installed?type=notify", 0, None),
+        ("/foglamp/plugins/installed?type=rule", 0, None),
+        ("/foglamp/plugins/installed?type=north&config=false", 4, False),
+        ("/foglamp/plugins/installed?type=north&config=true", 4, True)
+    ])
+    def test_default_plugins_installed_by_type(self, foglamp_url, method, count, config):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", method)
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert count == len(jdoc['plugins'])
+        name = []
+        for plugin in jdoc['plugins']:
+            assert 'config' in plugin if config else 'config' not in plugin
+            name.append(plugin['name'])
+        if count == 4:
+            assert Counter(['ocs', 'pi_server', 'PI_Server_V2', 'ocs_V2']) == Counter(name)
+
+    def test_south_plugins_installed(self, reset_plugins, foglamp_url):
+        install_plugin(type='south', plugin='sinusoid', plugin_lang='python')
+
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/plugins/installed?type=south')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        plugins = jdoc['plugins']
+        assert 1 == len(plugins)
+        assert 'sinusoid' == plugins[0]['name']
+
+        install_plugin(type='south', plugin='random', plugin_lang='C')
+
+        conn.request("GET", '/foglamp/plugins/installed?type=south')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        plugins = jdoc['plugins']
+        assert 2 == len(plugins)
+        assert 'sinusoid' == plugins[0]['name']
+        assert 'Random' == plugins[1]['name']
+
+    def test_north_plugins_installed(self, reset_plugins, foglamp_url):
+        install_plugin(type='north', plugin='http', plugin_lang='python')
+
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/plugins/installed?type=north')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        plugins = jdoc['plugins']
+        plugin_names = [name['name'] for name in plugins]
+        assert 5 == len(plugins)
+        assert Counter(['ocs', 'http_north', 'pi_server', 'PI_Server_V2',
+                        'ocs_V2']) == Counter(plugin_names)
+
+        install_plugin(type='north', plugin='thingspeak', plugin_lang='c')
+
+        conn.request("GET", '/foglamp/plugins/installed?type=north')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        plugins = jdoc['plugins']
+        plugin_names = [name['name'] for name in plugins]
+        assert 6 == len(plugins)
+        assert Counter(['ocs', 'http_north', 'pi_server', 'PI_Server_V2', 'ThingSpeak',
+                        'ocs_V2']) == Counter(plugin_names)
+
+    def test_filter_plugins_installed(self, reset_plugins, foglamp_url):
+        install_plugin(type='filter', plugin='rms', plugin_lang='c')
+
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/plugins/installed?type=filter')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        plugins = jdoc['plugins']
+        assert 1 == len(plugins)
+        assert 'rms' == plugins[0]['name']
+
+    @pytest.mark.skip(reason='FOGL-2642')
+    def test_delivery_plugins_installed(self, reset_plugins, foglamp_url):
+        pass
+
+    @pytest.mark.skip(reason='FOGL-2642')
+    def test_rule_plugins_installed(self, reset_plugins, foglamp_url):
+        pass

--- a/tests/system/python/scripts/install_c_plugin
+++ b/tests/system/python/scripts/install_c_plugin
@@ -19,13 +19,18 @@ PLUGIN_NAME=$3
 [[ -z "${PLUGIN_TYPE}" ]] && echo "Plugin type not found." && exit 1
 [[ -z "${PLUGIN_NAME}" ]] && echo "Plugin name not found." && exit 1
 
-###########################################################################################
+###############################################################################################################
 # FIXME: As some of the C-plugins are having different project name & repo name convention
 # So when we are using this script we need to check carefully about the convention
 # Plugin name converted to lowercase for repo name
-###########################################################################################
+# For PLUGIN_TYPE 'notificationDelivery' & 'notificationRule', In REPO_NAME type converted to 'notify' & 'rule'
+###############################################################################################################
 
 REPO_NAME=foglamp-${PLUGIN_TYPE}-${PLUGIN_NAME,,}
+
+if [[ "${PLUGIN_TYPE}" = "notificationDelivery" ]]; then REPO_NAME=foglamp-notify-${PLUGIN_NAME,,}; fi
+if [[ "${PLUGIN_TYPE}" = "notificationRule" ]]; then rm -rf /tmp/foglamp-service-notification; REPO_NAME=foglamp-rule-${PLUGIN_NAME,,}; fi
+
 
 clean () {
    rm -rf /tmp/${REPO_NAME}
@@ -36,14 +41,25 @@ clone_repo () {
    git clone -b ${BRANCH_NAME} --single-branch https://github.com/foglamp/${REPO_NAME}.git /tmp/${REPO_NAME}
 }
 
-req_file=$(find . -name requirement*.sh)
-[[ ! -z "${req_file}" ]] && ./${req_file} || echo "No external dependency needed for ${PLUGIN_NAME} plugin."
+install_requirement (){
+    req_file=$(find /tmp/${REPO_NAME} -name requirement*.sh)
+    [[ ! -z "${req_file}" ]] && sh ${req_file} || echo "No external dependency needed for ${PLUGIN_NAME} plugin."
+}
 
 install_binary_file () {
+   if [[ "${PLUGIN_TYPE}" = "notificationRule" ]]
+   then
+        # foglamp-service-notification repo is required to build notificationRule Plugins
+        service_repo_name='foglamp-service-notification'
+        git clone -b ${BRANCH_NAME} --single-branch https://github.com/foglamp/${service_repo_name}.git /tmp/${service_repo_name}
+        export NOTIFICATION_SERVICE_INCLUDE_DIRS=/tmp/${service_repo_name}/C/services/common/include
+   fi
+
    mkdir -p /tmp/${REPO_NAME}/build; cd /tmp/${REPO_NAME}/build; cmake -DFOGLAMP_INSTALL=${FOGLAMP_ROOT} ..; make -j4 && make install; cd -
 }
 
 clean
 clone_repo
+install_requirement
 install_binary_file
 echo "${PLUGIN_NAME} plugin is installed."

--- a/tests/system/python/scripts/reset_plugins
+++ b/tests/system/python/scripts/reset_plugins
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -e
+
+__author__="Ashish Jabble"
+__copyright__="Copyright (c) 2019 Dianomic Systems"
+__license__="Apache 2.0"
+__version__="1.0.0"
+
+#########################################################
+# Usage text for this script
+# $FOGLAMP_ROOT/tests/system/python/scripts/reset_plugins
+#########################################################
+
+remove_south_python () {
+    path="$FOGLAMP_ROOT/python/foglamp/plugins/south"
+    find ${path} -maxdepth 1 | grep -v "^${path}$" | egrep -v '(__init__.py)' | xargs rm -rf
+}
+
+remove_south_c () {
+    rm -rf $FOGLAMP_ROOT/plugins/south
+}
+
+remove_north_python () {
+    path="$FOGLAMP_ROOT/python/foglamp/plugins/north"
+    find ${path} -maxdepth 1 | grep -v "^${path}$" | egrep -v '(pi_server|ocs|common|empty|README.rst|__init__.py)' | xargs rm -rf
+}
+
+remove_north_c () {
+    path="$FOGLAMP_ROOT/plugins/north"
+    find ${path} -maxdepth 1 | grep -v "^${path}$" | egrep -v '(PI_Server_V2|ocs_V2)' | xargs rm -rf
+}
+
+remove_filter () {
+    path="$FOGLAMP_ROOT/plugins/filter"
+    find ${path} -maxdepth 1 | grep -v "^${path}$" | egrep -v '(common)' | xargs rm -rf
+}
+
+remove_notification_delivery () {
+    rm -rf $FOGLAMP_ROOT/plugins/notificationDelivery
+}
+
+remove_notification_rule () {
+    rm -rf $FOGLAMP_ROOT/plugins/notificationRule
+}
+
+remove_all () {
+    remove_south_python
+    remove_south_c
+    remove_north_python
+    remove_north_c
+    remove_filter
+    remove_notification_delivery
+    remove_notification_rule
+}
+
+remove_all
+echo "Removed all plugins..."


### PR DESCRIPTION
Verified on below environments: 
- [x] ub16.04
- [x] raspbian

**O/P**

```
$ pytest -s -vv test_plugin_discovery.py
============================================================= test session starts =============================================================
platform linux -- Python 3.5.3, pytest-3.6.0, py-1.8.0, pluggy-0.6.0 -- /usr/local/bin/python3.5
cachedir: ../.pytest_cache
rootdir: /home/foglamp/Development/systemTests/FogLAMP/tests/system/python, inifile: pytest.ini
plugins: mock-1.10.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 15 items                                                                                                                            

../TestPluginDiscovery test_cleanup <- api/test_plugin_discovery.py FogLAMP killed.
This script will remove all data stored in the SQLite3 datafile '/home/foglamp/Development/systemTests/FogLAMP/data/foglamp.db'
Enter YES if you want to continue: Starting FogLAMP v1.5.1......
FogLAMP started.
PASSED
../TestPluginDiscovery test_default_all_plugins_installed <- api/test_plugin_discovery.py PASSED
../TestPluginDiscovery test_default_all_plugins_installed <- api/test_plugin_discovery.py PASSED
../TestPluginDiscovery test_default_all_plugins_installed <- api/test_plugin_discovery.py PASSED
../TestPluginDiscovery test_default_plugins_installed_by_type <- api/test_plugin_discovery.py PASSED
../TestPluginDiscovery test_default_plugins_installed_by_type <- api/test_plugin_discovery.py PASSED
../TestPluginDiscovery test_default_plugins_installed_by_type <- api/test_plugin_discovery.py PASSED
../TestPluginDiscovery test_default_plugins_installed_by_type <- api/test_plugin_discovery.py PASSED
../TestPluginDiscovery test_default_plugins_installed_by_type <- api/test_plugin_discovery.py PASSED
../TestPluginDiscovery test_default_plugins_installed_by_type <- api/test_plugin_discovery.py PASSED
../TestPluginDiscovery test_south_plugins_installed <- api/test_plugin_discovery.py Cloning into '/tmp/foglamp-south-sinusoid'...
remote: Enumerating objects: 59, done.
remote: Counting objects: 100% (59/59), done.
remote: Compressing objects: 100% (24/24), done.
remote: Total 266 (delta 21), reused 36 (delta 15), pack-reused 207
Receiving objects: 100% (266/266), 46.77 KiB | 0 bytes/s, done.
Resolving deltas: 100% (83/83), done.
Checking connectivity... done.
No such external dependency needed for sinusoid plugin.
sinusoid plugin is installed.
Cloning into '/tmp/foglamp-south-random'...
remote: Enumerating objects: 58, done.
remote: Counting objects: 100% (58/58), done.
remote: Compressing objects: 100% (44/44), done.
remote: Total 158 (delta 20), reused 28 (delta 8), pack-reused 100
Receiving objects: 100% (158/158), 49.48 KiB | 0 bytes/s, done.
Resolving deltas: 100% (67/67), done.
Checking connectivity... done.
No external dependency needed for random plugin.
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is GNU 5.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- No options set.
   +Using found FOGLAMP_ROOT /home/foglamp/Development/systemTests/FogLAMP
-- Using FOGLAMP_ROOT for includes
   +/home/foglamp/Development/systemTests/FogLAMP/C/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/services/common/include
-- Using FOGLAMP_ROOT for libs 
   +/home/foglamp/Development/systemTests/FogLAMP/cmake_build/C/lib
-- Using third-party includes /home/foglamp/Development/systemTests/FogLAMP/C/thirdparty
-- Installing Random in /home/foglamp/Development/systemTests/FogLAMP/plugins/south/Random
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/foglamp-south-random/build
[ 25%] Generating version header
Scanning dependencies of target Random
[ 50%] Building CXX object CMakeFiles/Random.dir/plugin.o
[ 75%] Building CXX object CMakeFiles/Random.dir/random.o
[100%] Linking CXX shared library libRandom.so
[100%] Built target Random
[100%] Built target Random
Install the project...
-- Install configuration: ""
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/south/Random/libRandom.so.1
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/south/Random/libRandom.so
-- Set runtime path of "/home/foglamp/Development/systemTests/FogLAMP/plugins/south/Random/libRandom.so.1" to ""
/home/foglamp/Development/systemTests/FogLAMP/tests/system/python/api
random plugin is installed.
PASSED
../TestPluginDiscovery test_north_plugins_installed <- api/test_plugin_discovery.py Cloning into '/tmp/foglamp-north-http'...
remote: Enumerating objects: 35, done.
remote: Counting objects: 100% (35/35), done.
remote: Compressing objects: 100% (19/19), done.
remote: Total 254 (delta 5), reused 25 (delta 4), pack-reused 219
Receiving objects: 100% (254/254), 50.41 KiB | 0 bytes/s, done.
Resolving deltas: 100% (62/62), done.
Checking connectivity... done.
No such external dependency needed for http plugin.
http plugin is installed.
Cloning into '/tmp/foglamp-north-thingspeak'...
remote: Enumerating objects: 42, done.
remote: Counting objects: 100% (42/42), done.
remote: Compressing objects: 100% (30/30), done.
remote: Total 92 (delta 13), reused 22 (delta 6), pack-reused 50
Unpacking objects: 100% (92/92), done.
Checking connectivity... done.
No external dependency needed for thingspeak plugin.
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is GNU 5.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- No options set.
   +Using found FOGLAMP_ROOT /home/foglamp/Development/systemTests/FogLAMP
-- Using FOGLAMP_ROOT for includes
   +/home/foglamp/Development/systemTests/FogLAMP/C/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/services/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/plugins/filter/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/thirdparty/rapidjson/include
-- Using FOGLAMP_ROOT for libs 
   +/home/foglamp/Development/systemTests/FogLAMP/cmake_build/C/lib
-- Using third-party includes /home/foglamp/Development/systemTests/FogLAMP/C/thirdparty/Simple-Web-Server
-- Installing ThingSpeak in /home/foglamp/Development/systemTests/FogLAMP/plugins/north/ThingSpeak
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/foglamp-north-thingspeak/build
[ 25%] Generating version header
Scanning dependencies of target ThingSpeak
[ 50%] Building CXX object CMakeFiles/ThingSpeak.dir/ThingSpeak.o
[ 75%] Building CXX object CMakeFiles/ThingSpeak.dir/plugin.o
[100%] Linking CXX shared library libThingSpeak.so
[100%] Built target ThingSpeak
[100%] Built target ThingSpeak
Install the project...
-- Install configuration: ""
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/north/ThingSpeak/libThingSpeak.so.1
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/north/ThingSpeak/libThingSpeak.so
-- Set runtime path of "/home/foglamp/Development/systemTests/FogLAMP/plugins/north/ThingSpeak/libThingSpeak.so.1" to ""
/home/foglamp/Development/systemTests/FogLAMP/tests/system/python/api
thingspeak plugin is installed.
PASSED
../TestPluginDiscovery test_filter_plugins_installed <- api/test_plugin_discovery.py Cloning into '/tmp/foglamp-filter-rms'...
remote: Enumerating objects: 148, done.
remote: Counting objects: 100% (148/148), done.
remote: Compressing objects: 100% (76/76), done.
remote: Total 148 (delta 65), reused 112 (delta 42), pack-reused 0
Receiving objects: 100% (148/148), 40.81 KiB | 0 bytes/s, done.
Resolving deltas: 100% (65/65), done.
Checking connectivity... done.
No external dependency needed for rms plugin.
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is GNU 5.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- No options set.
   +Using found FOGLAMP_ROOT /home/foglamp/Development/systemTests/FogLAMP
-- Using FOGLAMP_ROOT for includes
   +/home/foglamp/Development/systemTests/FogLAMP/C/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/services/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/plugins/filter/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/thirdparty/rapidjson/include
-- Using FOGLAMP_ROOT for libs 
   +/home/foglamp/Development/systemTests/FogLAMP/cmake_build/C/lib
-- Using third-party includes /home/foglamp/Development/systemTests/FogLAMP/C/thirdparty/Simple-Web-Server
-- Installing rms in /home/foglamp/Development/systemTests/FogLAMP/plugins/filter/rms
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/foglamp-filter-rms/build
[ 25%] Generating version header
Scanning dependencies of target rms
[ 75%] Building CXX object CMakeFiles/rms.dir/plugin.cpp.o
[ 75%] Building CXX object CMakeFiles/rms.dir/rms.cpp.o
[100%] Linking CXX shared library librms.so
[100%] Built target rms
[100%] Built target rms
Install the project...
-- Install configuration: ""
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/filter/rms/librms.so.1
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/filter/rms/librms.so
-- Set runtime path of "/home/foglamp/Development/systemTests/FogLAMP/plugins/filter/rms/librms.so.1" to ""
/home/foglamp/Development/systemTests/FogLAMP/tests/system/python/api
rms plugin is installed.
PASSED
../TestPluginDiscovery test_delivery_plugins_installed <- api/test_plugin_discovery.py Cloning into '/tmp/foglamp-notify-slack'...
remote: Enumerating objects: 60, done.
remote: Counting objects: 100% (60/60), done.
remote: Compressing objects: 100% (31/31), done.
remote: Total 60 (delta 19), reused 46 (delta 13), pack-reused 0
Unpacking objects: 100% (60/60), done.
Checking connectivity... done.
[sudo] password for foglamp: 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
libcurl4-openssl-dev is already the newest version (7.47.0-1ubuntu2.12).
The following packages were automatically installed and are no longer required:
  libllvm5.0 linux-headers-4.13.0-41 linux-headers-4.13.0-41-generic linux-headers-4.13.0-43 linux-headers-4.13.0-43-generic
  linux-headers-4.13.0-45 linux-headers-4.13.0-45-generic linux-headers-4.15.0-29 linux-headers-4.15.0-29-generic
  linux-image-4.13.0-41-generic linux-image-4.13.0-43-generic linux-image-4.13.0-45-generic linux-image-4.15.0-29-generic
  linux-image-extra-4.13.0-41-generic linux-image-extra-4.13.0-43-generic linux-image-extra-4.13.0-45-generic linux-modules-4.15.0-29-generic
  linux-modules-extra-4.15.0-29-generic
Use 'sudo apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 37 not upgraded.
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is GNU 5.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- No options set.
   +Using found FOGLAMP_ROOT /home/foglamp/Development/systemTests/FogLAMP
-- Using FOGLAMP_ROOT for includes
   +/home/foglamp/Development/systemTests/FogLAMP/C/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/services/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/plugins/filter/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/thirdparty/rapidjson/include
-- Using FOGLAMP_ROOT for libs 
   +/home/foglamp/Development/systemTests/FogLAMP/cmake_build/C/lib
-- Using third-party includes /home/foglamp/Development/systemTests/FogLAMP/C/thirdparty/Simple-Web-Server
-- Installing slack in /home/foglamp/Development/systemTests/FogLAMP/plugins/notificationDelivery/slack
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/foglamp-notify-slack/build
[ 25%] Generating version header
Scanning dependencies of target slack
[ 50%] Building CXX object CMakeFiles/slack.dir/slack.cpp.o
[ 75%] Building CXX object CMakeFiles/slack.dir/plugin.cpp.o
[100%] Linking CXX shared library libslack.so
[100%] Built target slack
[100%] Built target slack
Install the project...
-- Install configuration: ""
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/notificationDelivery/slack/libslack.so.1
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/notificationDelivery/slack/libslack.so
-- Set runtime path of "/home/foglamp/Development/systemTests/FogLAMP/plugins/notificationDelivery/slack/libslack.so.1" to ""
/home/foglamp/Development/systemTests/FogLAMP/tests/system/python/api
slack plugin is installed.
PASSED
../TestPluginDiscovery test_rule_plugins_installed <- api/test_plugin_discovery.py Cloning into '/tmp/foglamp-rule-outofbound'...
remote: Enumerating objects: 42, done.
remote: Counting objects: 100% (42/42), done.
remote: Compressing objects: 100% (24/24), done.
remote: Total 42 (delta 8), reused 34 (delta 7), pack-reused 0
Unpacking objects: 100% (42/42), done.
Checking connectivity... done.
No external dependency needed for outofbound plugin.
Cloning into '/tmp/foglamp-service-notification'...
remote: Enumerating objects: 79, done.
remote: Counting objects: 100% (79/79), done.
remote: Compressing objects: 100% (43/43), done.
remote: Total 659 (delta 26), reused 56 (delta 19), pack-reused 580
Receiving objects: 100% (659/659), 198.00 KiB | 236.00 KiB/s, done.
Resolving deltas: 100% (389/389), done.
Checking connectivity... done.
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is GNU 5.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- No options set.
   +Using found FOGLAMP_ROOT /home/foglamp/Development/systemTests/FogLAMP
-- Using FOGLAMP_ROOT for includes
   +/home/foglamp/Development/systemTests/FogLAMP/C/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/services/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/plugins/filter/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/thirdparty/rapidjson/include
-- Using FOGLAMP_ROOT for libs 
   +/home/foglamp/Development/systemTests/FogLAMP/cmake_build/C/lib
-- Notification server includes dir set to /tmp/foglamp-service-notification/C/services/common/include
-- Using third-party includes /home/foglamp/Development/systemTests/FogLAMP/C/thirdparty/Simple-Web-Server
-- Installing OutOfBound in /home/foglamp/Development/systemTests/FogLAMP/plugins/notificationRule/OutOfBound
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/foglamp-rule-outofbound/build
[ 33%] Generating version header
Scanning dependencies of target OutOfBound
[ 66%] Building CXX object CMakeFiles/OutOfBound.dir/plugin.o
[100%] Linking CXX shared library libOutOfBound.so
[100%] Built target OutOfBound
[100%] Built target OutOfBound
Install the project...
-- Install configuration: ""
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/notificationRule/OutOfBound/libOutOfBound.so.1
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/notificationRule/OutOfBound/libOutOfBound.so
-- Set runtime path of "/home/foglamp/Development/systemTests/FogLAMP/plugins/notificationRule/OutOfBound/libOutOfBound.so.1" to ""
/home/foglamp/Development/systemTests/FogLAMP/tests/system/python/api
outofbound plugin is installed.
PASSED
====== 15 passed in 76.38 seconds ====
```