### PR TITLE
FOGL-2070 password type configuration secret text in REST API side ONLY

### DIFF
--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -4,11 +4,12 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-
+import copy
 from aiohttp import web
 import binascii
 import urllib.parse
 import os
+from typing import Dict
 
 from foglamp.services.core import connect
 from foglamp.common.configuration_manager import ConfigurationManager, _optional_items
@@ -94,6 +95,11 @@ async def get_category(request):
     if category is None:
         raise web.HTTPNotFound(reason="No such Category found for {}".format(category_name))
 
+    try:
+        request.is_core_mgt
+    except AttributeError:
+        category = hide_password(category)
+
     return web.json_response(category)
 
 
@@ -143,6 +149,10 @@ async def create_category(request):
         if data.get('children'):
             r = await cf_mgr.create_child_category(category_name, data.get('children'))
             result.update(r)
+        try:
+            request.is_core_mgt
+        except AttributeError:
+            result['value'] = hide_password(result['value'])
     except (KeyError, ValueError, TypeError) as ex:
         raise web.HTTPBadRequest(reason=str(ex))
     except LookupError as ex:
@@ -198,6 +208,11 @@ async def get_category_item(request):
     category_item = await cf_mgr.get_category_item(category_name, config_item)
     if category_item is None:
         raise web.HTTPNotFound(reason="No such Category item found for {}".format(config_item))
+
+    try:
+        request.is_core_mgt
+    except AttributeError:
+        category_item = hide_password(category_item)
 
     return web.json_response(category_item)
 
@@ -260,11 +275,16 @@ async def set_configuration_item(request):
     except (TypeError, KeyError) as ex:
         raise web.HTTPBadRequest(reason=ex)
 
-    result = await cf_mgr.get_category_item(category_name, config_item)
-    if result is None:
+    category_item = await cf_mgr.get_category_item(category_name, config_item)
+    if category_item is None:
         raise web.HTTPNotFound(reason="No detail found for the category_name: {} and config_item: {}".format(category_name, config_item))
 
-    return web.json_response(result)
+    try:
+        request.is_core_mgt
+    except AttributeError:
+        category_item = hide_password(category_item)
+
+    return web.json_response(category_item)
 
 
 async def update_configuration_item_bulk(request):
@@ -301,8 +321,12 @@ async def update_configuration_item_bulk(request):
     except Exception as ex:
         raise web.HTTPInternalServerError(reason=ex)
     else:
-        result = await cf_mgr.get_category_all_items(category_name)
-        return web.json_response(result)
+        cat = await cf_mgr.get_category_all_items(category_name)
+        try:
+            request.is_core_mgt
+        except AttributeError:
+            cat = hide_password(cat)
+        return web.json_response(cat)
 
 
 async def add_configuration_item(request):
@@ -419,6 +443,11 @@ async def delete_configuration_item_value(request):
 
     if result is None:
         raise web.HTTPNotFound(reason="No detail found for the category_name: {} and config_item: {}".format(category_name, config_item))
+
+    try:
+        request.is_core_mgt
+    except AttributeError:
+        result = hide_password(result)
 
     return web.json_response(result)
 
@@ -596,3 +625,15 @@ async def upload_script(request):
     else:
         result = await cf_mgr.get_category_item(category_name, config_item)
         return web.json_response(result)
+
+
+def hide_password(config: dict) -> Dict:
+    new_config = copy.deepcopy(config)
+    try:
+        for k, v in new_config.items():
+            if v['type'] == 'password':
+                v['value'] = "****"
+    except TypeError:
+        if new_config['type'] == 'password':
+            new_config['value'] = "****"
+    return new_config

--- a/python/foglamp/services/core/server.py
+++ b/python/foglamp/services/core/server.py
@@ -1298,6 +1298,7 @@ class Server:
 
     @classmethod
     async def create_configuration_category(cls, request):
+        request.is_core_mgt = True
         res = await conf_api.create_category(request)
         return res
 
@@ -1318,11 +1319,13 @@ class Server:
 
     @classmethod
     async def get_configuration_category(cls, request):
+        request.is_core_mgt = True
         res = await conf_api.get_category(request)
         return res
 
     @classmethod
     async def get_configuration_item(cls, request):
+        request.is_core_mgt = True
         res = await conf_api.get_category_item(request)
         return res
 

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -4,7 +4,7 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-
+import copy
 import asyncio
 import json
 from unittest.mock import MagicMock, patch
@@ -159,15 +159,15 @@ class TestConfiguration:
                 assert 'No such Category found for {}'.format(category_name) == resp.reason
             patch_get_all_items.assert_called_once_with(category_name)
 
