### PR TITLE
FOGL-2852: RHEL / CentOS: verify/fix some unit tests using Postgres/CentOS

### DIFF
--- a/tests/unit/C/services/storage/postgres/testRunner.sh
+++ b/tests/unit/C/services/storage/postgres/testRunner.sh
@@ -98,12 +98,23 @@ mkdir results
 cat testset | while read name method url payload optional; do
 echo -n "Test $testNum ${name}: "
 if [ "$payload" = "" ] ; then
-	curl -X $method $url -o results/$testNum >/dev/null 2>&1
+	output=$(curl -X $method $url -o results/$testNum 2>/dev/null)
 	curlstate=$?
 else
-	curl -X $method $url -d@payloads/$payload -o results/$testNum >/dev/null 2>&1
+	output=$(curl -X $method $url -d@payloads/$payload 2>/dev/null)
 	curlstate=$?
+
 fi
+
+# Forces the creation on an empty file if the output of the curl command is empty
+# it is needed for the behaviour of the curl command in RHEL/CentOS
+if [ "$output" = "" ] ; then
+
+	touch results/$testNum
+else
+	echo -n "${output}" > results/$testNum
+fi
+
 if [ "$optional" = "" ] ; then
 	if [ ! -f ${expected_dir}/$testNum ]; then
 		n_unchecked=`expr $n_unchecked + 1`

--- a/tests/unit/C/services/storage/postgres/testRunner.sh
+++ b/tests/unit/C/services/storage/postgres/testRunner.sh
@@ -107,7 +107,7 @@ else
 fi
 
 # Forces the creation on an empty file if the output of the curl command is empty
-# it is needed for the behaviour of the curl command in RHEL/CentOS
+# it is needed for the behavior of the curl command in RHEL/CentOS
 if [ "$output" = "" ] ; then
 
 	touch results/$testNum

--- a/tests/unit/C/services/storage/sqlite/testRunner.sh
+++ b/tests/unit/C/services/storage/sqlite/testRunner.sh
@@ -88,12 +88,22 @@ cat testset | while read name method url payload optional; do
 #sleep 0.003
 echo -n "Test $testNum ${name}: "
 if [ "$payload" = "" ] ; then
-	curl -X $method $url -o results/$testNum >/dev/null 2>&1
+	output=$(curl -X $method $url -o results/$testNum 2>/dev/null)
 	curlstate=$?
 else
-	curl -X $method $url -d@payloads/$payload -o results/$testNum >/dev/null 2>&1
+	output=$(curl -X $method $url -d@payloads/$payload -o results/$testNum 2>/dev/null)
 	curlstate=$?
 fi
+
+# Forces the creation on an empty file if the output of the curl command is empty
+# it is needed for the behaviour of the curl command in RHEL/CentOS
+if [ "$output" = "" ] ; then
+
+	touch results/$testNum
+else
+	echo -n "${output}" > results/$testNum
+fi
+
 if [ "$optional" = "" ] ; then
 	if [ ! -f ${expected_dir}/$testNum ]; then
 		n_unchecked=`expr $n_unchecked + 1`

--- a/tests/unit/C/services/storage/sqlite/testRunner.sh
+++ b/tests/unit/C/services/storage/sqlite/testRunner.sh
@@ -96,7 +96,7 @@ else
 fi
 
 # Forces the creation on an empty file if the output of the curl command is empty
-# it is needed for the behaviour of the curl command in RHEL/CentOS
+# it is needed for the behavior of the curl command in RHEL/CentOS
 if [ "$output" = "" ] ; then
 
 	touch results/$testNum


### PR DESCRIPTION
Forces the creation on an empty file if the output of the curl command is empty
it is needed for the behavior of the curl command in RHEL/CentOS

tested on :
* CentOS
* RHEL (in AWS)

REHL - SQLite :
![image](https://user-images.githubusercontent.com/4919069/59351222-2fae5400-8d1e-11e9-82ca-e7dee2431227.png)

REHL - Postgres:
![image](https://user-images.githubusercontent.com/4919069/59351161-055c9680-8d1e-11e9-8599-9c7f33831327.png)

