### PR TITLE
FOGL-2718: Unregister interest in registered categories during service shutdown

### DIFF
--- a/C/services/south/south.cpp
+++ b/C/services/south/south.cpp
@@ -404,6 +404,10 @@ void SouthService::start(string& coreAddress, unsigned short corePort)
 
 		if (southPlugin)
 			southPlugin->shutdown();
+
+		//Unregister interest in categories
+		m_mgtClient->unregisterCategory(m_name);
+		m_mgtClient->unregisterCategory(m_name+"Advanced");
 		
 		// Clean shutdown, unregister the storage service
 		m_mgtClient->unregisterService();


### PR DESCRIPTION
The reported error when recreating same service with same name is now not coming:

"ERROR: change_callback: foglamp.services.core.interest_registry.change_callback: Unable to notify microservice with uuid 194efc94-535d-43b2-8a25-c4e586e2d251 as it is not found in the service registry#012Traceback (most recent call last):#012  File "/usr/local/foglamp/python/foglamp/services/core/interest_registry/change_callback.py", line 51, in run#012    service_record = ServiceRegistry.get(idx=i._microservice_uuid)[0]#012  File "/usr/local/foglamp/python/foglamp/services/core/service_registry/service_registry.py", line 158, in get#012    raise service_registry_exceptions.DoesNotExist#012foglamp.services.core.service_registry.exceptions.DoesNotExist"

The other error during service shutdown is still there:

"ERROR: HTTP error during service unregistration: 404: Service with ef1637f4-34bc-4f34-81cf-ecc01f04824a does not exist"