### PR TITLE
FOGL-2623 add service system REST API tests added

### DIFF
--- a/tests/system/python/api/test_service.py
+++ b/tests/system/python/api/test_service.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Test add service using poll and async plugins for both python & C version REST API """
+
+import subprocess
+import http.client
+import json
+import time
+from uuid import UUID
+from collections import Counter
+import pytest
+import plugin_and_service
+
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2019 Dianomic Systems"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+SVC_NAME_1 = 'Random Walk #1'
+SVC_NAME_2 = 'HTTP-SOUTH'
+SVC_NAME_3 = 'Bench'
+SVC_NAME_4 = 'randomwalk'
+
+
+@pytest.fixture
+def install_plugins():
+    plugin_and_service.install('south', plugin='randomwalk')
+    plugin_and_service.install('south', plugin='http')
+    plugin_and_service.install('south', plugin='benchmark', plugin_lang='C')
+    # TODO: FOGL-2662 C-async plugin - Once done add 1 more plugin
+    # plugin_and_service.install('south', plugin='?', plugin_lang='C')
+
+
+class TestService:
+
+    def test_cleanup_and_setup(self, reset_and_start_foglamp, install_plugins):
+        # TODO: Remove this workaround
+        # Use better setup & teardown methods
+        pass
+
+    def test_default_service(self, foglamp_url):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/service')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        # Only storage and core service is expected by default
+        assert 2 == len(jdoc['services'])
+        keys = {'address', 'service_port', 'type', 'status', 'name', 'management_port', 'protocol'}
+        assert Counter(keys) == Counter(jdoc['services'][0].keys())
+
+        storage_svc = jdoc['services'][0]
+        assert isinstance(storage_svc['service_port'], int)
+        assert isinstance(storage_svc['management_port'], int)
+        assert 'running' == storage_svc['status']
+        assert 'Storage' == storage_svc['type']
+        assert 'localhost' == storage_svc['address']
+        assert 'FogLAMP Storage' == storage_svc['name']
+        assert 'http' == storage_svc['protocol']
+
+        core_svc = jdoc['services'][1]
+        assert isinstance(core_svc['management_port'], int)
+        assert 8081 == core_svc['service_port']
+        assert 'running' == core_svc['status']
+        assert 'Core' == core_svc['type']
+        assert '0.0.0.0' == core_svc['address']
+        assert 'FogLAMP Core' == core_svc['name']
+        assert 'http' == core_svc['protocol']
+
+    @pytest.mark.parametrize("plugin, svc_name, config, enabled, svc_count", [
+        ("randomwalk", SVC_NAME_1, None, True, 3),
+        ("http_south", SVC_NAME_2, None, False, 3),
+        ("Benchmark", SVC_NAME_3, None, True, 4)
+    ])
+    def test_add_service(self, foglamp_url, wait_time, plugin, svc_name, config, enabled, svc_count):
+        jdoc = plugin_and_service.add_south(plugin, foglamp_url, svc_name, config, enabled)
+        assert svc_name == jdoc['name']
+        assert UUID(jdoc['id'], version=4)
+
+        time.sleep(wait_time)
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/service')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        assert svc_count == len(jdoc['services'])
+        southbound_svc = jdoc['services'][svc_count - 1]
+        assert isinstance(southbound_svc['management_port'], int)
+        assert southbound_svc['service_port'] is None
+        assert svc_name if enabled else SVC_NAME_1 == southbound_svc['name']
+        assert 'running' == southbound_svc['status']
+        assert 'Southbound' == southbound_svc['type']
+        assert 'localhost' == southbound_svc['address']
+        assert 'http' == southbound_svc['protocol']
+
+    def test_add_service_with_config(self, foglamp_url):
+        data = {"name": SVC_NAME_4,
+                "type": "South",
+                "plugin": 'randomwalk',
+                "config": {"maxValue": {"value": "20"}, "assetName": {"value": "Random"}}
+                }
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("POST", '/foglamp/service', json.dumps(data))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert SVC_NAME_4 == jdoc['name']
+        assert UUID(jdoc['id'], version=4)
+
+        conn.request("GET", '/foglamp/category/{}'.format(SVC_NAME_4))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        assert data['config']['assetName']['value'] == jdoc['assetName']['value']
+        assert data['config']['maxValue']['value'] == jdoc['maxValue']['value']
+
+    @pytest.mark.parametrize("encoded_svc_name, svc_name, status", [
+        ("FogLAMP%20Storage", "FogLAMP Storage", 404),
+        ("FogLAMP%20Core", "FogLAMP Core", 404),
+        ("Random%20Walk%20%231", SVC_NAME_1, 200),
+        ("HTTP-SOUTH", SVC_NAME_2, 200),
+        (SVC_NAME_3, SVC_NAME_3, 200)
+    ])
+    def test_delete_service(self, encoded_svc_name, svc_name, status, foglamp_url):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("DELETE", '/foglamp/service/{}'.format(encoded_svc_name))
+        r = conn.getresponse()
+        assert status == r.status
+        if status == 404:
+            assert '{} service does not exist.'.format(svc_name) == r.reason
+        else:
+            r = r.read().decode()
+            jdoc = json.loads(r)
+            assert 'Service {} deleted successfully.'.format(svc_name) == jdoc['result']
+
+    def test_notification_service(self):
+        assert 1, "Already verified in test_e2e_notification_service_with_plugins.py"

--- a/tests/system/python/conftest.py
+++ b/tests/system/python/conftest.py
@@ -25,6 +25,7 @@ __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
+sys.path.append(os.path.join(os.path.dirname(__file__)))
 
 
 @pytest.fixture

--- a/tests/system/python/helpers/plugin_and_service.py
+++ b/tests/system/python/helpers/plugin_and_service.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+"""Install plugin as per type, plugin name, language & add/start south service"""
+
+import subprocess
+import http.client
+import json
+
+
+def install(_type, plugin, branch="develop", plugin_lang="python", use_pip_cache=True):
+    if plugin_lang == "python":
+        path = "$FOGLAMP_ROOT/tests/system/python/scripts/install_python_plugin {} {} {} {}".format(
+            branch, _type, plugin, use_pip_cache)
+    else:
+        path = "$FOGLAMP_ROOT/tests/system/python/scripts/install_c_plugin {} {} {}".format(
+            branch, _type, plugin)
+    try:
+        subprocess.run([path], shell=True, check=True)
+    except subprocess.CalledProcessError:
+        assert False, "{} plugin installation failed".format(plugin)
+
+    # Cleanup /tmp repos
+    if _type == "notificationDelivery":
+        _type = "notify"
+    if _type == "notificationRule":
+        _type = "rule"
+        subprocess.run(["rm -rf /tmp/foglamp-service-notification"], shell=True, check=True)
+    subprocess.run(["rm -rf /tmp/foglamp-{}-{}".format(_type, plugin)], shell=True, check=True)
+
+
+def reset():
+    try:
+        subprocess.run(["$FOGLAMP_ROOT/tests/system/python/scripts/reset_plugins"], shell=True, check=True)
+    except subprocess.CalledProcessError:
+        assert False, "reset plugin script failed"
+
+
+def add_south(south_plugin, foglamp_url, service_name, config=None, start_service=True):
+        """Add south plugin and start the service by default"""
+        _config = config if config is not None else {}
+        _enabled = "true" if start_service else "false"
+        data = {"name": "{}".format(service_name), "type": "South", "plugin": "{}".format(south_plugin),
+                "enabled": _enabled, "config": _config}
+
+        # Create south service
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("POST", '/foglamp/service', json.dumps(data))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        return json.loads(r)

--- a/tests/system/python/plugin_and_service.py
+++ b/tests/system/python/plugin_and_service.py
@@ -39,7 +39,7 @@ def reset():
         assert False, "reset plugin script failed"
 
 
-def add_south(south_plugin, foglamp_url, service_name, config=None, start_service=True):
+def add_south_service(south_plugin, foglamp_url, service_name, config=None, start_service=True):
         """Add south plugin and start the service by default"""
         _config = config if config is not None else {}
         _enabled = "true" if start_service else "false"


### PR DESCRIPTION
- [x] utility added to install plugin and add as service; As much needed and conftest fixtures are more tightly in nature therefore added

**O/P**

```
$ pytest -s -vv test_service.py 
============================================================= test session starts =============================================================
platform linux -- Python 3.5.3, pytest-3.6.0, py-1.8.0, pluggy-0.6.0 -- /usr/local/bin/python3.5
cachedir: ../.pytest_cache
rootdir: /home/foglamp/Development/systemTests/FogLAMP/tests/system/python, inifile: pytest.ini
plugins: mock-1.10.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 17 items                                                                                                                            

../TestService test_cleanup_and_setup <- api/test_service.py FogLAMP killed.
This script will remove all data stored in the SQLite3 datafile '/home/foglamp/Development/systemTests/FogLAMP/data/foglamp.db'
Enter YES if you want to continue: Starting FogLAMP v1.5.1......
FogLAMP started.
Cloning into '/tmp/foglamp-south-randomwalk'...
remote: Enumerating objects: 90, done.
remote: Counting objects: 100% (90/90), done.
remote: Compressing objects: 100% (44/44), done.
remote: Total 90 (delta 20), reused 75 (delta 15), pack-reused 0
Unpacking objects: 100% (90/90), done.
Checking connectivity... done.
No such external dependency needed for randomwalk plugin.
randomwalk plugin is installed.
Cloning into '/tmp/foglamp-south-http'...
remote: Enumerating objects: 275, done.
remote: Total 275 (delta 0), reused 0 (delta 0), pack-reused 275
Receiving objects: 100% (275/275), 47.68 KiB | 0 bytes/s, done.
Resolving deltas: 100% (75/75), done.
Checking connectivity... done.
No such external dependency needed for http plugin.
http plugin is installed.
Cloning into '/tmp/foglamp-south-benchmark'...
remote: Enumerating objects: 33, done.
remote: Counting objects: 100% (33/33), done.
remote: Compressing objects: 100% (22/22), done.
remote: Total 85 (delta 13), reused 19 (delta 8), pack-reused 52
Unpacking objects: 100% (85/85), done.
Checking connectivity... done.
No external dependency needed for benchmark plugin.
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is GNU 5.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- No options set.
   +Using found FOGLAMP_ROOT /home/foglamp/Development/systemTests/FogLAMP
-- Using FOGLAMP_ROOT for includes
   +/home/foglamp/Development/systemTests/FogLAMP/C/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/services/common/include
-- Using FOGLAMP_ROOT for libs 
   +/home/foglamp/Development/systemTests/FogLAMP/cmake_build/C/lib
-- Using third-party includes /home/foglamp/Development/systemTests/FogLAMP/C/thirdparty
-- Installing Benchmark in /home/foglamp/Development/systemTests/FogLAMP/plugins/south/Benchmark
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/foglamp-south-benchmark/build
[ 25%] Generating version header
Scanning dependencies of target Benchmark
[ 75%] Building CXX object CMakeFiles/Benchmark.dir/plugin.o
[ 75%] Building CXX object CMakeFiles/Benchmark.dir/random.o
[100%] Linking CXX shared library libBenchmark.so
[100%] Built target Benchmark
[100%] Built target Benchmark
Install the project...
-- Install configuration: ""
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/south/Benchmark/libBenchmark.so.1
-- Up-to-date: /home/foglamp/Development/systemTests/FogLAMP/plugins/south/Benchmark/libBenchmark.so
-- Set runtime path of "/home/foglamp/Development/systemTests/FogLAMP/plugins/south/Benchmark/libBenchmark.so.1" to ""
/home/foglamp/Development/systemTests/FogLAMP/tests/system/python/api
benchmark plugin is installed.
Cloning into '/tmp/foglamp-south-random'...
remote: Enumerating objects: 58, done.
remote: Counting objects: 100% (58/58), done.
remote: Compressing objects: 100% (44/44), done.
remote: Total 158 (delta 20), reused 28 (delta 8), pack-reused 100
Receiving objects: 100% (158/158), 49.48 KiB | 0 bytes/s, done.
Resolving deltas: 100% (67/67), done.
Checking connectivity... done.
No external dependency needed for random plugin.
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is GNU 5.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- No options set.
   +Using found FOGLAMP_ROOT /home/foglamp/Development/systemTests/FogLAMP
-- Using FOGLAMP_ROOT for includes
   +/home/foglamp/Development/systemTests/FogLAMP/C/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/services/common/include
-- Using FOGLAMP_ROOT for libs 
   +/home/foglamp/Development/systemTests/FogLAMP/cmake_build/C/lib
-- Using third-party includes /home/foglamp/Development/systemTests/FogLAMP/C/thirdparty
-- Installing Random in /home/foglamp/Development/systemTests/FogLAMP/plugins/south/Random
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/foglamp-south-random/build
[ 25%] Generating version header
Scanning dependencies of target Random
[ 75%] Building CXX object CMakeFiles/Random.dir/random.o
[ 75%] Building CXX object CMakeFiles/Random.dir/plugin.o
[100%] Linking CXX shared library libRandom.so
[100%] Built target Random
[100%] Built target Random
Install the project...
-- Install configuration: ""
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/south/Random/libRandom.so.1
-- Up-to-date: /home/foglamp/Development/systemTests/FogLAMP/plugins/south/Random/libRandom.so
-- Set runtime path of "/home/foglamp/Development/systemTests/FogLAMP/plugins/south/Random/libRandom.so.1" to ""
/home/foglamp/Development/systemTests/FogLAMP/tests/system/python/api
random plugin is installed.
PASSED
../TestService test_default_service <- api/test_service.py PASSED
../TestService test_add_service <- api/test_service.py PASSED
../TestService test_add_service <- api/test_service.py PASSED
../TestService test_add_service <- api/test_service.py PASSED
../TestService test_add_service <- api/test_service.py PASSED
../TestService test_add_service_with_config <- api/test_service.py PASSED
../TestService test_delete_service <- api/test_service.py PASSED
../TestService test_delete_service <- api/test_service.py PASSED
../TestService test_delete_service <- api/test_service.py PASSED
../TestService test_delete_service <- api/test_service.py PASSED
../TestService test_delete_service <- api/test_service.py PASSED
../TestService test_service_with_enable_schedule <- api/test_service.py PASSED
../TestService test_service_with_disable_schedule <- api/test_service.py PASSED
../TestService test_service_on_restart <- api/test_service.py PASSED
../TestService test_delete_service_with_filters <- api/test_service.py Cloning into '/tmp/foglamp-filter-metadata'...
remote: Enumerating objects: 98, done.
remote: Total 98 (delta 0), reused 0 (delta 0), pack-reused 98
Unpacking objects: 100% (98/98), done.
Checking connectivity... done.
No external dependency needed for metadata plugin.
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is GNU 5.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- No options set.
   +Using found FOGLAMP_ROOT /home/foglamp/Development/systemTests/FogLAMP
-- Using FOGLAMP_ROOT for includes
   +/home/foglamp/Development/systemTests/FogLAMP/C/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/services/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/plugins/filter/common/include
   +/home/foglamp/Development/systemTests/FogLAMP/C/thirdparty/rapidjson/include
-- Using FOGLAMP_ROOT for libs 
   +/home/foglamp/Development/systemTests/FogLAMP/cmake_build/C/lib
-- Using third-party includes /home/foglamp/Development/systemTests/FogLAMP/C/thirdparty/Simple-Web-Server
-- Installing metadata in /home/foglamp/Development/systemTests/FogLAMP/plugins/filter/metadata
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/foglamp-filter-metadata/build
[ 33%] Generating version header
Scanning dependencies of target metadata
[ 66%] Building CXX object CMakeFiles/metadata.dir/plugin.cpp.o
[100%] Linking CXX shared library libmetadata.so
[100%] Built target metadata
[100%] Built target metadata
Install the project...
-- Install configuration: ""
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/filter/metadata/libmetadata.so.1
-- Installing: /home/foglamp/Development/systemTests/FogLAMP/plugins/filter/metadata/libmetadata.so
-- Set runtime path of "/home/foglamp/Development/systemTests/FogLAMP/plugins/filter/metadata/libmetadata.so.1" to ""
/home/foglamp/Development/systemTests/FogLAMP/tests/system/python/api
metadata plugin is installed.
PASSED
../TestService test_notification_service <- api/test_service.py PASSED
======== 17 passed in 153.12 seconds ====
```