### PR TITLE
FOGL-2888 hybrid plugins merge configuration for all fields if given instead default

### DIFF
--- a/python/foglamp/services/core/api/plugins/common.py
+++ b/python/foglamp/services/core/api/plugins/common.py
@@ -64,6 +64,9 @@ def load_and_fetch_python_plugin_info(plugin_module_path: str, plugin: str, _typ
 def load_and_fetch_c_hybrid_plugin_info(plugin_name: str, is_config: bool, plugin_type='south') -> Dict:
     plugin_info = None
     if plugin_type == 'south':
+        config_items = ['default', 'type', 'description']
+        optional_items = ['readonly', 'order', 'length', 'maximum', 'minimum', 'rule', 'deprecated', 'displayName', 'options']
+        config_items.extend(optional_items)
         plugin_dir = _FOGLAMP_ROOT + '/' + 'plugins' + '/' + plugin_type
         if _FOGLAMP_PLUGIN_PATH:
             plugin_paths = _FOGLAMP_PLUGIN_PATH.split(";")
@@ -94,16 +97,15 @@ def load_and_fetch_c_hybrid_plugin_info(plugin_name: str, is_config: bool, plugi
                         temp['plugin']['default'] = plugin_name
                         temp['plugin']['description'] = data['description']
                         for _key in intersection:
-                            config_item_keys_a = set(temp[_key].keys())
-                            config_item_keys_b = set(data['defaults'][_key].keys())
-                            config_item_intersection = config_item_keys_a & config_item_keys_b
-                            for _config_key in config_item_intersection:
-                                if temp[_key]['type'] == 'JSON':
-                                    temp[_key][_config_key] = json.dumps(data['defaults'][_key][_config_key])
-                                elif temp[_key]['type'] == 'enumeration':
-                                    temp[_key][_config_key] = data['defaults'][_key][_config_key]
-                                else:
-                                    temp[_key][_config_key] = str(data['defaults'][_key][_config_key])
+                            config_item_keys = set(data['defaults'][_key].keys())
+                            for _config_key in config_item_keys:
+                                if _config_key in config_items:
+                                    if temp[_key]['type'] == 'JSON' and _config_key == 'default':
+                                        temp[_key][_config_key] = json.dumps(data['defaults'][_key][_config_key])
+                                    elif temp[_key]['type'] == 'enumeration' and _config_key == 'default':
+                                        temp[_key][_config_key] = data['defaults'][_key][_config_key]
+                                    else:
+                                        temp[_key][_config_key] = str(data['defaults'][_key][_config_key])
                         if is_config:
                             plugin_info.update({'config': temp})
                     else:

--- a/python/foglamp/services/core/api/plugins/common.py
+++ b/python/foglamp/services/core/api/plugins/common.py
@@ -88,13 +88,22 @@ def load_and_fetch_c_hybrid_plugin_info(plugin_name: str, is_config: bool, plugi
                         keys_a = set(jdoc['config'].keys())
                         keys_b = set(data['defaults'].keys())
                         intersection = keys_a & keys_b
-                        # Merge default configuration of both connection plugin and hybrid plugin with intersection of 'config' keys
+                        # Merge default and other configuration fields of both connection plugin and hybrid plugin with intersection of 'config' keys
                         # Use Hybrid Plugin name and description defined in json file
                         temp = jdoc['config']
                         temp['plugin']['default'] = plugin_name
                         temp['plugin']['description'] = data['description']
                         for _key in intersection:
-                            temp[_key]['default'] = json.dumps(data['defaults'][_key]['default']) if temp[_key]['type'] == 'JSON' else str(data['defaults'][_key]['default'])
+                            config_item_keys_a = set(temp[_key].keys())
+                            config_item_keys_b = set(data['defaults'][_key].keys())
+                            config_item_intersection = config_item_keys_a & config_item_keys_b
+                            for _config_key in config_item_intersection:
+                                if temp[_key]['type'] == 'JSON':
+                                    temp[_key][_config_key] = json.dumps(data['defaults'][_key][_config_key])
+                                elif temp[_key]['type'] == 'enumeration':
+                                    temp[_key][_config_key] = data['defaults'][_key][_config_key]
+                                else:
+                                    temp[_key][_config_key] = str(data['defaults'][_key][_config_key])
                         if is_config:
                             plugin_info.update({'config': temp})
                     else:


### PR DESCRIPTION
**JSON file content**

```
{
	"description": "A Modbus connected Flir AX8 thermal imaging camera",
	"name": "FlirAX8",
	"connection": "ModbusC",
	"defaults": {
		"map": {
			"default": {
				"values": [{
					"name": "delta1",
					"inputRegister": [1006, 1005],
					"type": "float"
				}]
			},
			"displayName": "Registered Map"
		},
		"protocol": {
			"default": "RTU",
			"readonly": "true",
			"blah": "blah",
			"deprecated": "true",
			"displayName": "updated protocol disp",
			"options": ["RTU", "TCP", "UDP"]
		},
		"port": {
			"default": "500",
			"type": "string",
			"length": "6"
		},
		"asset": {
			"default": "AX8",
			"order": "12",
			"displayName": "updated Asset Name disp",
			"description": "Updated asset name desc"
		},
		"parity": {
			"default": "even",
			"options": ["even"],
			"displayName": "updated parity disp",
			"description": "Updated parity desc"
		},
		"plugin": {
			"default": "ModbusC",
			"readonly": "false"
		},
		"baud": {
			"default": "1800",
			"minimum": "100",
			"maximum": "2000"
		}
	}
}

```

See the O/P => Now we have merged other fields including `default` key. For example with above sample `asset`, `protocol` config item etc....

```
$ curl -sX GET 'http://localhost:8081/foglamp/plugins/installed?type=south&config=true' | jq 
{
  "plugins": [
    {
 	"version": "1.6.0",
 	"config": {
 		"parity": {
 			"default": "even",
 			"type": "enumeration",
 			"displayName": "updated parity disp",
 			"description": "Updated parity desc",
 			"order": "9",
 			"options": [
 				"even"
 			]
 		},
 		"asset": {
 			"order": "12",
 			"default": "AX8",
 			"type": "string",
 			"displayName": "updated Asset Name disp",
 			"description": "Updated asset name desc"
 		},
 		"map": {
 			"order": "11",
 			"default": "{\"values\": [{\"inputRegister\": [1006, 1005], \"type\": \"float\", \"name\": \"delta1\"}]}",
 			"type": "JSON",
 			"displayName": "Registered Map",
 			"description": "Modbus register map"
 		},
 		"baud": {
 			"maximum": "2000",
 			"default": "1800",
 			"type": "integer",
 			"displayName": "Baud Rate",
 			"description": "Baud rate  of Modbus RTU",
 			"order": "6",
 			"minimum": "100"
 		},
 		"plugin": {
 			"default": "ModbusC",
 			"type": "string",
 			"description": "A Modbus connected Flir AX8 thermal imaging camera",
 			"readonly": "false"
 		},
 		"protocol": {
 			"default": "RTU",
 			"type": "enumeration",
 			"displayName": "updated protocol disp",
 			"description": "Protocol",
 			"order": "2",
 			"readonly": "true",
 			"options": [
 				"RTU",
 				"TCP",
 				"UDP"
 			],
 			"deprecated": "true"
 		},
 		"bits": {
 			"order": "7",
 			"default": "8",
 			"type": "integer",
 			"displayName": "Number Of Data Bits",
 			"description": "Number of data bits for Modbus RTU"
 		},
 		"device": {
 			"order": "5",
 			"default": "",
 			"type": "string",
 			"displayName": "Device",
 			"description": "Device for Modbus RTU"
 		},
 		"port": {
 			"default": "500",
 			"type": "string",
 			"displayName": "Port",
 			"description": "Port of Modbus TCP server",
 			"order": "4",
 			"length": "6"
 		},
 		"slave": {
 			"order": "10",
 			"default": "1",
 			"type": "integer",
 			"displayName": "Slave ID",
 			"description": "The Modbus device default slave ID"
 		},
 		"address": {
 			"order": "3",
 			"default": "127.0.0.1",
 			"type": "string",
 			"displayName": "Server Address",
 			"description": "Address of Modbus TCP server"
 		},
 		"stopbits": {
 			"order": "8",
 			"default": "1",
 			"type": "integer",
 			"displayName": "Number Of Stop Bits",
 			"description": "Number of stop bits for Modbus RTU"
 		}
 	},
 	"type": "south",
 	"description": "A Modbus connected Flir AX8 thermal imaging camera",
 	"name": "FlirAX8"
 }
  ]
}

```