### PR TITLE
FOGL-2773: Allow service name with double quotes escaped in FogLAMP C…

### DIFF
--- a/C/common/include/json_utils.h
+++ b/C/common/include/json_utils.h
@@ -7,8 +7,11 @@
  *
  * Released under the Apache 2.0 Licence
  *
- * Author: Stefano Simonelli
+ * Author: Stefano Simonelli, Massimiliano Pinto
  */
+
+#include<vector>
+#include<string>
 
 bool JSONStringToVectorString(std::vector<std::string>& vectorString,
                               const std::string& JSONString,

--- a/C/common/service_record.cpp
+++ b/C/common/service_record.cpp
@@ -10,6 +10,7 @@
 #include <service_record.h>
 #include <string>
 #include <sstream>
+#include <json_utils.h>
 
 using namespace std;
 
@@ -63,7 +64,7 @@ void ServiceRecord::asJSON(string& json) const
 ostringstream convert;
 
 	convert << "{ ";
-	convert << "\"name\" : \"" << m_name << "\",";
+	convert << "\"name\" : \"" << JSONescape(m_name) << "\",";
 	convert << "\"type\" : \"" << m_type << "\",";
 	convert << "\"protocol\" : \"" << m_protocol << "\",";
 	convert << "\"address\" : \"" << m_address << "\",";


### PR DESCRIPTION
…++ classes

FOGL-2773: Allow service name with double quotes escaped in FogLAMP C++ classes