### PR TITLE
FOGL-2910 - Exclude non-plugins package from GET/POST available plugins

### DIFF
--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -62,16 +62,19 @@ async def get_plugins_available(request: web.Request) -> web.Response:
 
         :Example:
             curl -X GET http://localhost:8081/foglamp/plugins/available
-            curl -X GET http://localhost:8081/foglamp/plugins/available?type=north | south | filter | notify | rule | service
+            curl -X GET http://localhost:8081/foglamp/plugins/available?type=north | south | filter | notify | rule
     """
     try:
         package_type = ""
         if 'type' in request.query and request.query['type'] != '':
             package_type = request.query['type'].lower()
 
-        if package_type and package_type not in ['north', 'south', 'filter', 'notify', 'rule', 'service']:
-            raise ValueError("Invalid package type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule' or 'service'.")
+        if package_type and package_type not in ['north', 'south', 'filter', 'notify', 'rule']:
+            raise ValueError("Invalid package type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'.")
         plugins = common.fetch_available_plugins(package_type)
+        # foglamp-gui, foglamp-quickstart and foglamp-service-* packages are excluded when no type is given
+        if not package_type:
+            plugins = [e for e in plugins if not str(e).startswith('foglamp-service-') and e not in ('foglamp-quickstart', 'foglamp-gui')]
     except ValueError as ex:
         raise web.HTTPBadRequest(reason=ex)
     except Exception as ex:

--- a/python/foglamp/services/core/api/plugin_discovery.py
+++ b/python/foglamp/services/core/api/plugin_discovery.py
@@ -71,10 +71,10 @@ async def get_plugins_available(request: web.Request) -> web.Response:
 
         if package_type and package_type not in ['north', 'south', 'filter', 'notify', 'rule']:
             raise ValueError("Invalid package type. Must be 'north' or 'south' or 'filter' or 'notify' or 'rule'.")
-        plugins = common.fetch_available_plugins(package_type)
+        plugins = common.fetch_available_packages(package_type)
         # foglamp-gui, foglamp-quickstart and foglamp-service-* packages are excluded when no type is given
         if not package_type:
-            plugins = [e for e in plugins if not str(e).startswith('foglamp-service-') and e not in ('foglamp-quickstart', 'foglamp-gui')]
+            plugins = [p for p in plugins if not str(p).startswith('foglamp-service-') and p not in ('foglamp-quickstart', 'foglamp-gui')]
     except ValueError as ex:
         raise web.HTTPBadRequest(reason=ex)
     except Exception as ex:

--- a/python/foglamp/services/core/api/plugins/common.py
+++ b/python/foglamp/services/core/api/plugins/common.py
@@ -106,7 +106,7 @@ def load_and_fetch_c_hybrid_plugin_info(plugin_name: str, is_config: bool, plugi
     return plugin_info
 
 
-def fetch_available_plugins(package_type: str = "") -> list:
+def fetch_available_packages(package_type: str = "") -> list:
     plugins = []
     plugin_dir = '/plugins/'
     _PATH = _FOGLAMP_DATA + plugin_dir if _FOGLAMP_DATA else _FOGLAMP_ROOT + '/data{}'.format(plugin_dir)

--- a/python/foglamp/services/core/api/plugins/install.py
+++ b/python/foglamp/services/core/api/plugins/install.py
@@ -72,7 +72,7 @@ async def add_plugin(request: web.Request) -> web.Response:
                 if str(version).count(delimiter) != 2:
                     raise ValueError('Plugin semantic version is incorrect; it should be like X.Y.Z')
 
-            plugins = common.fetch_available_plugins()
+            plugins = common.fetch_available_packages()
             if name not in plugins:
                 raise KeyError('{} plugin is not available for the given repository'.format(name))
 

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -164,7 +164,7 @@ async def add_service(request):
                     if str(version).count(delimiter) != 2:
                         raise ValueError('Service semantic version is incorrect; it should be like X.Y.Z')
 
-                services = common.fetch_available_plugins("service")
+                services = common.fetch_available_packages("service")
                 if name not in services:
                     raise KeyError('{} service is not available for the given repository or already installed'.format(name))
 
@@ -369,7 +369,7 @@ async def get_available(request: web.Request) -> web.Response:
             curl -X GET http://localhost:8081/foglamp/service/available
     """
     try:
