### PR TITLE
FOGL-2692 Prevent update to item for which optional attribute readonly has been set to true

### DIFF
--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -468,6 +468,11 @@ class ConfigurationManager(ConfigurationManagerSingleton):
             for item_name, new_val in config_item_list.items():
                 if item_name not in cat_info:
                     raise KeyError('{} config item not found'.format(item_name))
+                # Prevent update to item for which optional attribute "readonly" has been set to "true"
+                if 'readonly' in cat_info[item_name]:
+                    if cat_info[item_name]['readonly'] == 'true':
+                        raise ValueError("Update not allowed for {} item_name as it has readonly attribute set".format(item_name))
+
                 # Evaluate new_val as per rule if defined
                 if 'rule' in cat_info[item_name]:
                     rule = cat_info[item_name]['rule'].replace("value", new_val)
@@ -685,6 +690,11 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                                      .format(category_name, item_name))
                 if storage_value_entry == new_value_entry:
                     return
+
+            # Prevent update to item for which optional attribute "readonly" has been set to "true"
+            if 'readonly' in storage_value_entry:
+                if storage_value_entry['readonly'] == 'true':
+                    raise TypeError("Update not allowed for {} item_name as it has readonly attribute set".format(item_name))
 
             # Special case for enumeration field type handling
             if storage_value_entry['type'] == 'enumeration':

--- a/tests/unit/python/foglamp/common/test_configuration_manager.py
+++ b/tests/unit/python/foglamp/common/test_configuration_manager.py
@@ -1095,7 +1095,7 @@ class TestConfigurationManager:
         category_name = 'catname'
         item_name = 'itemname'
         new_value_entry = 'newvalentry'
-        storage_value_entry = {'value': 'test', 'description': 'Test desc', 'type': 'string', 'default': 'test'}
+        storage_value_entry = {'value': 'test', 'description': 'Test desc', 'type': 'string', 'default': 'test', 'readonly': 'false'}
         c_mgr._cacheManager.update(category_name, {item_name: storage_value_entry})
         with patch.object(ConfigurationManager, '_read_item_val', return_value=async_mock(storage_value_entry)) as readpatch:
             with patch.object(ConfigurationManager, '_update_value_val', return_value=async_mock(None)) as updatepatch:
@@ -1104,6 +1104,26 @@ class TestConfigurationManager:
                 callbackpatch.assert_called_once_with(category_name)
             updatepatch.assert_called_once_with(category_name, item_name, new_value_entry)
         readpatch.assert_called_once_with(category_name, item_name)
+
+    @pytest.mark.asyncio
+    async def test_set_category_item_value_entry_with_optional_attribute(self, reset_singleton):
+        async def async_mock(return_value):
+            return return_value
+
+        storage_client_mock = MagicMock(spec=StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        category_name = 'catname'
+        item_name = 'itemname'
+        new_value_entry = 'newvalentry'
+        storage_value_entry = {'value': 'test', 'description': 'Test desc', 'type': 'string', 'default': 'test', 'readonly': 'true'}
+        with patch.object(_logger, 'exception') as log_exc:
+            with patch.object(ConfigurationManager, '_read_item_val', return_value=async_mock(storage_value_entry)) as readpatch:
+                with pytest.raises(Exception) as excinfo:
+                    await c_mgr.set_category_item_value_entry(category_name, item_name, new_value_entry)
+                assert excinfo.type is TypeError
+                assert 'Update not allowed for {} item_name as it has readonly attribute set'.format(item_name) == str(excinfo.value)
+            readpatch.assert_called_once_with(category_name, item_name)
+        assert 1 == log_exc.call_count
 
     @pytest.mark.asyncio
     async def test_set_category_item_value_entry_bad_update(self, reset_singleton):
@@ -2582,5 +2602,23 @@ class TestConfigurationManager:
                     await c_mgr.update_configuration_item_bulk(category_name, config_item_list)
                 assert exc_info.type is ValueError
                 assert 'Proposed value for item_name info is not allowed as per rule defined' == str(exc_info.value)
+            assert 1 == patch_log_exc.call_count
+        patch_get_all_items.assert_called_once_with(category_name)
+
+    async def test_update_configuration_item_bulk_with_readonly_optional_attribute(self, category_name='testcat'):
+        async def async_mock(return_value):
+            return return_value
+
+        cat_info = {'info': {'default': '3', 'description': 'Test', 'value': '3',
+                             'type': 'integer', 'readonly': 'true'}, 'info1': {'default': '3', 'description': 'Test', 'value': '3',
+                                                           'type': 'integer', 'readonly': 'false'}}
+        storage_client_mock = MagicMock(spec=StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock(cat_info)) as patch_get_all_items:
+            with patch.object(_logger, 'exception') as patch_log_exc:
+                with pytest.raises(Exception) as exc_info:
+                    await c_mgr.update_configuration_item_bulk(category_name, {"info": "9", "info1": "25"})
+                assert exc_info.type is ValueError
+                assert 'Update not allowed for info item_name as it has readonly attribute set' == str(exc_info.value)
             assert 1 == patch_log_exc.call_count
         patch_get_all_items.assert_called_once_with(category_name)


### PR DESCRIPTION
- [x] Restrict config items to update when optional attribute readonly set to true
- [x] Added unit tests in conf manager

**Note**:  No tests required for test_conf api; as we check only exception code and type which is covered before. So only important tests are in conf manager