### PR TITLE
FOGL-1541 optional config items set support added with an existing enpdoint PUT category with different payload

### DIFF
--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -799,14 +799,21 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 # Validation is fairly minimal, minimum, maximum like
                 # maximum should be greater than minimum or vice-versa
                 # And no link between minimum, maximum and length is needed.
+                # condition check with numeric operands (int or float) rather than with string operands
+                def convert(value, _type):
+                    return int(value) if _type == "integer" else float(value) if _type == "float" else value
+
                 if optional_entry_name == 'minimum':
-                    if new_value_entry >= storage_value_entry['maximum']:
+                    new = convert(new_value_entry, storage_value_entry['type'])
+                    old = convert(storage_value_entry['maximum'], storage_value_entry['type'])
+                    if new > old:
                         raise ValueError('Minimum value should be less than equal to Maximum value')
 
                 if optional_entry_name == 'maximum':
-                    if new_value_entry <= storage_value_entry['minimum']:
+                    new = convert(new_value_entry, storage_value_entry['type'])
+                    old = convert(storage_value_entry['minimum'], storage_value_entry['type'])
+                    if new < old:
                         raise ValueError('Maximum value should be greater than equal to Minimum value')
-
             payload = PayloadBuilder().SELECT("key", "description", "ts", "value") \
                 .JSON_PROPERTY(("value", [item_name, optional_entry_name], new_value_entry)) \
                 .FORMAT("return", ("ts", "YYYY-MM-DD HH24:MI:SS.MS")) \

--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -35,6 +35,7 @@ _logger = logger.setup(__name__)
 # MAKE UPPER_CASE
 _valid_type_strings = sorted(['boolean', 'integer', 'float', 'string', 'IPv4', 'IPv6', 'X509 certificate', 'password', 'JSON',
                               'URL', 'enumeration', 'script'])
