### PR TITLE
E2E tests added with filters on both ingress and egress side

### DIFF
--- a/tests/system/python/e2e/test_e2e_ingress_egress_with_filter.py
+++ b/tests/system/python/e2e/test_e2e_ingress_egress_with_filter.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Test end to end flow with:
+        HTTP south plugin
+        PI Server (C) plugin
+        Scale filter plugin (on both Ingress & Egress with different scale & offset value)
+"""
+
+import os
+import subprocess
+import http.client
+import json
+import time
+import pytest
+import utils
+
+
+__author__ = "Ashish Jabble"
+__copyright__ = "Copyright (c) 2019 Dianomic Systems"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+
+SOUTH_PLUGIN = "http_south"
+SVC_NAME = "Http #1"
+ASSET_PREFIX = "http-"
+ASSET_NAME = "Http"
+
+TASK_NAME = "North 2 PI"
+
+FILTER_PLUGIN = "scale"
+INGRESS_FILTER_NAME = "F#1 Scale"
+EGRESS_FILTER_NAME = "F2 Scale"
+OFFSET = 13
+
+TEMPLATE_NAME = "template.json"
+READ_KEY = "sensor"
+SENSOR_VALUE = 20
+
+# default scale factor
+MULTIPLIER = 100.0
+OUTPUT_1 = SENSOR_VALUE * MULTIPLIER
+OUTPUT_2 = (OUTPUT_1 * MULTIPLIER) + OFFSET
+
+
+class TestE2eIngressEgressWithFilter:
+
+    def get_ping_status(self, foglamp_url):
+        _connection = http.client.HTTPConnection(foglamp_url)
+        _connection.request("GET", '/foglamp/ping')
+        r = _connection.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        return jdoc
+
+    def get_statistics_map(self, foglamp_url):
+        _connection = http.client.HTTPConnection(foglamp_url)
+        _connection.request("GET", '/foglamp/statistics')
+        r = _connection.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        return utils.serialize_stats_map(jdoc)
+
+    @pytest.fixture
+    def start_south_north(self, reset_and_start_foglamp, add_south, remove_data_file, remove_directories,
+                          south_branch, foglamp_url, add_filter, filter_branch, filter_name,
+                          start_north_pi_server_c, pi_host, pi_port, pi_token):
+        """ This fixture clone a south repo and starts both south and PI north C instance
+            reset_and_start_foglamp: Fixture that resets and starts foglamp, no explicit invocation, called at start
+            add_south: Fixture that adds a south service with given configuration with enabled mode
+            remove_data_file: Fixture that remove data file created during the test
+            remove_directories: Fixture that remove directories created during the test
+            add_filter: Fixture that add a filter with given configuration with enabled mode
+        """
+        # Define the template file for fogbench
+        fogbench_template_path = os.path.join(
+            os.path.expandvars('${FOGLAMP_ROOT}'), 'data/{}'.format(TEMPLATE_NAME))
+        with open(fogbench_template_path, "w") as f:
+            f.write(
+                '[{"name": "%s", "sensor_values": '
+                '[{"name": "%s", "type": "number", "min": %d, "max": %d, "precision": 0}]}]' % (
+                    ASSET_NAME, READ_KEY, SENSOR_VALUE, SENSOR_VALUE))
+
+        # add south & INGRESS_FILTER_NAME
+        filter_cfg = {"enable": "true"}
+        add_south(SOUTH_PLUGIN, south_branch, foglamp_url, service_name=SVC_NAME)
+        add_filter(FILTER_PLUGIN, filter_branch, INGRESS_FILTER_NAME, filter_cfg, foglamp_url, SVC_NAME)
+
+        # add north & EGRESS_FILTER_NAME
+        filter_cfg = {"offset": str(OFFSET), "enable": "true"}
+        start_north_pi_server_c(foglamp_url, pi_host, pi_port, pi_token, taskname=TASK_NAME)
+        add_filter(FILTER_PLUGIN, filter_branch, EGRESS_FILTER_NAME, filter_cfg, foglamp_url, TASK_NAME)
+
+        yield self.start_south_north
+
+        remove_data_file(fogbench_template_path)
+        remove_directories("/tmp/foglamp-south-{}".format(ASSET_NAME.lower()))
+        remove_directories("/tmp/foglamp-filter-{}".format(FILTER_PLUGIN))
+
+    def test_end_to_end(self, start_south_north, read_data_from_pi, foglamp_url, pi_host, pi_admin,
+                        pi_passwd, pi_db, wait_time, retries, skip_verify_north_interface,
+                        disable_schedule, enable_schedule):
+        # ingest first reading via fogbench
+        subprocess.run(["cd $FOGLAMP_ROOT/extras/python; python3 -m fogbench -t ../../data/{} -p http; cd -".format(
+            TEMPLATE_NAME)], shell=True, check=True)
+        # Let the readings to be ingressed & extra wait time needed for sent
+        time.sleep(wait_time * 2)
+
+        # verify ping and statistics
+        self._verify_ping_and_statistics(1, foglamp_url)
+
+        # verify ingest with first reading
+        conn = http.client.HTTPConnection(foglamp_url)
+        self._verify_ingest(conn, 1, OUTPUT_1)
+
+        # verify egress with first reading
+        if not skip_verify_north_interface:
+            self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time,
+                                retries, OUTPUT_1)
+
+        # Disable TASK_NAME schedule
+        disable_schedule(foglamp_url, TASK_NAME)
+
+        # ingest second reading via fogbench
+        subprocess.run(["cd $FOGLAMP_ROOT/extras/python; python3 -m fogbench -t ../../data/{} -p http; cd -"
+                       .format(TEMPLATE_NAME)], shell=True, check=True)
+
+        # Enable TASK_NAME schedule to pick filter config
+        enable_schedule(foglamp_url, TASK_NAME)
+
+        # extra wait time needed for sent
+        time.sleep(wait_time * 2)
+
+        # verify ping and statistics
+        self._verify_ping_and_statistics(2, foglamp_url)
+
+        # verify ingest with second reading
+        self._verify_ingest(conn, 2, OUTPUT_1)
+
+        # verify egress with second reading
+        if not skip_verify_north_interface:
+            self._verify_egress(read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time,
+                                retries, OUTPUT_2)
+
+    def _verify_ping_and_statistics(self, count, foglamp_url):
+        ping_response = self.get_ping_status(foglamp_url)
+        assert count == ping_response["dataRead"]
+        assert count == ping_response["dataSent"]
+
+        actual_stats_map = self.get_statistics_map(foglamp_url)
+        key = "{}{}".format(ASSET_PREFIX.upper(), ASSET_NAME.upper())
+        assert count == actual_stats_map[key]
+        assert count == actual_stats_map[TASK_NAME]
+        assert count == actual_stats_map['READINGS']
+        assert count == actual_stats_map['Readings Sent']
+
+    def _verify_ingest(self, conn, read_count, value):
+        conn.request("GET", '/foglamp/asset')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        assert "{}{}".format(ASSET_PREFIX, ASSET_NAME) == jdoc[0]["assetCode"]
+        assert read_count == jdoc[0]["count"]
+
+        conn.request("GET", '/foglamp/asset/{}{}'.format(ASSET_PREFIX, ASSET_NAME))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert len(jdoc), "No data found"
+        # verify INGRESS scale filter is applied and O/P with (readings * 100) on BOTH reading case
+        assert value == jdoc[0]["reading"][READ_KEY]
+        if read_count == 2:
+            assert value == jdoc[1]["reading"][READ_KEY]
+
+    def _verify_egress(self, read_data_from_pi, pi_host, pi_admin, pi_passwd, pi_db, wait_time, retries, value):
+        retry_count = 0
+        data_from_pi = None
+        while (data_from_pi is None or data_from_pi == []) and retry_count < retries:
+            name = "{}{}".format(ASSET_PREFIX, ASSET_NAME)
+            data_from_pi = read_data_from_pi(pi_host, pi_admin, pi_passwd, pi_db, name, {READ_KEY})
+            retry_count += 1
+            time.sleep(wait_time * 2)
+
+        if data_from_pi is None or retry_count == retries:
+            assert False, "Failed to read data from PI"
+
+        assert len(data_from_pi), "No data found from pi"
+
+        # verify OUTPUT_1 (readings * 100) on egress side with INGRESS scale filter
+        # verify OUTPUT_2 (readings * 100 + OFFSET) on egress side with EGRESS scale filter
+        assert READ_KEY in data_from_pi
+        assert isinstance(data_from_pi[READ_KEY], list)
+        assert value in data_from_pi[READ_KEY]


### PR DESCRIPTION
```
Test end to end flow with:
        HTTP south plugin
        PI Server (C) plugin
        Scale filter plugin (on both Ingress & Egress with different scale & offset value)
```

```
$ pytest -s -vv test_e2e_ingress_egress_with_filter.py  --pi-db={DB_NAME} --pi-host={HOST} --pi-admin={USERNAME} --pi-passwd={PASSWD} --pi-token={TOKEN}
============================================================= test session starts =============================================================
platform linux -- Python 3.5.3, pytest-3.6.0, py-1.8.0, pluggy-0.6.0 -- /usr/local/bin/python3.5
cachedir: ../.pytest_cache
rootdir: /home/foglamp/Development/FogLAMP/tests/system/python, inifile: pytest.ini
plugins: mock-1.10.0, cov-2.5.1, asyncio-0.8.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 1 item                                                                                                                              

../TestE2eIngressEgressWithFilter test_end_to_end <- e2e/test_e2e_ingress_egress_with_filter.py FogLAMP killed.
This script will remove all data stored in the SQLite3 datafile '/home/foglamp/Development/FogLAMP/data/foglamp.db'
Enter YES if you want to continue: Starting FogLAMP v1.5.1......
FogLAMP started.
Cloning into '/tmp/foglamp-south-http'...
remote: Enumerating objects: 275, done.
remote: Total 275 (delta 0), reused 0 (delta 0), pack-reused 275
Receiving objects: 100% (275/275), 47.68 KiB | 0 bytes/s, done.
Resolving deltas: 100% (75/75), done.
Checking connectivity... done.
No such external dependency needed for http_south plugin.
http_south plugin is installed.
Cloning into '/tmp/foglamp-filter-scale'...
remote: Enumerating objects: 61, done.
remote: Counting objects: 100% (61/61), done.
remote: Compressing objects: 100% (40/40), done.
remote: Total 154 (delta 26), reused 37 (delta 15), pack-reused 93
Receiving objects: 100% (154/154), 52.13 KiB | 0 bytes/s, done.
Resolving deltas: 100% (70/70), done.
Checking connectivity... done.
No external dependency needed for scale plugin.
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is GNU 5.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- No options set.
   +Using found FOGLAMP_ROOT /home/foglamp/Development/FogLAMP
-- Using FOGLAMP_ROOT for includes
   +/home/foglamp/Development/FogLAMP/C/common/include
   +/home/foglamp/Development/FogLAMP/C/services/common/include
   +/home/foglamp/Development/FogLAMP/C/plugins/filter/common/include
   +/home/foglamp/Development/FogLAMP/C/thirdparty/rapidjson/include
-- Using FOGLAMP_ROOT for libs 
   +/home/foglamp/Development/FogLAMP/cmake_build/C/lib
-- Using third-party includes /home/foglamp/Development/FogLAMP/C/thirdparty/Simple-Web-Server
-- Installing scale in /home/foglamp/Development/FogLAMP/plugins/filter/scale
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/foglamp-filter-scale/build
[ 33%] Generating version header
Scanning dependencies of target scale
[ 66%] Building CXX object CMakeFiles/scale.dir/plugin.o
[100%] Linking CXX shared library libscale.so
[100%] Built target scale
[100%] Built target scale
Install the project...
-- Install configuration: ""
-- Installing: /home/foglamp/Development/FogLAMP/plugins/filter/scale/libscale.so.1
-- Installing: /home/foglamp/Development/FogLAMP/plugins/filter/scale/libscale.so
-- Set runtime path of "/home/foglamp/Development/FogLAMP/plugins/filter/scale/libscale.so.1" to ""
/home/foglamp/Development/FogLAMP/tests/system/python/e2e
scale plugin is installed.

Cloning into '/tmp/foglamp-filter-scale'...
remote: Enumerating objects: 61, done.
remote: Counting objects: 100% (61/61), done.
remote: Compressing objects: 100% (40/40), done.
remote: Total 154 (delta 26), reused 37 (delta 15), pack-reused 93
Receiving objects: 100% (154/154), 52.13 KiB | 0 bytes/s, done.
Resolving deltas: 100% (70/70), done.
Checking connectivity... done.
No external dependency needed for scale plugin.
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is GNU 5.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- No options set.
   +Using found FOGLAMP_ROOT /home/foglamp/Development/FogLAMP
-- Using FOGLAMP_ROOT for includes
   +/home/foglamp/Development/FogLAMP/C/common/include
   +/home/foglamp/Development/FogLAMP/C/services/common/include
   +/home/foglamp/Development/FogLAMP/C/plugins/filter/common/include
   +/home/foglamp/Development/FogLAMP/C/thirdparty/rapidjson/include
-- Using FOGLAMP_ROOT for libs 
   +/home/foglamp/Development/FogLAMP/cmake_build/C/lib
-- Using third-party includes /home/foglamp/Development/FogLAMP/C/thirdparty/Simple-Web-Server
-- Installing scale in /home/foglamp/Development/FogLAMP/plugins/filter/scale
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/foglamp-filter-scale/build
[ 33%] Generating version header
Scanning dependencies of target scale
[ 66%] Building CXX object CMakeFiles/scale.dir/plugin.o
[100%] Linking CXX shared library libscale.so
[100%] Built target scale
[100%] Built target scale
Install the project...
-- Install configuration: ""
-- Installing: /home/foglamp/Development/FogLAMP/plugins/filter/scale/libscale.so.1
-- Installing: /home/foglamp/Development/FogLAMP/plugins/filter/scale/libscale.so
-- Set runtime path of "/home/foglamp/Development/FogLAMP/plugins/filter/scale/libscale.so.1" to ""
/home/foglamp/Development/FogLAMP/tests/system/python/e2e
scale plugin is installed.

>>> Make sure south HTTP plugin service is running 
 & listening on specified host and port 

Total Statistics:

Start Time: 2019-04-03 15:44:37.198898
End Time:   2019-04-03 15:44:37.219558

Total Messages Transferred: 1
Total Bytes Transferred:    288

Total Iterations: 1
Total Messages per Iteration: 1.0
Total Bytes per Iteration:    288.0

Min messages/second: 48.402710551790896
Max messages/second: 48.402710551790896
Avg messages/second: 48.402710551790896

Min Bytes/second: 13939.980638915778
Max Bytes/second: 13939.980638915778
Avg Bytes/second: 13939.980638915778
/home/foglamp/Development/FogLAMP/tests/system/python/e2e

>>> Make sure south HTTP plugin service is running 
 & listening on specified host and port 

Total Statistics:

Start Time: 2019-04-03 15:45:03.186371
End Time:   2019-04-03 15:45:03.212372

Total Messages Transferred: 1
Total Bytes Transferred:    288

Total Iterations: 1
Total Messages per Iteration: 1.0
Total Bytes per Iteration:    288.0

Min messages/second: 38.46005922849121
Max messages/second: 38.46005922849121
Avg messages/second: 38.46005922849121

Min Bytes/second: 11076.497057805469
Max Bytes/second: 11076.497057805469
Avg Bytes/second: 11076.497057805469
/home/foglamp/Development/FogLAMP/tests/system/python/e2e

======= 1 passed in 107.95 seconds ====
```