### PR TITLE
FOGL-2869 plugins available support added in REST API

### DIFF
--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -4,10 +4,18 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
+import os
+import platform
+import subprocess
+import logging
+
 from aiohttp import web
 from foglamp.common.plugin_discovery import PluginDiscovery
+from foglamp.services.core.api import utils
+from foglamp.common.common import _FOGLAMP_ROOT, _FOGLAMP_DATA
+from foglamp.common import logger
 
-__author__ = "Amarendra K Sinha"
+__author__ = "Amarendra K Sinha, Ashish Jabble"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
@@ -16,8 +24,10 @@ __version__ = "${VERSION}"
 _help = """
     -------------------------------------------------------------------------------
     | GET             | /foglamp/plugins/installed                                |
+    | GET             | /foglamp/plugins/available                                |
     -------------------------------------------------------------------------------
 """
+_logger = logger.setup(__name__, level=logging.INFO)
 
 
 async def get_plugins_installed(request):
@@ -47,5 +57,62 @@ async def get_plugins_installed(request):
             (type(config) is bool and config is True))) else False
 
     plugins_list = PluginDiscovery.get_plugins_installed(plugin_type, is_config)
+
+    return web.json_response({"plugins": plugins_list})
+
+
+async def get_plugins_available(request: web.Request) -> web.Response:
+    """ get list of a available plugins via package management i.e apt or yum
+
+        :Example:
+            curl -X GET http://localhost:8081/foglamp/plugins/available
+            curl -X GET http://localhost:8081/foglamp/plugins/available?type=north | south | filter | notify | rule | service
+    """
+    try:
+        package_type = None
+        if 'type' in request.query and request.query['type'] != '':
+            package_type = request.query['type'].lower()
+
+        if package_type is not None and package_type not in ['north', 'south', 'filter', 'notify', 'rule', 'service']:
+            raise ValueError("Invalid package type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule' or 'service'.")
+
+        plugins_list = []
+        plugin_dir = '/plugins/'
+        _PATH = _FOGLAMP_DATA + plugin_dir if _FOGLAMP_DATA else _FOGLAMP_ROOT + '/data{}'.format(plugin_dir)
+        stdout_file_name = "output.txt"
+        stdout_file_path = "/{}/{}".format(_PATH, stdout_file_name)
+
+        if not os.path.exists(_PATH):
+            os.makedirs(_PATH)
+
+        _platform = platform.platform()
+
+        pkg_type = "" if package_type is None else package_type
+        if 'centos' in _platform or 'redhat' in _platform:
+            cmd = "sudo yum list available foglamp-{}\* | grep foglamp | cut -d . -f1 > {} 2>&1".format(pkg_type, stdout_file_path)
+        else:
+            cmd = "sudo apt list | grep foglamp-{} | grep -v installed | cut -d / -f1  > {} 2>&1".format(pkg_type, stdout_file_path)
+
+        ret_code = os.system(cmd)
+        if ret_code != 0:
+            raise ValueError
+
+        with open("{}".format(stdout_file_path), 'r') as fh:
+            for line in fh:
+                line = line.rstrip("\n")
+                plugins_list.append(line)
+
+        # Remove stdout file
+        arg1 = utils._find_c_util('cmdutil')
+        # FIXME: (low priority) special case for cmdutil when FOGLAMP_DATA as we do not need absolute path for filename to delete
+        # and cmdutil commands only works with make install
+        # arg2 = plugin_dir if _FOGLAMP_DATA else '/data{}'.format(plugin_dir)
+        arg2 = '/data{}'.format(plugin_dir)
+        cmd = "{} rm {}{}".format(arg1, arg2, stdout_file_name)
+        subprocess.run([cmd], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    except ValueError as ex:
+        raise web.HTTPBadRequest(reason=ex)
+    except Exception as ex:
+        raise web.HTTPInternalServerError(reason=ex)
 
     return web.json_response({"plugins": plugins_list})

--- a/python/foglamp/services/core/routes.py
+++ b/python/foglamp/services/core/routes.py
@@ -159,6 +159,7 @@ def setup(app):
 
     # Plugins (install, discovery)
     app.router.add_route('GET', '/foglamp/plugins/installed', plugin_discovery.get_plugins_installed)
+    app.router.add_route('GET', '/foglamp/plugins/available', plugin_discovery.get_plugins_available)
     app.router.add_route('POST', '/foglamp/plugins', plugins_install.add_plugin)
 
     # Filters 


### PR DESCRIPTION
Below is the list for installed packages
```$ sudo yum list installed | grep foglamp
foglamp.x86_64                   1.6.0-1         installed                        
foglamp-south-sinusoid.x86_64    1.6.0-1         installed
```

All available packages onto system
```
1) $ curl -sX GET http://localhost:8081/foglamp/plugins/available | jq
{
  "plugins": [
    "foglamp-filter-asset",
    "foglamp-filter-delta",
    "foglamp-filter-expression",
    "foglamp-filter-fft",
    "foglamp-filter-metadata",
    "foglamp-filter-python35",
    "foglamp-filter-rate",
    "foglamp-filter-rms",
    "foglamp-filter-scale",
    "foglamp-filter-scale-set",
    "foglamp-filter-threshold",
    "foglamp-gui",
    "foglamp-north-http",
    "foglamp-north-httpc",
    "foglamp-north-kafka",
    "foglamp-north-thingspeak",
    "foglamp-notify-alexa",
    "foglamp-notify-asset",
    "foglamp-notify-blynk",
    "foglamp-notify-email",
    "foglamp-notify-hangouts",
    "foglamp-notify-ifttt",
    "foglamp-notify-python35",
    "foglamp-notify-slack",
    "foglamp-notify-telegram",
    "foglamp-quickstart",
    "foglamp-rule-outofbound",
    "foglamp-rule-simple-expression",
    "foglamp-service-notification",
    "foglamp-south-CSV-Async",
    "foglamp-south-benchmark",
    "foglamp-south-cc2650",
    "foglamp-south-coap",
    "foglamp-south-csv",
    "foglamp-south-expression",
    "foglamp-south-http",
    "foglamp-south-modbus",
    "foglamp-south-modbustcp",
    "foglamp-south-mqtt_sparkplug",
    "foglamp-south-opcua",
    "foglamp-south-openweathermap",
    "foglamp-south-playback",
    "foglamp-south-random",
    "foglamp-south-randomwalk",
    "foglamp-south-roxtec",
    "foglamp-south-sensorphone",
    "foglamp-south-systeminfo"
  ]
}
```
**via type request param** ( Supported types are north | south | filter | notify | rule | service)
```
2) $ curl -sX GET http://localhost:8081/foglamp/plugins/available?type=north | jq
{
  "plugins": [
    "foglamp-north-http",
    "foglamp-north-httpc",
    "foglamp-north-kafka",
    "foglamp-north-thingspeak"
  ]
}

```

@MarkRiddoch Do we need to exclude foglamp-gui and foglamp-quickstart packages in the response?