+_optional_items = sorted(['readonly', 'order', 'length', 'maximum', 'minimum', 'rule', 'deprecated', 'displayName'])
 RESERVED_CATG = ['South', 'North', 'General',
                   'Advanced', 'Utilities', 'rest_api',
                   'Security', 'service', 'SCHEDULER',
@@ -283,7 +284,6 @@ class ConfigurationManager(ConfigurationManagerSingleton):
 
                     d = {entry_name: entry_val}
                     expected_item_entries.update(d)
-
                 num_entries = expected_item_entries.get(entry_name)
                 if set_value_val_from_default_val and entry_name == 'value':
                     raise ValueError('Specifying value_name and value_val for item_name {} is not allowed if '
@@ -312,7 +312,6 @@ class ConfigurationManager(ConfigurationManagerSingleton):
             if set_value_val_from_default_val:
                 item_val['default'] = self._clean(item_val['type'], item_val['default'])
                 item_val['value'] = item_val['default']
-
         return category_val_copy
 
     async def _create_new_category(self, category_name, category_val, category_description, display_name=None):
@@ -743,6 +742,72 @@ class ConfigurationManager(ConfigurationManagerSingleton):
         except:
             _logger.exception(
                 'Unable to run callbacks for category_name %s', category_name)
+            raise
+
+    async def set_optional_value_entry(self, category_name, item_name, optional_entry_name, new_value_entry):
+        try:
+            storage_value_entry = None
+            if category_name in self._cacheManager:
+                if item_name not in self._cacheManager.cache[category_name]['value']:
+                    raise ValueError("No detail found for the category_name: {} and item_name: {}"
+                                     .format(category_name, item_name))
+                storage_value_entry = self._cacheManager.cache[category_name]['value'][item_name]
+                if optional_entry_name not in storage_value_entry:
+                    raise KeyError("{} does not exist".format(optional_entry_name))
+                if storage_value_entry[optional_entry_name] == new_value_entry:
+                    return
+            else:
+                # get storage_value_entry and compare against new_value_value with its type, update if different
+                storage_value_entry = await self._read_item_val(category_name, item_name)
+                # check for category_name and item_name combination existence in storage
+                if storage_value_entry is None:
+                    raise ValueError("No detail found for the category_name: {} and item_name: {}"
+                                     .format(category_name, item_name))
+                if storage_value_entry[optional_entry_name] == new_value_entry:
+                    return
+            # Validate optional types
+            if optional_entry_name == 'readonly' or optional_entry_name == 'deprecated':
+                if self._validate_type_value('boolean', new_value_entry) is False:
+                    raise ValueError('For {} category, entry value must be boolean for optional item name {}; got {}'
+                                     .format(category_name, optional_entry_name, type(new_value_entry)))
+            elif optional_entry_name == 'minimum' or optional_entry_name == 'maximum':
+                if (self._validate_type_value('integer', new_value_entry) or self._validate_type_value('float', new_value_entry)) is False:
+                    raise ValueError('For {} category, entry value must be an integer or float for optional item '
+                                     '{}; got {}'.format(category_name, optional_entry_name, type(new_value_entry)))
+            elif optional_entry_name == 'rule' or optional_entry_name == 'displayName':
+                if not isinstance(new_value_entry, str):
+                    raise ValueError('For {} category, entry value must be string for optional item {}; got {}'
+                                     .format(category_name, optional_entry_name, type(new_value_entry)))
+            else:
+                if self._validate_type_value('integer', new_value_entry) is False:
+                    raise ValueError('For {} category, entry value must be an integer for optional item {}; got {}'
+                                     .format(category_name, optional_entry_name, type(new_value_entry)))
+
+            # Validation is fairly minimal, minimum, maximum like maximum should be greater than minimum or vice-versa
+            # And no link between minimum, maximum and length is needed.
+            if optional_entry_name == 'minimum':
+                if new_value_entry >= storage_value_entry['maximum']:
+                    raise ValueError('Minimum value should be less than equal to Maximum value')
+
+            if optional_entry_name == 'maximum':
+                if new_value_entry <= storage_value_entry['minimum']:
+                    raise ValueError('Maximum value should be greater than equal to Minimum value')
+
+            payload = PayloadBuilder().SELECT("key", "description", "ts", "value") \
+                .JSON_PROPERTY(("value", [item_name, optional_entry_name], new_value_entry)) \
+                .FORMAT("return", ("ts", "YYYY-MM-DD HH24:MI:SS.MS")) \
+                .WHERE(["key", "=", category_name]).payload()
+            await self._storage.update_tbl("configuration", payload)
+            # always get value from storage
+            cat_item = await self._read_item_val(category_name, item_name)
+            if category_name in self._cacheManager.cache:
+                if item_name in self._cacheManager.cache[category_name]['value']:
+                    self._cacheManager.cache[category_name]['value'][item_name][optional_entry_name] = cat_item[optional_entry_name]
+                else:
+                    self._cacheManager.cache[category_name]['value'].update({item_name: cat_item[optional_entry_name]})
+        except:
+            _logger.exception(
+                'Unable to set optional %s entry based on category_name %s and item_name %s and value_item_entry %s', optional_entry_name, category_name, item_name, new_value_entry)
             raise
 
     async def create_category(self, category_name, category_value, category_description='', keep_original_items=False, display_name=None):

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -276,12 +276,16 @@ class TestConfiguration:
                 assert resp.reason is None
             patch_set_entry.assert_called_once_with(category_name, item_name, payload['value'])
 
-    async def test_set_optional_in_config_item(self, client, category_name='rest_api', item_name='http_port'):
+    @pytest.mark.parametrize("value", [
+        '',
+        'false',
+        'true'
+    ])
+    async def test_set_optional_in_config_item(self, client, value, category_name='rest_api', item_name='http_port', optional_key='readonly'):
         async def async_mock(return_value):
             return return_value
 
-        optional_key = 'readonly'
-        payload = {optional_key: 'false'}
+        payload = {optional_key: value}
         result = {optional_key: 'false', 'value': '8082', 'type': 'integer', 'default': '8081',
                   'description': 'The port to accept HTTP connections on'}
 

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -276,6 +276,41 @@ class TestConfiguration:
                 assert resp.reason is None
             patch_set_entry.assert_called_once_with(category_name, item_name, payload['value'])
 
+    async def test_set_optional_in_config_item(self, client, category_name='rest_api', item_name='http_port'):
+        async def async_mock(return_value):
+            return return_value
+
+        optional_key = 'readonly'
+        payload = {optional_key: 'false'}
+        result = {optional_key: 'false', 'value': '8082', 'type': 'integer', 'default': '8081',
+                  'description': 'The port to accept HTTP connections on'}
+
+        storage_client_mock = MagicMock(StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+            with patch.object(c_mgr, 'set_optional_value_entry', return_value=async_mock(None)) as patch_set_entry:
+                with patch.object(c_mgr, 'get_category_item', return_value=async_mock(result)) as patch_get_cat_item:
+                    resp = await client.put('/foglamp/category/{}/{}'.format(category_name, item_name),
+                                            data=json.dumps(payload))
+                    assert 200 == resp.status
+                    r = await resp.text()
+                    json_response = json.loads(r)
+                    assert result == json_response
+                patch_get_cat_item.assert_called_once_with(category_name, item_name)
+            patch_set_entry.assert_called_once_with(category_name, item_name, optional_key, payload[optional_key])
+
+    async def test_set_optional_in_config_item_exception(self, client, category_name='rest_api', item_name='http_port'):
+        optional_key = 'readonly'
+        payload = {optional_key: '8082'}
+        storage_client_mock = MagicMock(StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
+            with patch.object(c_mgr, 'set_optional_value_entry', side_effect=ValueError) as patch_set_entry:
+                resp = await client.put('/foglamp/category/{}/{}'.format(category_name, item_name), data=json.dumps(payload))
+                assert 400 == resp.status
+                assert resp.reason is None
+            patch_set_entry.assert_called_once_with(category_name, item_name, optional_key, payload[optional_key])
+
     async def test_delete_config_item(self, client, category_name='rest_api', item_name='http_port'):
         result = {'value': '8081', 'type': 'integer', 'default': '8081',
                   'description': 'The port to accept HTTP connections on'}


### PR DESCRIPTION
**Examples:**

1) Set optional filed
```
curl -X PUT -d '{"minimum": "900"}' http://localhost:8081/foglamp/category/category_name/item_name
```
2) Unsetting an optional field
```
curl -X PUT -d '{"minimum": ""}' http://localhost:8081/foglamp/category/category_name/item_name
```

**Note:** -  Validation is fairly minimal for optional attributes like minimum, maximum and length so all be numeric and maximum should be greater than minimum or vice-versa. And no link between minimum, maximum and length is needed.