-    async def test_get_category(self, client, category_name='rest_api'):
-        result = {'httpPort': {'default': '8081', 'value': '8081', 'type': 'integer',
-                               'description': 'The port to accept HTTP connections on'},
-                  'certificateName': {'default': 'foglamp', 'value': 'foglamp', 'type': 'string',
-                                      'description': 'Certificate file name'}}
-
+    @pytest.mark.parametrize("result, hide_password", [
+        ({'httpPort': {'default': '8081', 'value': '8081', 'type': 'integer', 'description': 'The port to accept HTTP'},
+          'certificateName': {'default': 'foglamp', 'value': 'foglamp', 'type': 'string', 
+                              'description': 'Certificate file name'}}, False),
+        ({"p2": {"type": "password", "description": "Test Password", "default": "foglamp", "value": "FogLAMP"}}, True)
+    ])
+    async def test_get_category(self, client, result, hide_password, category_name='rest_api'):
         async def async_mock():
             return result
-
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -176,6 +176,8 @@ class TestConfiguration:
                 assert 200 == resp.status
                 r = await resp.text()
                 json_response = json.loads(r)
+                if hide_password:
+                    result[list(result.keys())[0]]['value'] = "****"
                 assert result == json_response
             patch_get_all_items.assert_called_once_with(category_name)
 
@@ -192,13 +194,14 @@ class TestConfiguration:
                 assert 'No such Category item found for {}'.format(item_name) == resp.reason
             patch_get_cat_item.assert_called_once_with(category_name, item_name)
 
-    async def test_get_category_item(self, client, category_name='rest_api', item_name='http_port'):
-        result = {'value': '8081', 'type': 'integer', 'default': '8081',
-                  'description': 'The port to accept HTTP connections on'}
-
+    @pytest.mark.parametrize("result, hide_password", [
+        ({'value': '8081', 'type': 'integer', 'default': '8081', 'description': 'Port to accept HTTP conn on'}, False),
+        ({'type': 'password', 'description': 'Test Password', 'default': 'foglamp', 'value': 'FogLAMP'}, True)
+    ])
+    async def test_get_category_item(self, client, result, hide_password, category_name='rest_api',
+                                     item_name='http_port'):
         async def async_mock():
             return result
-
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -207,16 +210,20 @@ class TestConfiguration:
                 assert 200 == resp.status
                 r = await resp.text()
                 json_response = json.loads(r)
+                if hide_password:
+                    result['value'] = "****"
                 assert result == json_response
             patch_get_cat_item.assert_called_once_with(category_name, item_name)
 
-    async def test_set_config_item(self, client, category_name='rest_api', item_name='http_port'):
+    @pytest.mark.parametrize("result, hide_password", [
+        ({'value': '8082', 'type': 'integer', 'default': '8081', 'description': 'Port to accept HTTP conn on'}, False),
+        ({'type': 'password', 'description': 'Test Password', 'default': 'foglamp', 'value': 'FogLAMP'}, True)
+    ])
+    async def test_set_config_item(self, client, result, hide_password, category_name='rest_api',
+                                   item_name='http_port'):
         async def async_mock(return_value):
             return return_value
-
-        payload = {"value": '8082'}
-        result = {'value': '8082', 'type': 'integer', 'default': '8081',
-                  'description': 'The port to accept HTTP connections on'}
+        payload = {"value": result['value']}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
@@ -227,6 +234,8 @@ class TestConfiguration:
                     assert 200 == resp.status
                     r = await resp.text()
                     json_response = json.loads(r)
+                    if hide_password:
+                        result['value'] = "****"
                     assert result == json_response
                 assert 2 == patch_get_cat_item.call_count
                 calls = patch_get_cat_item.call_args_list
@@ -332,25 +341,26 @@ class TestConfiguration:
                 assert resp.reason is None
             patch_set_entry.assert_called_once_with(category_name, item_name, optional_key, payload[optional_key])
 
-    async def test_delete_config_item(self, client, category_name='rest_api', item_name='http_port'):
-        result = {'value': '8081', 'type': 'integer', 'default': '8081',
-                  'description': 'The port to accept HTTP connections on'}
-
-        async def async_mock_set_item():
-            return None
-
-        async def async_mock():
-            return result
+    @pytest.mark.parametrize("result, hide_password", [
+        ({'value': '8082', 'type': 'integer', 'default': '8081', 'description': 'Port to accept HTTP conn on'}, False),
+        ({'type': 'password', 'description': 'Test Password', 'default': 'foglamp', 'value': 'FogLAMP'}, True)
+    ])
+    async def test_delete_config_item(self, client, result, hide_password, category_name='rest_api',
+                                      item_name='http_port'):
+        async def async_mock(return_value):
+            return return_value
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
-            with patch.object(c_mgr, 'get_category_item', side_effect=[async_mock(), async_mock()]) as patch_get_cat_item:
-                with patch.object(c_mgr, 'set_category_item_value_entry', return_value=async_mock_set_item()) as patch_set_entry:
+            with patch.object(c_mgr, 'get_category_item', side_effect=[async_mock(result), async_mock(result)]) as patch_get_cat_item:
+                with patch.object(c_mgr, 'set_category_item_value_entry', return_value=async_mock(None)) as patch_set_entry:
                     resp = await client.delete('/foglamp/category/{}/{}/value'.format(category_name, item_name))
                     assert 200 == resp.status
                     r = await resp.text()
                     json_response = json.loads(r)
