### PR TITLE
FOGL-2642 fixes to find notification delivery and rule plugins in plugin_discovery API

### DIFF
--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -32,8 +32,8 @@ class PluginDiscovery(object):
             plugins_list_c_north = cls.fetch_c_plugins_installed("north", is_config)
             plugins_list_c_south = cls.fetch_c_plugins_installed("south", is_config)
             plugins_list_c_filter = cls.fetch_c_plugins_installed("filter", is_config)
-            plugins_list_c_notify = cls.fetch_c_plugins_installed("notify", is_config)
-            plugins_list_c_rule = cls.fetch_c_plugins_installed("rule", is_config)
+            plugins_list_c_notify = cls.fetch_c_plugins_installed("notificationDelivery", is_config)
+            plugins_list_c_rule = cls.fetch_c_plugins_installed("notificationRule", is_config)
             plugins_list.extend(plugins_list_north)
             plugins_list.extend(plugins_list_c_north)
             plugins_list.extend(plugins_list_south)
@@ -41,7 +41,7 @@ class PluginDiscovery(object):
             plugins_list.extend(plugins_list_c_filter)
             plugins_list.extend(plugins_list_c_notify)
             plugins_list.extend(plugins_list_c_rule)
-        elif plugin_type in ['filter', 'notify', 'rule']:
+        elif plugin_type in ['filter', 'notificationDelivery', 'notificationRule']:
             plugins_list = cls.fetch_c_plugins_installed(plugin_type, is_config)
         else:
             plugins_list = cls.fetch_plugins_installed(plugin_type, is_config)

--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -26,17 +26,17 @@ async def get_plugins_installed(request):
     :Example:
         curl -X GET http://localhost:8081/foglamp/plugins/installed
         curl -X GET http://localhost:8081/foglamp/plugins/installed?config=true
