### PR TITLE
FOGL-2620: Add system tests for notification REST API

### DIFF
--- a/tests/system/python/api/test_notification.py
+++ b/tests/system/python/api/test_notification.py
@@ -40,10 +40,10 @@ class TestNotificationServiceAPI:
         conn = http.client.HTTPConnection(foglamp_url)
         conn.request("GET", '/foglamp/notification')
         r = conn.getresponse()
-        assert 200 == r.status
+        pytest.xfail("FOGL-2748")
+        assert 400 == r.status
         r = r.read().decode()
-        jdoc = json.loads(r)
-        assert {'notifications': []} == jdoc
+        assert "404: No Notification service available." == r
 
         conn.request("GET", '/foglamp/notification/plugin')
         r = conn.getresponse()
@@ -172,8 +172,8 @@ class TestNotificationServiceAPI:
         assert 2 == len(jdoc['rules'])
 
     @pytest.mark.parametrize("test_input, expected_error", [
-        pytest.param({"name": "Test8"}, '400: Name update is not allowed.', marks=pytest.mark.skip(reason="FOGL-2673")),
-        pytest.param({"name": "="}, '400: Invalid name property in payload.', marks=pytest.mark.skip(reason="FOGL-2673")),
+        pytest.param({"name": "Test8"}, '400: Name update is not allowed.', marks=pytest.mark.xfail(reason="FOGL-2673")),
+        pytest.param({"name": "="}, '400: Invalid name property in payload.', marks=pytest.mark.xfail(reason="FOGL-2673")),
         ({"rule": "+"}, '400: Invalid rule property in payload.'),
         ({"channel": ":"}, '400: Invalid channel property in payload.'),
         ({"enabled": "bla"}, '400: Only "true", "false", true, false are allowed for value of enabled.'),
@@ -192,7 +192,7 @@ class TestNotificationServiceAPI:
         r = r.read().decode()
         assert expected_error == r
 
-    @pytest.mark.skip(reason="FOGL-2738")
+    @pytest.mark.xfail(reason="FOGL-2738")
     def test_invalid_name_update_notification_instance(self, foglamp_url):
         conn = http.client.HTTPConnection(foglamp_url)
         changed_data = {"description": "changed_desc"}
@@ -236,4 +236,4 @@ class TestNotificationServiceAPI:
         r = r.read().decode()
         jdoc = json.loads(r)
         assert "Service {} deleted successfully.".format(SERVICE_NAME) == jdoc['result']
-        assert False
+

--- a/tests/system/python/api/test_notification.py
+++ b/tests/system/python/api/test_notification.py
@@ -41,7 +41,7 @@ class TestNotificationServiceAPI:
         conn.request("GET", '/foglamp/notification')
         r = conn.getresponse()
         pytest.xfail("FOGL-2748")
-        assert 400 == r.status
+        assert 404 == r.status
         r = r.read().decode()
         assert "404: No Notification service available." == r
 

--- a/tests/system/python/api/test_notification.py
+++ b/tests/system/python/api/test_notification.py
@@ -38,12 +38,6 @@ class TestNotificationServiceAPI:
         # Wait for foglamp server to start
         time.sleep(wait_time)
         conn = http.client.HTTPConnection(foglamp_url)
-        conn.request("GET", '/foglamp/notification')
-        r = conn.getresponse()
-        pytest.xfail("FOGL-2748")
-        assert 404 == r.status
-        r = r.read().decode()
-        assert "404: No Notification service available." == r
 
         conn.request("GET", '/foglamp/notification/plugin')
         r = conn.getresponse()
@@ -59,6 +53,13 @@ class TestNotificationServiceAPI:
         assert {"notification_type": ["one shot", "retriggered", "toggled"]} == jdoc
 
         conn.request("POST", '/foglamp/notification', json.dumps({}))
+        r = conn.getresponse()
+        assert 404 == r.status
+        r = r.read().decode()
+        assert "404: No Notification service available." == r
+
+        pytest.xfail("FOGL-2748")
+        conn.request("GET", '/foglamp/notification')
         r = conn.getresponse()
         assert 404 == r.status
         r = r.read().decode()

--- a/tests/system/python/api/test_notification.py
+++ b/tests/system/python/api/test_notification.py
@@ -4,7 +4,7 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-""" Test add service using poll and async plugins for both python & C version REST API """
+""" Test notification REST API """
 
 import os
 import subprocess
@@ -12,11 +12,7 @@ import http.client
 import json
 import time
 import urllib
-from uuid import UUID
-from collections import Counter
-from urllib.parse import quote
 import pytest
-import apt
 
 
 __author__ = "Vaibhav Singhal"

--- a/tests/system/python/api/test_notification.py
+++ b/tests/system/python/api/test_notification.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+
+# FOGLAMP_BEGIN
+# See: http://foglamp.readthedocs.io/
+# FOGLAMP_END
+
+""" Test add service using poll and async plugins for both python & C version REST API """
+
+import os
+import subprocess
+import http.client
+import json
+import time
+import urllib
+from uuid import UUID
+from collections import Counter
+from urllib.parse import quote
+import pytest
+import apt
+
+
+__author__ = "Vaibhav Singhal"
+__copyright__ = "Copyright (c) 2019 Dianomic Systems"
+__license__ = "Apache 2.0"
+__version__ = "${VERSION}"
+
+SERVICE = "notification"
+SERVICE_NAME = "Notification Server #1"
+NOTIFY_PLUGIN = "slack"
+NOTIFY_INBUILT_RULES = ["OverMaxRule", "UnderMinRule"]
+data = {"name": "Test - 1",
+        "description": "Test4_Notification",
+        "rule": NOTIFY_INBUILT_RULES[1],
+        "channel": NOTIFY_PLUGIN,
+        "enabled": True,
+        "notification_type": "one shot"
+        }
+
+
+class TestNotificationServiceAPI:
+    def test_notification_without_install(self, reset_and_start_foglamp, foglamp_url, wait_time):
+        # Wait for foglamp server to start
+        time.sleep(wait_time)
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("GET", '/foglamp/notification')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert {'notifications': []} == jdoc
+
+        conn.request("GET", '/foglamp/notification/plugin')
+        r = conn.getresponse()
+        assert 404 == r.status
+        r = r.read().decode()
+        assert "404: No Notification service available." == r
+
+        conn.request("GET", '/foglamp/notification/type')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert {"notification_type": ["one shot", "retriggered", "toggled"]} == jdoc
+
+        conn.request("POST", '/foglamp/notification', json.dumps({}))
+        r = conn.getresponse()
+        assert 404 == r.status
+        r = r.read().decode()
+        assert "404: No Notification service available." == r
+
+    def test_notification_service_add(self, service_branch, foglamp_url, wait_time, remove_directories):
+        try:
+            subprocess.run(["$FOGLAMP_ROOT/tests/system/python/scripts/install_c_service {} {}"
+                           .format(service_branch, SERVICE)], shell=True, check=True)
+        except subprocess.CalledProcessError:
+            assert False, "{} installation failed".format(SERVICE)
+        finally:
+            remove_directories("/tmp/foglamp-service-{}".format(SERVICE))
+
+        # Start service
+        conn = http.client.HTTPConnection(foglamp_url)
+        data = {"name": SERVICE_NAME,
+                "type": "notification",
+                "enabled": "true"
+                }
+        conn.request("POST", '/foglamp/service', json.dumps(data))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert 2 == len(jdoc)
+        assert SERVICE_NAME == jdoc['name']
+
+        # Wait for service to get created
+        time.sleep(wait_time)
+        conn.request("GET", '/foglamp/service')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert SERVICE_NAME == jdoc['services'][2]['name']
+
+    def test_install_delivery_plugin(self, notify_branch, remove_directories):
+        # Remove any external plugins if installed
+        remove_directories(os.path.expandvars('$FOGLAMP_ROOT/plugins/notificationDelivery'))
+        remove_directories(os.path.expandvars('$FOGLAMP_ROOT/plugins/notificationRule'))
+        try:
+            subprocess.run(["$FOGLAMP_ROOT/tests/system/python/scripts/install_c_plugin {} notify {}".format(
+                notify_branch, NOTIFY_PLUGIN)], shell=True, check=True)
+        except subprocess.CalledProcessError:
+            assert False, "{} installation failed".format(NOTIFY_PLUGIN)
+        finally:
+            remove_directories("/tmp/foglamp-notify-{}".format(NOTIFY_PLUGIN))
+
+    @pytest.mark.parametrize("test_input, expected_error", [
+        ({"description": "Test4_Notification", "rule": NOTIFY_INBUILT_RULES[1], "channel": NOTIFY_PLUGIN,
+          "enabled": True, "notification_type": "one shot"}, '400: Missing name property in payload.'),
+        ({"name": "Test4","rule": NOTIFY_INBUILT_RULES[1], "channel": NOTIFY_PLUGIN, "enabled": True,
+          "notification_type": "one shot"}, '400: Missing description property in payload.'),
+        ({"name": "Test4", "description": "Test4_Notification", "channel": NOTIFY_PLUGIN, "enabled": True,
+          "notification_type": "one shot"}, '400: Missing rule property in payload.'),
+        ({"name": "Test4", "description": "Test4_Notification", "rule": NOTIFY_INBUILT_RULES[1], "enabled": True,
+          "notification_type": "one shot"}, '400: Missing channel property in payload.'),
+        ({"name": "Test4", "description": "Test4_Notification", "rule": NOTIFY_INBUILT_RULES[1],
+          "channel": NOTIFY_PLUGIN, "enabled": True}, '400: Missing notification_type property in payload.'),
+        ({"name": "=", "description": "Test4_Notification", "rule": NOTIFY_INBUILT_RULES[1], "channel": NOTIFY_PLUGIN,
+          "enabled": True, "notification_type": "one shot"}, '400: Invalid name property in payload.'),
+        ({"name": "Test4", "description": "Test4_Notification", "rule": "+", "channel": NOTIFY_PLUGIN, "enabled": True,
+          "notification_type": "one shot"}, '400: Invalid rule property in payload.'),
+        ({"name": "Test4", "description": "Test4_Notification", "rule": NOTIFY_INBUILT_RULES[1], "channel": ":",
+          "enabled": True, "notification_type": "one shot"}, '400: Invalid channel property in payload.'),
+        ({"name": "Test4", "description": "Test4_Notification", "rule": NOTIFY_INBUILT_RULES[1],
+          "channel": NOTIFY_PLUGIN, "enabled": "bla", "notification_type": "one shot"},
+         '400: Only "true", "false", true, false are allowed for value of enabled.'),
+        ({"name": "Test4", "description": "Test4_Notification", "rule": "InvalidRulePlugin",
+          "channel": "InvalidChannelPlugin", "enabled": True, "notification_type": "one shot"},
+         '400: Invalid rule plugin InvalidRulePlugin and/or delivery plugin InvalidChannelPlugin supplied.')
+    ])
+    def test_invalid_create_notification_instance(self, foglamp_url, test_input, expected_error):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("POST", '/foglamp/notification', json.dumps(test_input))
+        r = conn.getresponse()
+        assert 400 == r.status
+        r = r.read().decode()
+        assert expected_error == r
+
+    def test_create_valid_notification_instance(self, foglamp_url):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("POST", '/foglamp/notification', json.dumps(data))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert "Notification {} created successfully".format(data['name']) == jdoc['result']
+
+        conn.request("GET", '/foglamp/notification')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert data['name'] == jdoc['notifications'][0]['name']
+        assert data['channel'] == jdoc['notifications'][0]['channel']
+        assert 'true' == jdoc['notifications'][0]['enable']
+        assert data['notification_type'] == jdoc['notifications'][0]['notificationType']
+        assert data['rule'] == jdoc['notifications'][0]['rule']
+
+        conn.request("GET", '/foglamp/notification/plugin')
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert 2 == len(jdoc)
+        assert NOTIFY_PLUGIN == jdoc['delivery'][0]['name']
+        assert "notificationDelivery" == jdoc['delivery'][0]['type']
+        assert 2 == len(jdoc['rules'])
+
+    # TODO - FOGL-2738, FOGL-2673
+    @pytest.mark.parametrize("test_input, expected_error", [
+        # ({"name": "=", "description": "Test4_Notification", "rule": NOTIFY_INBUILT_RULES[1], "channel": NOTIFY_PLUGIN,
+        #   "enabled": True, "notification_type": "one shot"}, '400: Invalid name property in payload.'),
+        ({"name": "Test4", "description": "Test4_Notification", "rule": "+", "channel": NOTIFY_PLUGIN, "enabled": True,
+          "notification_type": "one shot"}, '400: Invalid rule property in payload.'),
+        ({"name": "Test4", "description": "Test4_Notification", "rule": NOTIFY_INBUILT_RULES[1], "channel": ":",
+          "enabled": True, "notification_type": "one shot"}, '400: Invalid channel property in payload.'),
+        ({"name": "Test4", "description": "Test4_Notification", "rule": NOTIFY_INBUILT_RULES[1],
+          "channel": NOTIFY_PLUGIN, "enabled": "bla", "notification_type": "one shot"},
+         '400: Only "true", "false", true, false are allowed for value of enabled.'),
+        ({"name": "Test4", "description": "Test4_Notification", "rule": "InvalidRulePlugin",
+          "channel": "InvalidChannelPlugin", "enabled": True, "notification_type": "one shot"},
+         '400: Invalid rule plugin:InvalidRulePlugin and/or delivery plugin:InvalidChannelPlugin supplied.')
+    ])
+    def test_invalid_update_notification_instance(self, foglamp_url, test_input, expected_error):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("PUT", '/foglamp/notification/{}'.format(urllib.parse.quote(data['name'])), json.dumps(test_input))
+        r = conn.getresponse()
+        assert 400 == r.status
+        r = r.read().decode()
+        assert expected_error == r
+
+    def test_update_valid_notification_instance(self, foglamp_url):
+        changed_data = {"description": "changed_desc"}
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("PUT", '/foglamp/notification/{}'.format(urllib.parse.quote(data['name'])), json.dumps(changed_data))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert "Notification {} updated successfully".format(data["name"]) == jdoc['result']
+
+    def test_delete_service_without_notification_delete(self, foglamp_url):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("DELETE", '/foglamp/service/{}'.format(urllib.parse.quote(SERVICE_NAME)))
+        r = conn.getresponse()
+        assert 400 == r.status
+        r = r.read().decode()
+        assert "400: Notification service `{}` can not be deleted, as ['{}'] " \
+               "notification instances exist.".format(SERVICE_NAME, data['name']) == r
+
+    def test_delete_notification_and_service(self, foglamp_url):
+        conn = http.client.HTTPConnection(foglamp_url)
+        conn.request("DELETE", '/foglamp/notification/{}'.format(urllib.parse.quote(data['name'])))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert "Notification {} deleted successfully.".format(data['name']) == jdoc['result']
+
+        conn.request("DELETE", '/foglamp/service/{}'.format(urllib.parse.quote(SERVICE_NAME)))
+        r = conn.getresponse()
+        assert 200 == r.status
+        r = r.read().decode()
+        jdoc = json.loads(r)
+        assert "Service {} deleted successfully.".format(SERVICE_NAME) == jdoc['result']

--- a/tests/system/python/e2e/test_e2e_notification_service_with_plugins.py
+++ b/tests/system/python/e2e/test_e2e_notification_service_with_plugins.py
@@ -134,7 +134,9 @@ class TestNotificationService:
 
     def test_get_default_notification_plugins(self, foglamp_url, remove_directories):
         remove_directories(os.environ['FOGLAMP_ROOT'] + '/plugins/notificationDelivery')
+        remove_directories(os.environ['FOGLAMP_ROOT'] + '/plugins/notificationRule')
         remove_directories(os.environ['FOGLAMP_ROOT'] + 'cmake_build/C/plugins/notificationDelivery')
+        remove_directories(os.environ['FOGLAMP_ROOT'] + 'cmake_build/C/plugins/notificationRule')
         jdoc = _get_result(foglamp_url, '/foglamp/notification/plugin')
         assert [] == jdoc['delivery']
         assert 2 == len(jdoc['rules'])


### PR DESCRIPTION
1. Tests added for api test of notification
2. Fixed cleanup of system test for notification
```
FogLAMP/tests/system/python/api $ pytest test_notification.py
=== 22 passed, 4 xfailed in 175.03 seconds ==
```