+                    if hide_password:
+                        result['value'] = "****"
                     assert result == json_response
                 patch_set_entry.assert_called_once_with(category_name, item_name, result['default'])
             assert 2 == patch_get_cat_item.call_count
@@ -431,19 +441,18 @@ class TestConfiguration:
             assert 400 == resp.status
             assert message == resp.reason
 
-    @pytest.mark.parametrize("payload", [
-        {"key": "T1", "description": "Test"},
-        {"key": "T2", "description": "Test 2", "display_name": "Test Display"}
+    @pytest.mark.parametrize("payload, hide_password", [
+        ({"key": "T1", "description": "Test"}, False),
+        ({"key": "T2", "description": "Test 2", "display_name": "Test Display"}, False),
+        ({"key": "T3", "description": "Test 3"}, True)
     ])
-    async def test_create_category(self, client, reset_singleton, payload):
-        info = {'info': {'type': 'boolean', 'value': 'False', 'description': 'Test', 'default': 'False'}}
-        payload.update({"value": info})
+    async def test_create_category(self, client, reset_singleton, payload, hide_password):
+        info = {'p1': {'type': 'password', 'description': 'P1', 'default': 'P1', 'value': 'P1'}} if hide_password else {'info': {'type': 'boolean', 'value': 'False', 'description': 'Test', 'default': 'False'}}
+        new_info = copy.deepcopy(info)
+        payload["value"] = new_info
 
-        async def async_mock_create_cat():
-            return None
-
-        async def async_mock():
-            return info
+        async def async_mock(return_value):
+            return return_value
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
@@ -452,14 +461,16 @@ class TestConfiguration:
         else:
             payload.update({'displayName': payload['key']})
 
-        c_mgr._cacheManager.update(payload['key'], info, payload['displayName'])
+        c_mgr._cacheManager.update(payload['key'], new_info, payload['displayName'])
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
-            with patch.object(c_mgr, 'create_category', return_value=async_mock_create_cat()) as patch_create_cat:
-                with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock()) as patch_cat_all_item:
+            with patch.object(c_mgr, 'create_category', return_value=async_mock(None)) as patch_create_cat:
+                with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock(new_info)) as patch_cat_all_item:
                     resp = await client.post('/foglamp/category', data=json.dumps(payload))
                     assert 200 == resp.status
                     r = await resp.text()
                     json_response = json.loads(r)
+                    if hide_password:
+                        payload['value'][list(payload['value'].keys())[0]]['value'] = "****"
                     assert payload == json_response
                 patch_cat_all_item.assert_called_once_with(category_name=payload['key'])
             patch_create_cat.assert_called_once_with(category_name=payload['key'], category_description=payload['description'],


### PR DESCRIPTION
**Response:**
1) Category having password type returns **"****"** at ADMIN API side

```
 $ curl -sX GET http://localhost:8081/foglamp/category/C1 | jq
{
  "p2": {
    "default": "P2",
    "type": "password",
    "value": "****",
    "description": "P2"
  },
  "p1": {
    "default": "P1",
    "type": "password",
    "value": "****",
    "description": "P1"
  },
  "test1": {
    "default": "",
    "type": "script",
    "value": "",
    "file": "",
    "description": "d"
  }
}

```
2) Category having password type returns **plain text** when microservice management API

```
$ curl -sX GET http://localhost:35359/foglamp/service/category/C1 | jq
{
  "p2": {
    "default": "P2",
    "value": "foglamp",
    "type": "password",
    "description": "P2"
  },
  "p1": {
    "default": "P1",
    "value": "FogLAMP",
    "type": "password",
    "description": "P1"
  },
  "test1": {
    "file": "",
    "default": "",
    "value": "",
    "type": "script",
    "description": "d"
  }
}

```


Fixed for below endpoints
- [x] GET /foglamp/category/{category_name}
- [x]  GET  /foglamp/category/{category_name}/{config_item}
- [x]  PUT  /foglamp/category/{category_name}/{config_item}
- [x]  DELETE  /foglamp/category/{category_name}/{config_item}/value
- [x] POST /foglamp/category
- [x] PUT /foglamp/category/{category_name} -- fyi, bulk update only exists at Admin API side