-        curl -X GET http://localhost:8081/foglamp/plugins/installed?type=north|south|filter|notify|rule
+        curl -X GET http://localhost:8081/foglamp/plugins/installed?type=north|south|filter|notificationDelivery|notificationRule
         curl -X 'GET http://localhost:8081/foglamp/plugins/installed?type=north&config=true'
     """
 
     plugin_type = None
     is_config = False
     if 'type' in request.query and request.query['type'] != '':
-        plugin_type = request.query['type'].lower()
+        plugin_type = request.query['type'].lower() if request.query['type'] not in ['notificationDelivery', 'notificationRule'] else request.query['type']
 
-    if plugin_type is not None and plugin_type not in ['north', 'south', 'filter', 'notify', 'rule']:
-        raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'.")
+    if plugin_type is not None and plugin_type not in ['north', 'south', 'filter', 'notificationDelivery', 'notificationRule']:
+        raise web.HTTPBadRequest(reason="Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notificationDelivery' or 'notificationRule'.")
 
     if 'config' in request.query:
         config = request.query['config']

--- a/tests/unit/python/foglamp/common/test_plugin_discovery.py
+++ b/tests/unit/python/foglamp/common/test_plugin_discovery.py
@@ -118,7 +118,7 @@ class TestPluginDiscovery:
     mock_c_notify_config = [
         {"name": "email",
          "version": "1.0.0",
-         "type": "notify",
+         "type": "notificationDelivery",
          "description": "Email notification plugin",
          "config": {"plugin": {"type": "string", "description": "Email notification plugin", "default": "email"}}}
     ]
@@ -126,7 +126,7 @@ class TestPluginDiscovery:
     mock_c_rule_config = [
         {"name": "OverMaxRule",
          "version": "1.0.0",
-         "type": "rule",
+         "type": "notificationRule",
          "description": "The OverMaxRule notification rule",
          "config": {"plugin": {"type": "string", "description": "The OverMaxRule notification rule plugin", "default": "OverMaxRule"}}}
     ]
@@ -154,14 +154,14 @@ class TestPluginDiscovery:
                  "default": "scale",
                  "type": "string",
                  "description": "Scale filter plugin"}}},
-        {"name": "email", "type": "notify", "version": "1.0.0", "description": "Email notification plugin",
+        {"name": "email", "type": "notificationDelivery", "version": "1.0.0", "description": "Email notification plugin",
          "config": {"plugin": {
              "type": "string",
              "description": "Email notification plugin",
              "default": "email"}}},
         {"name": "OverMaxRule",
          "version": "1.0.0",
-         "type": "rule",
+         "type": "notificationRule",
          "description": "The OverMaxRule notification rule",
          "config": {"plugin": {"type": "string", "description": "The OverMaxRule notification rule plugin",
                                "default": "OverMaxRule"}}}
@@ -273,7 +273,7 @@ class TestPluginDiscovery:
         mock_get_c_notify_folders = mocker.patch.object(utils, "find_c_plugin_libs", return_value=next(mock_notify_folders()))
         mock_get_c_notify_plugin_config = mocker.patch.object(utils, "get_plugin_info", side_effect=TestPluginDiscovery.mock_c_notify_config)
 
-        plugins = PluginDiscovery.get_plugins_installed("notify")
+        plugins = PluginDiscovery.get_plugins_installed("notificationDelivery")
         # expected_plugin = TestPluginDiscovery.mock_c_plugins_config[3]
         # FIXME: ordering issue
         # assert expected_plugin == plugins
@@ -288,7 +288,7 @@ class TestPluginDiscovery:
         mock_get_c_rule_folders = mocker.patch.object(utils, "find_c_plugin_libs", return_value=next(mock_rule_folders()))
         mock_get_c_rule_plugin_config = mocker.patch.object(utils, "get_plugin_info", side_effect=TestPluginDiscovery.mock_c_rule_config)
 
-        plugins = PluginDiscovery.get_plugins_installed("rule")
+        plugins = PluginDiscovery.get_plugins_installed("notificationRule")
         # expected_plugin = TestPluginDiscovery.mock_c_plugins_config[4]
         # FIXME: ordering issue
         # assert expected_plugin == plugins
@@ -367,8 +367,8 @@ class TestPluginDiscovery:
         (mock_c_plugins_config[0], "south"),
         (mock_c_plugins_config[1], "north"),
         (mock_c_plugins_config[2], "filter"),
-        (mock_c_plugins_config[3], "notify"),
-        (mock_c_plugins_config[4], "rule")
+        (mock_c_plugins_config[3], "notificationDelivery"),
+        (mock_c_plugins_config[4], "notificationRule")
     ])
     def test_fetch_c_plugins_installed(self, info, dir_name):
         with patch.object(utils, "find_c_plugin_libs", return_value=[info['name']]) as patch_plugin_lib:

--- a/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
@@ -45,59 +45,58 @@ class TestPluginDiscoveryApi:
             assert {'plugins': result} == json_response
         patch_get_plugin_installed.assert_called_once_with(None, is_config)
 
-    @pytest.mark.parametrize("param", [
-        "north",
-        "south",
-        "North",
-        "South",
-        "NORTH",
-        "SOUTH",
-        "filter",
-        "Filter",
-        "FILTER",
-        "notify",
-        "NOTIFY",
-        "rule",
-        "Rule",
-        "RULE"
+    @pytest.mark.parametrize("param, type", [
+        ("north", "north"),
+        ("south", "south"),
+        ("North", "north"),
+        ("South", "south"),
+        ("NORTH", "north"),
+        ("SOUTH", "south"),
+        ("filter", "filter"),
+        ("Filter", "filter"),
+        ("FILTER", "filter"),
+        ("notificationDelivery", "notificationDelivery"),
+        ("notificationRule", "notificationRule")
     ])
-    async def test_get_plugins_installed_by_params(self, client, param):
+    async def test_get_plugins_installed_by_params(self, client, param, type):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value={}) as patch_get_plugin_installed:
             resp = await client.get('/foglamp/plugins/installed?type={}'.format(param))
             assert 200 == resp.status
             r = await resp.text()
             json_response = json.loads(r)
             assert {'plugins': {}} == json_response
-        patch_get_plugin_installed.assert_called_once_with(param.lower(), False)
+        patch_get_plugin_installed.assert_called_once_with(type, False)
 
-    @pytest.mark.parametrize("param, direction, result, is_config", [
+    @pytest.mark.parametrize("param, type, result, is_config", [
         ("?type=north&config=false", "north", {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin"}, False),
         ("?type=south&config=false", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin"}, False),
         ("?type=filter&config=false", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin"}, False),
-        ("?type=notify&config=false", "notify", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin"}, False),
-        ("?type=rule&config=false", "rule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin"}, False),
+        ("?type=notificationDelivery&config=false", "notificationDelivery", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin"}, False),
+        ("?type=notificationRule&config=false", "notificationRule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin"}, False),
         ("?type=north&config=true", "north", {"name": "http", "version": "1.0.0", "type": "north", "description": "HTTP North-C plugin",
                                               "config": {"plugin": {"description": "HTTP North-C plugin", "type": "string", "default": "http-north"}}}, True),
         ("?type=south&config=true", "south", {"name": "sinusoid", "version": "1.0", "type": "south", "description": "sinusoid plugin",
                                               "config": {"plugin": {"description": "sinusoid plugin", "type": "string", "default": "sinusoid", "readonly": "true"}}}, True),
         ("?type=filter&config=true", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin",
                                                 "config": {"offset": {"default": "0.0", "type": "float", "description": "A constant offset"}, "factor": {"default": "100.0", "type": "float", "description": "Scale factor for a reading."}, "plugin": {"default": "scale", "type": "string", "description": "Scale filter plugin"}, "enable": {"default": "false", "type": "boolean", "description": "A switch that can be used to enable or disable."}}}, True),
-        ("?type=notify&config=true", "notify", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin",
+        ("?type=notificationDelivery&config=true", "notificationDelivery", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin",
                                                 "config": {"plugin": {"type": "string", "description": "Email notification plugin", "default": "email"}}}, True),
-        ("?type=rule&config=true", "rule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin",
+        ("?type=notificationRule&config=true", "notificationRule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin",
                                             "config": {"plugin": {"type": "string", "description": "The OverMaxRule notification rule plugin", "default": "OverMaxRule"}}}, True)
     ])
-    async def test_get_plugins_installed_by_type_and_config(self, client, param, direction, result, is_config):
+    async def test_get_plugins_installed_by_type_and_config(self, client, param, type, result, is_config):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value=result) as patch_get_plugin_installed:
             resp = await client.get('/foglamp/plugins/installed{}'.format(param))
             assert 200 == resp.status
             r = await resp.text()
             json_response = json.loads(r)
             assert {'plugins': result} == json_response
-        patch_get_plugin_installed.assert_called_once_with(direction, is_config)
+        patch_get_plugin_installed.assert_called_once_with(type, is_config)
 
     @pytest.mark.parametrize("param, message", [
-        ("?type=blah", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'."),
+        ("?type=blah", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notificationDelivery' or 'notificationRule'."),
+        ("?type=notify", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notificationDelivery' or 'notificationRule'."),
+        ("?type=rule", "Invalid plugin type. Must be 'north' or 'south' or 'filter' or 'notificationDelivery' or 'notificationRule'."),
         ("?config=blah", 'Only "true", "false", true, false are allowed for value of config.'),
         ("?config=False", 'Only "true", "false", true, false are allowed for value of config.'),
         ("?config=True", 'Only "true", "false", true, false are allowed for value of config.'),


### PR DESCRIPTION
**Curl O/P**

```
$ curl -sX GET 'http://localhost:8081/foglamp/plugins/installed' | jq
{
  "plugins": [
    {
      "name": "ocs",
      "description": "OCS (OSIsoft Cloud Services) North Plugin",
      "version": "1.0.0",
      "type": "north"
    },
 
    {
      "name": "pi_server",
      "description": "PI Server North Plugin",
      "version": "1.0.0",
      "type": "north"
    },
    {
      "name": "PI_Server_V2",
      "description": "PI Server North C Plugin",
      "version": "1.0.0",
      "type": "north"
    },
    {
      "name": "ocs_V2",
      "description": "OCS (OSIsoft Cloud Services) North C Plugin",
      "version": "1.0.0",
      "type": "north"
    },
   {
      "name": "coap",
      "description": "CoAP Listener South Plugin",
      "version": "1.5.0",
      "type": "south"
    },
    {
      "name": "email",
      "description": "Email notification plugin",
      "version": "1.0.0",
      "type": "notificationDelivery"
    },
    {
      "name": "OutOfBound",
      "description": "OutOfBound notification rule",
      "version": "1.0.0",
      "type": "notificationRule"
    }
  ]
}
```


```
$ curl -sX GET http://localhost:8081/foglamp/plugins/installed?type=notificationDelivery | jq
{
  "plugins": [
    {
      "name": "email",
      "description": "Email notification plugin",
      "version": "1.0.0",
      "type": "notificationDelivery"
    }
  ]
}
```

```
$ curl -sX GET http://localhost:8081/foglamp/plugins/installed?type=notificationRule | jq
{
  "plugins": [
    {
      "name": "OutOfBound",
      "description": "OutOfBound notification rule",
      "version": "1.0.0",
      "type": "notificationRule"
    }
  ]
}
```

```
$ curl -sX GET 'http://localhost:8081/foglamp/plugins/installed?type=notificationRule&config=true' | jq
{
  "plugins": [
    {
      "name": "OutOfBound",
      "description": "OutOfBound notification rule",
      "version": "1.0.0",
      "type": "notificationRule",
      "config": {
        "description": {
          "description": "Generate a notification if all configured assets trigger",
          "displayName": "Rule",
          "default": "Generate a notification if all configured assets trigger",
          "type": "string",
          "order": "1"
        },
        "rule_config": {
          "description": "The array of rules.",
          "displayName": "Configuration",
          "default": "{\"rules\" : [{ \"asset\" : {\"description\" : \"The asset name for which notifications will be generated.\", \"name\" : \"\" }, \"evaluation_type\": {\"description\": \"Rule evaluation type\", \"type\": \"enumeration\", \"options\": [ \"window\", \"maximum\", \"minimum\", \"average\", \"latest\" ], \"value\": \"latest\" }, \"time_window\": {\"description\": \"Duration of the time window, in seconds, for collecting data points except for 'latest' evaluation.\", \"type\": \"integer\" , \"value\": 30 }, \"eval_all_datapoints\" : true, \"datapoints\": [ {\"name\": \"\", \"type\": \"float\", \"trigger_value\": 0.0} ] } ] }",
          "type": "JSON",
          "order": "2"
        },
        "plugin": {
          "description": "OutOfBound notification rule",
          "readonly": "true",
          "default": "OutOfBound",
          "type": "string"
        }
      }
    }
  ]
}

```