### PR TITLE
FOGL-2770 updated pyjq to latest version; Required for coral board

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,4 +5,4 @@ cchardet==2.1.1
 pyjwt==1.6.4
 
 # Transformation of data, Apply JqFilter
-pyjq==2.2.0
+pyjq==2.3.1


### PR DESCRIPTION
**Test compatibility issues with all the other platforms we support and packaging implications of this change.**

- [x] Ubuntu 16
- [x] Ubuntu 18 
- [x] Raspbian
- [x] RHEL, 
- [x] CentOS [Tested with FOGL-2751 branch]
- [x] AArch64 
- [x] Docker containers 