-        services = common.fetch_available_plugins("service")
+        services = common.fetch_available_packages("service")
     except ValueError as ex:
         raise web.HTTPBadRequest(reason=ex)
     except Exception as ex:

--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -134,8 +134,8 @@ async def add_service(request):
              curl -sX POST http://localhost:8081/foglamp/service -d '{"name": "Sine", "plugin": "sinusoid", "type": "south", "enabled": true, "config": {"dataPointsPerSec": {"value": "10"}}}' | jq
              curl -X POST http://localhost:8081/foglamp/service -d '{"name": "NotificationServer", "type": "notification", "enabled": true}' | jq
 
-             curl -sX POST http://localhost:8081/foglamp/plugins -d '{"format":"repository", "name": "foglamp-service-notification"}?action=install'
-             curl -sX POST http://localhost:8081/foglamp/plugins -d '{"format":"repository", "name": "foglamp-service-notification", "version":"1.6.0"}?action=install'
+             curl -sX POST http://localhost:8081/foglamp/service?action=install -d '{"format":"repository", "name": "foglamp-service-notification"}'
+             curl -sX POST http://localhost:8081/foglamp/service?action=install -d '{"format":"repository", "name": "foglamp-service-notification", "version":"1.6.0"}'
     """
 
     try:
@@ -375,4 +375,4 @@ async def get_available(request: web.Request) -> web.Response:
     except Exception as ex:
         raise web.HTTPInternalServerError(reason=ex)
 
-    return web.json_response({"service": services})
+    return web.json_response({"services": services})

--- a/python/foglamp/services/core/routes.py
+++ b/python/foglamp/services/core/routes.py
@@ -105,6 +105,7 @@ def setup(app):
     app.router.add_route('POST', '/foglamp/service', service.add_service)
     app.router.add_route('GET', '/foglamp/service', service.get_health)
     app.router.add_route('DELETE', '/foglamp/service/{service_name}', service.delete_service)
+    app.router.add_route('GET', '/foglamp/service/available', service.get_available)
 
     # Task
     app.router.add_route('POST', '/foglamp/scheduled/task', task.add_task)

--- a/tests/unit/python/foglamp/services/core/api/plugins/test_install.py
+++ b/tests/unit/python/foglamp/services/core/api/plugins/test_install.py
@@ -226,11 +226,11 @@ class TestPluginInstall:
     async def test_post_bad_plugin_install_package_from_repo(self, client):
         plugin = "foglamp-south-sinusoid"
         param = {"format": "repository", "name": plugin}
-        with patch.object(common, 'fetch_available_plugins', return_value=[]) as avail_plugin_patch:
+        with patch.object(common, 'fetch_available_packages', return_value=[]) as patch_fetch_available_package:
             resp = await client.post('/foglamp/plugins', data=json.dumps(param))
             assert 404 == resp.status
             assert "'{} plugin is not available for the given repository'".format(plugin) == resp.reason
-        avail_plugin_patch.assert_called_once_with()
+        patch_fetch_available_package.assert_called_once_with()
 
     @pytest.mark.parametrize("plugin_name", [
         'foglamp-south-modbusc',
@@ -243,9 +243,9 @@ class TestPluginInstall:
         param = {"format": "repository", "name": plugin_name}
         _platform = platform.platform()
         pkg_mgt = 'yum' if 'centos' in _platform or 'redhat' in _platform else 'apt'
-        with patch.object(common, 'fetch_available_plugins',
+        with patch.object(common, 'fetch_available_packages',
                           return_value=[plugin_name, "foglamp-north-http",
-                                        "foglamp-service-notification"]) as avail_plugin_patch:
+                                        "foglamp-service-notification"]) as patch_fetch_available_package:
             with patch.object(plugins_install, 'install_package_from_repo',
                               return_value=(0, 'Success')) as install_package_patch:
                 resp = await client.post('/foglamp/plugins', data=json.dumps(param))
@@ -254,4 +254,4 @@ class TestPluginInstall:
                 response = json.loads(result)
                 assert {"message": "{} is successfully installed".format(plugin_name)} == response
             install_package_patch.assert_called_once_with(plugin_name, pkg_mgt, None)
-        avail_plugin_patch.assert_called_once_with()
+        patch_fetch_available_package.assert_called_once_with()

--- a/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_plugin_discovery_api.py
@@ -81,9 +81,9 @@ class TestPluginDiscoveryApi:
         ("?type=filter&config=true", "filter", {"name": "scale", "version": "1.0.0", "type": "filter", "description": "Filter Scale plugin",
                                                 "config": {"offset": {"default": "0.0", "type": "float", "description": "A constant offset"}, "factor": {"default": "100.0", "type": "float", "description": "Scale factor for a reading."}, "plugin": {"default": "scale", "type": "string", "description": "Scale filter plugin"}, "enable": {"default": "false", "type": "boolean", "description": "A switch that can be used to enable or disable."}}}, True),
         ("?type=notificationDelivery&config=true", "notificationDelivery", {"name": "email", "version": "1.0.0", "type": "notify", "description": "Email notification plugin",
-                                                "config": {"plugin": {"type": "string", "description": "Email notification plugin", "default": "email"}}}, True),
+                                                                            "config": {"plugin": {"type": "string", "description": "Email notification plugin", "default": "email"}}}, True),
         ("?type=notificationRule&config=true", "notificationRule", {"name": "OverMaxRule", "version": "1.0.0", "type": "rule", "description": "The OverMaxRule notification rule plugin",
-                                            "config": {"plugin": {"type": "string", "description": "The OverMaxRule notification rule plugin", "default": "OverMaxRule"}}}, True)
+                                                                    "config": {"plugin": {"type": "string", "description": "The OverMaxRule notification rule plugin", "default": "OverMaxRule"}}}, True)
     ])
     async def test_get_plugins_installed_by_type_and_config(self, client, param, _type, result, is_config):
         with patch.object(PluginDiscovery, 'get_plugins_installed', return_value=result) as patch_get_plugin_installed:
@@ -124,14 +124,14 @@ class TestPluginDiscoveryApi:
         ("?type=notify", ['foglamp-notify-slack'], ['foglamp-notify-slack'])
     ])
     async def test_get_plugins_available(self, client, param, output, result):
-        with patch.object(common, 'fetch_available_plugins', return_value=output) as patch_fetch_available_plugins:
+        with patch.object(common, 'fetch_available_packages', return_value=output) as patch_fetch_available_package:
             resp = await client.get('/foglamp/plugins/available{}'.format(param))
             assert 200 == resp.status
             r = await resp.text()
             json_response = json.loads(r)
             assert result == json_response['plugins']
         if param:
-            patch_fetch_available_plugins.assert_called_once_with(param.split("=")[1])
+            patch_fetch_available_package.assert_called_once_with(param.split("=")[1])
 
     async def test_bad_get_plugins_available(self, client):
         resp = await client.get('/foglamp/plugins/available?type=blah')

--- a/tests/unit/python/foglamp/services/core/api/test_service.py
+++ b/tests/unit/python/foglamp/services/core/api/test_service.py
@@ -644,4 +644,13 @@ class TestService:
             assert "'{} service is not available for the given repository or already installed'".format(svc) == resp.reason
         patch_fetch_available_package.assert_called_once_with('service')
 
+    async def test_get_service_available(self, client):
+        with patch.object(common, 'fetch_available_packages', return_value=[]) as patch_fetch_available_package:
+            resp = await client.get('/foglamp/service/available')
+            assert 200 == resp.status
+            result = await resp.text()
+            json_response = json.loads(result)
+            assert {'services': []} == json_response
+        patch_fetch_available_package.assert_called_once_with('service')
+
 # TODO:  add negative tests and C type plugin add service tests

--- a/tests/unit/python/foglamp/services/core/api/test_service.py
+++ b/tests/unit/python/foglamp/services/core/api/test_service.py
@@ -4,13 +4,14 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-
+import platform
 import asyncio
 import json
 from uuid import UUID
-from aiohttp import web
-import pytest
 from unittest.mock import MagicMock, patch, call
+import pytest
+from aiohttp import web
+
 from foglamp.services.core import routes
 from foglamp.services.core import connect
 from foglamp.common.storage_client.storage_client import StorageClientAsync
@@ -24,6 +25,8 @@ from foglamp.common.configuration_manager import ConfigurationManager
 from foglamp.services.core.api import service
 from foglamp.services.core.api.plugins import common
 from foglamp.services.core.api.service import _logger
+from foglamp.services.core.api.plugins import install
+
 
 __author__ = "Ashwin Gopalakrishnan, Ashish Jabble"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -602,5 +605,43 @@ class TestService:
         resp = await client.delete("/foglamp/service/{}".format(name))
         assert 404 == resp.status
         assert '{} service does not exist.'.format(name) == resp.reason
+
+    async def test_post_service_package_from_repo(self, client):
+        svc_name = 'foglamp-service-notification'
+        param = {"format": "repository", "name": svc_name}
+        _platform = platform.platform()
+        pkg_mgt = 'yum' if 'centos' in _platform or 'redhat' in _platform else 'apt'
+        with patch.object(common, 'fetch_available_plugins', return_value=[svc_name]) as avail_plugin_patch:
+            with patch.object(install, 'install_package_from_repo',
+                              return_value=(0, 'Success')) as install_package_patch:
+                resp = await client.post('/foglamp/service?action=install', data=json.dumps(param))
+                assert 200 == resp.status
+                result = await resp.text()
+                response = json.loads(result)
+                assert {"message": "{} is successfully installed".format(svc_name)} == response
+            install_package_patch.assert_called_once_with(svc_name, pkg_mgt, None)
+        avail_plugin_patch.assert_called_once_with('service')
+
+    @pytest.mark.parametrize("req_param, post_param, message", [
+        ("?action=install", {"name": "blah"}, "format param is required"),
+        ("?action=install", {"format": "repository"}, "Missing name property in payload."),
+        ("?action=install", {"format": "blah", "name": "blah"}, "Invalid format. Must be 'repository'"),
+        ("?action=blah", {"format": "blah", "name": "blah"}, "blah is not a valid action"),
+        ("?action=install", {"format": "repository", "name": "foglamp-service-notification", "version": "1.6"},
+         "Service semantic version is incorrect; it should be like X.Y.Z")
+    ])
+    async def test_bad_post_service_package_from_repo(self, client, req_param, post_param, message):
+        resp = await client.post('/foglamp/service{}'.format(req_param), data=json.dumps(post_param))
+        assert 400 == resp.status
+        assert message == resp.reason
+
+    async def test_post_service_package_from_repo_is_not_available(self, client):
+        svc = "foglamp-service-notification"
+        param = {"format": "repository", "name": svc}
+        with patch.object(common, 'fetch_available_plugins', return_value=[]) as avail_plugin_patch:
+            resp = await client.post('/foglamp/service?action=install', data=json.dumps(param))
+            assert 404 == resp.status
+            assert "'{} service is not available for the given repository or already installed'".format(svc) == resp.reason
+        avail_plugin_patch.assert_called_once_with('service')
 
 # TODO:  add negative tests and C type plugin add service tests


### PR DESCRIPTION
Fixed items
- [x] foglamp-gui, foglamp-quickstart and foglamp-service-* - excluded from GET available plugins
- [x] New endpoint GET  /foglamp/service/available   added
- [x] POST endpoint to install service package with optional request param `?action=install` -- As this is not a SERVICE to add
- [x] unit tests added with improve code coverage