### PR TITLE
FOGL-2947: Pi_Server plugin : handle kerberos authentication using the libcurl library

### DIFF
--- a/C/common/include/string_utils.h
+++ b/C/common/include/string_utils.h
@@ -18,5 +18,6 @@ void StringReplace(std::string& StringToManage,
 		   const std::string& StringToSearch,
 		   const std::string& StringReplacement);
 
+void StringStripCRLF(std::string& StringToManage);
 
 #endif

--- a/C/common/string_utils.cpp
+++ b/C/common/string_utils.cpp
@@ -34,3 +34,25 @@ void StringReplace(std::string& StringToManage,
 				       StringReplacement);
 	}
 }
+
+/**
+ * Strips Line feed and carige return
+ *
+ */
+void StringStripCRLF(std::string& StringToManage)
+{
+	string::size_type pos = 0;
+
+	pos = StringToManage.find ('\r',pos);
+	if (pos != string::npos )
+	{
+		StringToManage.erase ( pos, 2 );
+	}
+
+	pos = StringToManage.find ('\n',pos);
+	if (pos != string::npos )
+	{
+		StringToManage.erase ( pos, 2 );
+	}
+
+}

--- a/C/plugins/common/CMakeLists.txt
+++ b/C/plugins/common/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 set(NEEDED_FOGLAMP_LIBS common-lib services-common-lib)
+set(LIBCURL_LIB -lcurl)
 
 set(BOOST_COMPONENTS system thread)
 # Late 2017 TODO: remove the following checks and always use std::regex
@@ -33,6 +34,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/../../lib)
 # Create shared library
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${NEEDED_FOGLAMP_LIBS} z ssl crypto)
+target_link_libraries(${PROJECT_NAME} ${LIBCURL_LIB})
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1)
 
 # Install library

--- a/C/plugins/common/include/http_sender.h
+++ b/C/plugins/common/include/http_sender.h
@@ -37,6 +37,9 @@ class HttpSender
 				const std::string& payload = std::string()) = 0;
 
                 virtual std::string getHostPort() = 0;
+
+    		virtual void setAuthMethod          (std::string& authMethod) = 0;
+    		virtual void setAuthBasicCredentials(std::string& authBasicCredentials) = 0;
 };
 
 /**

--- a/C/plugins/common/include/libcurl_https.h
+++ b/C/plugins/common/include/libcurl_https.h
@@ -1,0 +1,68 @@
+#ifndef _LIBCURL_HTTPS_H
+#define _LIBCURL_HTTPS_H
+/*
+ * FogLAMP HTTP Sender wrapper.
+ *
+ * Copyright (c) 2019 Diamnomic Systems
+ *
+ * Released under the Apache 2.0 Licence
+ *
+ * Author: Stefano Simonelli
+ */
+
+#include <string>
+#include <vector>
+#include <http_sender.h>
+#include <curl/curl.h>
+
+using namespace std;
+
+class LibcurlHttps:  public HttpSender
+{
+public:
+    /**
+     * Constructor:
+     * pass host:port, connect & request timeouts, retry_sleep_Time, max_retry
+     */
+    LibcurlHttps(const std::string& host_port,
+		unsigned int connect_timeout = 0,
+		unsigned int request_timeout = 0,
+		unsigned int retry_sleep_Time = 1,
+		unsigned int max_retry = 4);
+
+    // Destructor
+    ~LibcurlHttps();
+
+    /**
+     * HTTP(S) request: pass method and path, HTTP headers and POST/PUT payload.
+     */
+    int sendRequest(const std::string& method = std::string(HTTP_SENDER_DEFAULT_METHOD),
+		    const std::string& path = std::string(HTTP_SENDER_DEFAULT_PATH),
+		    const std::vector<std::pair<std::string, std::string>>& headers = {},
+		    const std::string& payload = std::string());
+
+    void setAuthMethod          (std::string& authMethod)           {m_authMethod = authMethod; }
+    void setAuthBasicCredentials(std::string& authBasicCredentials) {m_authBasicCredentials = authBasicCredentials; }
+
+    std::string getHostPort() { return m_host_port; };
+
+private:
+	// Make private the copy constructor and operator=
+	LibcurlHttps(const LibcurlHttps&);
+	LibcurlHttps&     operator=(LibcurlHttps const &);
+
+    	void setLibCurlOptions(CURL *sender, const std::string& path, const vector<pair<std::string, std::string>>& headers);
+
+private:
+	CURL               *m_sender;
+	std::string         m_host_port;
+	unsigned int        m_retry_sleep_time;       // Seconds between each retry
+	unsigned int        m_max_retry;              // Max number of retries in the communication
+	std::string         m_authMethod;             // Authentication method to be used
+	std::string         m_authBasicCredentials;   // Credentials is the base64 encoding of id and password joined by a single colon (:)
+    	struct curl_slist  *m_chunk = NULL;
+	unsigned int        m_request_timeout;
+	unsigned int        m_connect_timeout;
+};
+
+#endif

--- a/C/plugins/common/libcurl_https.cpp
+++ b/C/plugins/common/libcurl_https.cpp
@@ -1,0 +1,406 @@
+/*
+ * FogLAMP HTTPS Sender implementation using the libcurl library
+ *  - https://curl.haxx.se/libcurl/
+ *  - https://github.com/curl/curl
+ *
+ * FogLAMP uses the libcurl library to support the Kerberos authentication
+ *
+ * Copyright (c) 2019 Dianomic Systems
+ *
+ * Released under the Apache 2.0 Licence
+ *
+ * Author: Stefano Simonelli
+ */
+
+#include <thread>
+#include <logger.h>
+#include <vector>
+#include <sstream>
+#include <string.h>
+#include <stdlib.h>
+#include <curl/curl.h>
+
+#include "libcurl_https.h"
+#include "string_utils.h"
+
+#define VERBOSE_LOG      0
+
+#define HTTP_HEADER_LINE 255
+
+using namespace std;
+
+/**
+ * Constructor: host:port, connect_timeout, request_timeout,
+ *              retry_sleep_Time, max_retry
+ */
+LibcurlHttps::LibcurlHttps(const string& host_port,
+			 unsigned int connect_timeout,
+			 unsigned int request_timeout,
+			 unsigned int retry_sleep_Time,
+			 unsigned int max_retry) :
+			HttpSender(),
+			m_connect_timeout(connect_timeout),
+			m_request_timeout(request_timeout),
+			m_host_port(host_port),
+			m_retry_sleep_time(retry_sleep_Time),
+			m_max_retry (max_retry)
+{
+
+	if (curl_global_init(CURL_GLOBAL_DEFAULT) != 0)
+	{
+		Logger::getLogger()->error("libcurl_https - curl_global_init failed, the libcurl library cannot be initialized.");
+	}
+}
+
+/**
+ * Destructor
+ */
+LibcurlHttps::~LibcurlHttps()
+{
+	curl_global_cleanup();
+}
+
+/**
+ * Avoid libcurl debug messages
+ */
+size_t cb_write_data(void *buffer, size_t size, size_t nmemb, void *userp)
+{
+	return size * nmemb;
+}
+
+/**
+ * Handle the call back header to retrieve the text message in response to an HTTP request
+ * this call back is called for all the headers lines
+ *
+ * received header is nitems * size long in 'buffer' NOT ZERO TERMINATED
+ * userdata' is set with CURLOPT_HEADERDATA
+ *
+ * @param buffer        Header message
+ * @param size          (nitems * size) is the size of 'buffer'
+ * @param nitems
+ * @param userdata out  Buffer to store the data needed
+ *
+ */
+static size_t cb_header(char *buffer, size_t size, size_t nitems, void *userdata)
+{
+
+	char *header = (char *)  userdata;
+	int  numBytes = 0;
+	bool getHeader = false;
+
+	// Only the first line of the headers is needed
+	if (*header == '\0')
+	{
+		getHeader = true;
+	}
+	else
+	{
+		// in some situations as using Kerberos
+		// the last header starting with HTTP contains the real error
+		char tmpBuffer[10];
+		sprintf(tmpBuffer, "%.*s", 4, buffer);
+
+		string tmpStr = tmpBuffer;
+		for (auto & c: tmpStr) c = toupper(c);
+
+		if (tmpStr.compare("HTTP") == 0) {
+
+			getHeader = true;
+		}
+
+	}
+
+	if (getHeader)
+	{
+		if ((size * nitems) < (HTTP_HEADER_LINE - 1))
+			numBytes = size * nitems;
+		else
+			numBytes = HTTP_HEADER_LINE - 1;
+
+		sprintf(header, "%.*s", numBytes, buffer);
+	}
+	return nitems * size;
+}
+
+/**
+ * Setups the libcurl general options used in all the HTTP methods
+ *
+ * @param sender    libcurl handle on which the options should be configured
+ * @param path      The URL path
+ * @param headers   The optional headers to send
+ *
+ */
+void LibcurlHttps::setLibCurlOptions(CURL *sender, const string& path, const vector<pair<string, string>>& headers)
+{
+	string httpHeader;
+
+#if VERBOSE_LOG
+	curl_easy_setopt(m_sender, CURLOPT_VERBOSE, 1L);
+#else
+	curl_easy_setopt(m_sender, CURLOPT_VERBOSE, 0L);
+	// this workaround is needed to avoid all libcurl debug messages
+	curl_easy_setopt(m_sender, CURLOPT_WRITEFUNCTION, cb_write_data);
+#endif
+	curl_easy_setopt(m_sender, CURLOPT_NOPROGRESS, 1L);
+	curl_easy_setopt(m_sender, CURLOPT_TCP_KEEPALIVE, 1L);
+
+	curl_easy_setopt(m_sender, CURLOPT_TIMEOUT,        m_request_timeout);
+	curl_easy_setopt(m_sender, CURLOPT_CONNECTTIMEOUT, m_connect_timeout);
+
+	// HTTP headers handling
+	m_chunk = curl_slist_append(m_chunk, "User-Agent: " HTTP_SENDER_USER_AGENT);
+
+	for (auto it = headers.begin(); it != headers.end(); ++it)
+	{
+		httpHeader = (*it).first + ": " + (*it).second;
+		m_chunk = curl_slist_append(m_chunk, httpHeader.c_str());
+	}
+
+	// Handle basic authentication
+	if (m_authMethod == "b")
+	{
+		// TODO : To be implemented / verified
+		httpHeader = "Basic: " + m_authBasicCredentials;
+		m_chunk = curl_slist_append(m_chunk, httpHeader.c_str());
+
+		/* set user name and password for the authentication */
+		//curl_easy_setopt(m_sender, CURLOPT_USERPWD, "user:pwd");
+	}
+	curl_easy_setopt(m_sender, CURLOPT_HTTPHEADER, m_chunk);
+
+	// Handle Kerberos authentication
+	if (m_authMethod == "k")
+	{
+		Logger::getLogger()->debug("Kerberos authentication - keytab file :%s: ", getenv("KRB5_CLIENT_KTNAME"));
+
+		curl_easy_setopt(m_sender, CURLOPT_HTTPAUTH, CURLAUTH_GSSNEGOTIATE);
+		// The empty user should be defined for Kerberos authentication
+		curl_easy_setopt(m_sender, CURLOPT_USERPWD, ":");
+	}
+
+	// Configure libcurl
+	string url = "https://" + m_host_port + path;
+
+	curl_easy_setopt(m_sender, CURLOPT_URL, url.c_str());
+
+	// Setup SSL
+	curl_easy_setopt(m_sender, CURLOPT_USE_SSL, CURLUSESSL_ALL);
+	curl_easy_setopt(m_sender, CURLOPT_SSL_VERIFYPEER, 0L);
+	curl_easy_setopt(m_sender, CURLOPT_SSL_VERIFYHOST, 0L);
+	curl_easy_setopt(m_sender, CURLOPT_HTTP_VERSION, (long)CURL_HTTP_VERSION_2TLS);
+}
+
+/**
+ * Send data, it retries the operation m_max_retry times
+ * waiting m_retry_sleep_time*2 at each attempt
+ *
+ * @param method    The HTTP method (GET, POST, ...)
+ * @param path      The URL path
+ * @param headers   The optional headers to send
+ * @param payload   The optional data payload (for POST, PUT)
+ * @return          The HTTP code for the cases : 1xx Informational /
+ *                                                2xx Success /
+ *                                                3xx Redirection
+ * @throw	    BadRequest for HTTP 400 error
+ *		    std::exception as generic exception for all the
+ *		    cases >= 401 Client errors / 5xx Server errors
+ */
+int LibcurlHttps::sendRequest(const string& method,
+			     const string& path,
+			     const vector<pair<string, string>>& headers,
+			     const string& payload)
+{
+	// Variables definition
+	long   httpCode = 0;
+	string httpResponseText;
+	char   httpHeaderBuffer[HTTP_HEADER_LINE];
+
+	bool retry = false;
+	int  retryCount = 1;
+	int  sleepTime = m_retry_sleep_time;
+
+	CURLcode res = CURLE_OK;
+
+	enum exceptionType
+	{
+	    none, typeBadRequest, typeException
+	};
+
+	exceptionType exceptionRaised = none;
+	string exceptionMessage;
+	string errorMessage;
+
+	// Init libcurl
+	m_sender = curl_easy_init();
+	if(m_sender)
+	{
+		setLibCurlOptions(m_sender, path, headers);
+	}
+	else
+	{
+		string errorMessage = "libcurl_https - curl_easy_init failed, the libcurl library cannot be initialized.";
+
+		Logger::getLogger()->error(errorMessage);
+		throw runtime_error(errorMessage.c_str());
+	}
+
+	// Select the requested HTTP method
+	if (method.compare("POST") == 0)
+	{
+		curl_easy_setopt(m_sender, CURLOPT_POST, 1L);
+
+		curl_easy_setopt(m_sender, CURLOPT_POSTFIELDS,           payload.c_str());
+		curl_easy_setopt(m_sender, CURLOPT_POSTFIELDSIZE, (long) payload.length());
+	}
+	else if (method.compare("GET") == 0)
+	{
+		// TODO : to be implemented
+		errorMessage = "libcurl_https - method GET is not currently implemented";
+		Logger::getLogger()->debug(errorMessage);
+		throw runtime_error(errorMessage);
+	}
+	else if (method.compare("PUT") == 0)
+	{
+		// TODO : to be implemented
+		errorMessage = "libcurl_https - method PUT currently not implemented";
+		Logger::getLogger()->debug("libcurl_https - method PUT is not currently implemented");
+		throw runtime_error(errorMessage);
+
+	}
+	else if (method.compare("DELETE") == 0)
+	{
+		// TODO : to be implemented
+		errorMessage = "libcurl_https - method DELETE currently not implemented";
+		Logger::getLogger()->debug("libcurl_https - method DELETE is not currently implemented ");
+		throw runtime_error(errorMessage);
+	}
+
+	do
+	{
+		try
+		{
+			exceptionRaised = none;
+			httpCode = 0;
+			httpResponseText = "";
+			httpHeaderBuffer[0] = '\0';
+
+			// It is needed to handle the call back header to retrieve the text message
+			// in response to an HTTP request
+			// curl.haxx.se/mail/lib-2013-10/0114.html
+			curl_easy_setopt(m_sender, CURLOPT_HEADERDATA,     httpHeaderBuffer);
+			curl_easy_setopt(m_sender, CURLOPT_HEADERFUNCTION, cb_header);
+
+			// Execute the HTTP method
+			res = curl_easy_perform(m_sender);
+
+			curl_easy_getinfo(m_sender, CURLINFO_RESPONSE_CODE, &httpCode);
+
+			// fix the text message
+			// NOTE : the text should be considered only if the HTTP code is not an ACK
+			httpResponseText = httpHeaderBuffer;
+			StringStripCRLF(httpResponseText);
+		}
+		catch (exception &ex)
+		{
+			exceptionRaised = typeException;
+			errorMessage = "Failed to send data: ";
+			errorMessage.append(ex.what());
+		}
+
+
+		if ( (res == CURLE_OK )                          &&
+		     (exceptionRaised == none )                  &&
+		     ((httpCode >= 200) && (httpCode <= 399))
+		     )
+		{
+			retry = false;
+#if VERBOSE_LOG
+			Logger::getLogger()->info("HTTPS sendRequest succeeded : retry count |%d| HTTP code |%d|",
+						  retryCount,
+						  httpCode);
+#endif
+		}
+		else
+		{
+			if (res != CURLE_OK)
+			{
+				errorMessage = string(curl_easy_strerror(res) );
+				if (httpResponseText.compare("") != 0 )
+					errorMessage += " - " + httpResponseText;
+			}
+			else
+			{
+				// the situation is : CURLE_OK but the httpCode reports an error
+				errorMessage = httpResponseText;
+			}
+
+#if VERBOSE_LOG
+			if (exceptionRaised)
+			{
+				Logger::getLogger()->error(
+					"HTTPS sendRequest : retry count |%d| error |%s| message |%s|",
+					retryCount,
+					errorMessage.c_str(),
+					payload.c_str());
+
+			}
+			else
+			{
+				Logger::getLogger()->error(
+					"HTTPS sendRequest : retry count |%d| HTTP code |%d| error message |%s| HTTP message |%s|",
+					retryCount,
+					httpCode,
+					errorMessage.c_str(),
+					payload.c_str());
+			}
+#endif
+
+			if (retryCount < m_max_retry)
+			{
+				this_thread::sleep_for(chrono::seconds(sleepTime));
+
+				retry = true;
+				sleepTime *= 2;
+				retryCount++;
+			}
+			else
+			{
+				retry = false;
+			}
+
+		}
+	} while (retry);
+
+	// Cleanup
+	curl_easy_cleanup(m_sender);
+	curl_slist_free_all(m_chunk);
+	m_sender = NULL;
+	m_chunk = NULL;
+
+	// Check if an error should be raised
+	if (exceptionRaised == none)
+	{
+		// 0 = HTTP failed without an HTTP code
+		if (httpCode == 0)
+		{
+			throw runtime_error(errorMessage);
+		}
+		else if (httpCode == 400)
+		{
+			throw BadRequest(errorMessage);
+		}
+		else if (httpCode >= 401)
+		{
+			string errorMessageHTTP;
+			errorMessageHTTP = "HTTP code |" + to_string(httpCode) +  "| - HTTP error |" + errorMessage + "|";
+
+			throw runtime_error(errorMessageHTTP);
+		}
+	}
+	else
+	{
+		throw runtime_error(errorMessage);
+	}
+
+	return httpCode;
+}

--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -487,6 +487,7 @@ bool OMF::AFHierarchySendMessage(const string& msgType, string& jsonData)
 {
 	bool success = true;
 	int res = 0;
+	string errorMessage;
 
 	vector<pair<string, string>> resType = OMF::createMessageHeader(msgType);
 
@@ -498,24 +499,37 @@ bool OMF::AFHierarchySendMessage(const string& msgType, string& jsonData)
 			success = false;
 		}
 	}
-	catch (const BadRequest& e)
+	catch (const BadRequest& ex)
 	{
 		success = false;
+		errorMessage = ex.what();
 	}
-	catch (const std::exception& e)
+	catch (const std::exception& ex)
 	{
 		success = false;
+		errorMessage = ex.what();
 	}
 
 	if (! success)
 	{
-		Logger::getLogger()->error("Sending JSON  Asset Framework hierarchy, "
-			                   "- error: HTTP code |%d| - HostPort |%s| - path |%s| message type |%s| - OMF message |%s|",
-					   res,
-					   m_sender.getHostPort().c_str(),
-					   m_path.c_str(),
-					   msgType.c_str(),
-					   jsonData.c_str() );
+		if (res != 0)
+			Logger::getLogger()->error("Sending JSON  Asset Framework hierarchy, "
+						   "- HTTP code |%d| - error message |%s| - HostPort |%s| - path |%s| message type |%s| - OMF message |%s|",
+						   res,
+						   errorMessage.c_str(),
+						   m_sender.getHostPort().c_str(),
+						   m_path.c_str(),
+						   msgType.c_str(),
+						   jsonData.c_str() );
+		else
+			Logger::getLogger()->error("Sending JSON  Asset Framework hierarchy, "
+						   "- error message |%s| - HostPort |%s| - path |%s| message type |%s| - OMF message |%s|",
+						   errorMessage.c_str(),
+						   m_sender.getHostPort().c_str(),
+						   m_path.c_str(),
+						   msgType.c_str(),
+						   jsonData.c_str() );
+
 	}
 
 	return success;

--- a/data/etc/kerberos/README.rst
+++ b/data/etc/kerberos/README.rst
@@ -1,0 +1,12 @@
+.. |br| raw:: html
+
+   <br />
+
+
+********
+Kerberos
+********
+
+This directory should contain the ketytab file named **piwebapi_kerberos_https.keytab** needed for the Kerberos authentication.
+
+|br| |br|

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -32,6 +32,7 @@ The North plugin has a set of configurable options that should be changed, using
 to select the Kerberos authentication.
 
 The *URL* should be set to reference your end point server, an example: *https://pi-server:443/piwebapi/omf*.
+
 *pi-server* should be substituted with the name/IP-Address of your PI-Server node
 
 The North plugin supports the configurable option *PIServerEndpoint* for allowing to select the target among:

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -15,7 +15,7 @@ Introduction
 ============
 FogLAMP implements through his North plugin PI_server Token, Basic and Kerberos authentication, the latter is especially relevant for the integration with PI Web API using `OMF`_.
 
-The *requirements.sh* script installs the Kerberos client to allow the integration with what in the specific terminology is called KDC (the Kerberos server).
+The FogLAMP *requirements.sh* script installs the Kerberos client to allow the integration with what in the specific terminology is called KDC (the Kerberos server).
 
 PI-Server as the North endpoint
 ===============================
@@ -197,8 +197,3 @@ the version 7.65.3 to provide Kerberos authentication, output of the curl after 
     Features: AsynchDNS GSS-API HTTPS-proxy IPv6 Kerberos Largefile libz NTLM NTLM_WB SPNEGO SSL UnixSockets
 
 The sources are downloaded from the curl repository `curl sources`_, the curl homepage is available at `curl homepage`_.
-
-Kerberos authentication on Raspbian/Ubuntu
-==========================================
-
-

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -72,6 +72,7 @@ A set of commands for an usual configuration
 	curl -X PUT http://localhost:8081/foglamp/category/North_statistics_to_PI/AFHierarchy1Level                -d '{ "value" : "foglamp_data_piwebapi_stat" }'
 
 **NOTE:**
+
 - *North_statistics_to_PI should correspond to the name of the North plugin you have created in FogLAMP*
 
 

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -39,7 +39,7 @@ The North plugin supports the configurable option *PIServerEndpoint* for allowin
 
 *Auto Discovery* will let the North plugin to evaluate if the provided URL is related to an either *Connector Relay* or *PI Web API* endpoint.
 
-The *URL* should be set to reference your end point server, these are the addresses to be used against the OSIsoft components:
+The *URL* should be set to reference your endpoint server, these are the addresses to be used against the OSIsoft components:
 ::
 
     - PI Web API       - https://pi-server:443/piwebapi/omf
@@ -64,16 +64,19 @@ directory:
 
 - *A keytab is a file containing pairs of Kerberos principals and encrypted keys (which are derived from the Kerberos password). A keytab file allows to authenticate to various remote systems using Kerberos without entering a password.*
 
-A set of commands for an usual configuration
+the *AFHierarchy1Level* option allows to specific the first level of the hierarchy that will be created into the Asset Framework and will contain the information for the specific
+North plugin.
+
+A sample set of commands for selecting *PI Web API* usingthe *Kerberos* authentication:
 ::
 	curl -X PUT http://localhost:8081/foglamp/category/North_statistics_to_PI/URL                              -d '{ "value" : "https://pi-server:443/piwebapi/omf" }'
 	curl -X PUT http://localhost:8081/foglamp/category/North_statistics_to_PI/PIServerEndpoint                 -d '{ "value" : "PI Web API" }'
 	curl -X PUT http://localhost:8081/foglamp/category/North_statistics_to_PI/PIWebAPIAuthenticationMethod     -d '{ "value" : "kerberos" }'
-	curl -X PUT http://localhost:8081/foglamp/category/North_statistics_to_PI/AFHierarchy1Level                -d '{ "value" : "foglamp_data_piwebapi_stat" }'
+	curl -X PUT http://localhost:8081/foglamp/category/North_statistics_to_PI/AFHierarchy1Level                -d '{ "value" : "foglamp_data_piwebapi" }'
 
 **NOTE:**
 
-- *North_statistics_to_PI should correspond to the name of the North plugin you have created in FogLAMP*
+- *North_statistics_to_PI* should correspond to the name of the North plugin you have created in FogLAMP
 
 
 FogLAMP server configuration
@@ -159,6 +162,7 @@ Troubleshooting the Kerberos authentication
     64 bytes from pi-server.dianomic.com (192.168.1.51): icmp_seq=1 ttl=128 time=5.07 ms
     64 bytes from pi-server.dianomic.com (192.168.1.51): icmp_seq=2 ttl=128 time=1.92 ms
 
+::
     # Kerberos reachability and keys retrival
     $ kinit -p HTTPS/pi-server@DIANOMIC.COM
     Password for HTTPS/pi-server@DIANOMIC.COM:

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -1,0 +1,188 @@
+.. |br| raw:: html
+
+   <br />
+
+.. Links
+.. _curl homepage: https://curl.haxx.se/
+.. _curl sources: https://github.com/curl/curl/releases
+.. _OMF: https://omf-docs.readthedocs.io/en/v1.1/
+
+***********************
+Kerberos authentication
+***********************
+
+Introduction
+============
+FogLAMP implements through his North plugin PI_server Token, Basic and Kerberos authentication, the latter is especially relevant for the integration with PI Web API using `OMF`_.
+
+The *requirements.sh* script installs the Kerberos client to allow the integration with what in the specific terminology is called KDC (the Kerberos server).
+
+PI-Server as the North endpoint
+===============================
+The OSI *Connector Relay* allows token authentication while *PI Web API* supports Basic and Kerberos.
+
+There could be more than one configuration to allow the Kerberos authentication,
+the easiest one is the Windows server on which the PI-Server is executed act as the Kerberos server also.
+
+The Windows Active directory should be installed and properly configured for allowing the Windows server to authenticate Kerberos requests.
+
+FogLAMP North plugin
+====================
+Configure the *URL* options to the proper value, for example:
+    https://pi-server:443/piwebapi/omf
+
+**NOTE:**
+- *pi-server should be substituted with the name/IP-Address of your PI-Server node*
+
+The North plugin supports the configurable option *PIServerEndpoint* for allowing to select the target among:
+::
+	Connector Relay
+	PI Web API
+	Auto Discovery
+
+*Auto Discovery* will let the North plugin to evaluate if the provided URL is related to an either *Connector Relay* or *PI Web API* endpoint.
+
+the *PIWebAPIAuthenticationMethod* option permits to select the desired authentication among:
+::
+	anonymous
+	basic
+	kerberos
+
+the Kerberos authentication requires a keytab file, the *PIWebAPIKerberosKeytabFileName* option specifies the name of the file expected under the
+directory:
+::
+	${FOGLAMP_ROOT}/data/etc/kerberos
+
+**NOTE:**
+
+- *A keytab is a file containing pairs of Kerberos principals and encrypted keys (which are derived from the Kerberos password). A keytab file allows to authenticate to various remote systems using Kerberos without entering a password.*
+
+A set of commands for an usual configuration
+::
+	curl -X PUT http://localhost:8081/foglamp/category/North_statistics_to_PI/URL                              -d '{ "value" : "https://pi-server:443/piwebapi/omf" }'
+	curl -X PUT http://localhost:8081/foglamp/category/North_statistics_to_PI/PIServerEndpoint                 -d '{ "value" : "PI Web API" }'
+	curl -X PUT http://localhost:8081/foglamp/category/North_statistics_to_PI/PIWebAPIAuthenticationMethod     -d '{ "value" : "kerberos" }'
+	curl -X PUT http://localhost:8081/foglamp/category/North_statistics_to_PI/AFHierarchy1Level                -d '{ "value" : "foglamp_data_piwebapi_stat" }'
+
+**NOTE:**
+- *North_statistics_to_PI should correspond to the name of the North plugin you have created in FogLAMP*
+
+
+FogLAMP server configuration
+============================
+The server on which FogLAMP is going to be executed needs to be properly configured to allow the Kerberos authentication.
+
+The following steps are needed:
+
+- *IP Address resolution for the KDC*
+
+- *Kerberos client configuration*
+
+- *Kerberos keytab file setup*
+
+IP Address resolution of the KDC
+--------------------------------
+The Kerberos server name should be resolved to the corresponding IP Address, editing the */etc/hosts* is one of the possible and the easiest way, sample row to add:
+::
+	192.168.1.51    pi-server.dianomic.com pi-server
+
+try the resolution of the name using the usual *ping* command:
+::
+	$ ping -c 1 pi-server.dianomic.com
+
+	PING pi-server.dianomic.com (192.168.1.51) 56(84) bytes of data.
+	64 bytes from pi-server.dianomic.com (192.168.1.51): icmp_seq=1 ttl=128 time=0.317 ms
+	64 bytes from pi-server.dianomic.com (192.168.1.51): icmp_seq=2 ttl=128 time=0.360 ms
+	64 bytes from pi-server.dianomic.com (192.168.1.51): icmp_seq=3 ttl=128 time=0.455 ms
+
+**NOTE:**
+- *the name of the KDC should be the first in the list of aliases*
+
+
+Kerberos client configuration
+-----------------------------
+The server on which FogLAMP runs act like a Kerberos client and the related configuration file should be edited for allowing the proper Kerberos server identification.
+The information should be added into the */etc/krb5.conf* file in the corresponding section, for example:
+::
+	[libdefaults]
+		default_realm = DIANOMIC.COM
+
+	[realms]
+	    DIANOMIC.COM = {
+	        kdc = pi-server.dianomic.com
+	        admin_server = pi-server.dianomic.com
+	    }
+
+Kerberos keytab file
+--------------------
+The keytab file should be generated on the Kerberos server and copied into the FogLAMP server in the directory:
+::
+	${FOGLAMP_ROOT}/data/etc/kerberos
+
+The name of the file should match the value of the North plugin option *PIWebAPIKerberosKeytabFileName*, by default *piwebapi_kerberos_https.keytab*
+::
+	$ ls -l ${FOGLAMP_ROOT}/data/etc/kerberos
+	-rwxrwxrwx 1 foglamp foglamp  91 Jul 17 09:07 piwebapi_kerberos_https.keytab
+	-rw-rw-r-- 1 foglamp foglamp 199 Aug 13 15:30 README.rst
+
+The way the keytab file is generated depends on the type of the Kerberos server, in the case of Windows Active Directory this is an sample command:
+::
+
+	ktpass -princ HTTPS/pi-server@DIANOMIC.COM -mapuser Administrator@DIANOMIC.COM -pass Password -crypto AES256-SHA1 -ptype KRB5_NT_PRINCIPAL -out C:\Temp\piwebapi_kerberos_https.keytab
+
+
+Troubleshooting the Kerberos authentication
+--------------------------------------------
+1) check the North plugin configuration, a sample command
+::
+    curl -s -S -X GET http://localhost:8081/foglamp/category/North_Readings_to_PI | jq ".|{URL,"PIServerEndpoint",PIWebAPIAuthenticationMethod,PIWebAPIKerberosKeytabFileName,AFHierarchy1Level}"
+
+2) check the presence of the keytab file
+::
+	$ ls -l ${FOGLAMP_ROOT}/data/etc/kerberos
+	-rwxrwxrwx 1 foglamp foglamp  91 Jul 17 09:07 piwebapi_kerberos_https.keytab
+	-rw-rw-r-- 1 foglamp foglamp 199 Aug 13 15:30 README.rst
+
+3) verify the reachability of the Kerberos server (usually the PI-Server)
+::
+    # Network reachability
+    $ ping pi-server.dianomic.com
+    PING pi-server.dianomic.com (192.168.1.51) 56(84) bytes of data.
+    64 bytes from pi-server.dianomic.com (192.168.1.51): icmp_seq=1 ttl=128 time=5.07 ms
+    64 bytes from pi-server.dianomic.com (192.168.1.51): icmp_seq=2 ttl=128 time=1.92 ms
+
+    # Kerberos reachability and keys retrival
+    $ kinit -p HTTPS/pi-server@DIANOMIC.COM
+    Password for HTTPS/pi-server@DIANOMIC.COM:
+    $ klist
+    Ticket cache: FILE:/tmp/krb5cc_1001
+    Default principal: HTTPS/pi-server@DIANOMIC.COM
+
+    Valid starting       Expires              Service principal
+    09/27/2019 11:51:47  09/27/2019 21:51:47  krbtgt/DIANOMIC.COM@DIANOMIC.COM
+        renew until 09/28/2019 11:51:46
+    $
+
+Kerberos authentication on RedHat/CentOS
+========================================
+RedHat and CentOS version 7.6 provide by default an old version of curl and the related libcurl,
+it moreover does not support Kerberos, output of the curl provided by RedHat:
+::
+	$curl -V
+
+	curl 7.29.0 (x86_64-redhat-linux-gnu) libcurl/7.29.0 NSS/3.36 zlib/1.2.7 libidn/1.28 libssh2/1.4.3
+	Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp scp sftp smtp smtps telnet tftp
+	Features: AsynchDNS GSS-Negotiate IDN IPv6 Largefile NTLM NTLM_WB SSL libz unix-sockets
+
+The *requirements.sh* evaluates if the default version, 7.29.0, is installed and in this case it will build from the sources
+a defined and stable version of curl to provide Kerberos authentication and a more recent version.
+
+At the current stage as described at `curl homepage`_, the most recent stable version is the 7.65.3, released on 19th of July 2019,
+so *requirements.sh* will eventually install this version downloading the sources directly from `curl sources`_
+
+
+
+Kerberos authentication on Raspbian/Ubuntu
+==========================================
+
+

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -142,9 +142,9 @@ The way the keytab file is generated depends on the type of the Kerberos server,
 
 	ktpass -princ HTTPS/pi-server@DIANOMIC.COM -mapuser Administrator@DIANOMIC.COM -pass Password -crypto AES256-SHA1 -ptype KRB5_NT_PRINCIPAL -out C:\Temp\piwebapi_kerberos_https.keytab
 
-
 Troubleshooting the Kerberos authentication
 --------------------------------------------
+
 1) check the North plugin configuration, a sample command
 ::
     curl -s -S -X GET http://localhost:8081/foglamp/category/North_Readings_to_PI | jq ".|{URL,"PIServerEndpoint",PIWebAPIAuthenticationMethod,PIWebAPIKerberosKeytabFileName,AFHierarchy1Level}"
@@ -155,9 +155,7 @@ Troubleshooting the Kerberos authentication
 	-rwxrwxrwx 1 foglamp foglamp  91 Jul 17 09:07 piwebapi_kerberos_https.keytab
 	-rw-rw-r-- 1 foglamp foglamp 199 Aug 13 15:30 README.rst
 
-3) verify the reachability of the Kerberos server (usually the PI-Server)
-
-Network reachability
+3) verify the reachability of the Kerberos server (usually the PI-Server) - Network reachability
 ::
 
     $ ping pi-server.dianomic.com

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -166,19 +166,24 @@ Troubleshooting the Kerberos authentication
 Kerberos authentication on RedHat/CentOS
 ========================================
 RedHat and CentOS version 7.6 provide by default an old version of curl and the related libcurl,
-it moreover does not support Kerberos, output of the curl provided by RedHat:
+and it does not support Kerberos, output of the curl provided by CentOS:
 ::
-	$curl -V
+	$ curl -V
+    curl 7.29.0 (x86_64-redhat-linux-gnu) libcurl/7.29.0 NSS/3.36 zlib/1.2.7 libidn/1.28 libssh2/1.4.3
+    Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp scp sftp smtp smtps telnet tftp
+    Features: AsynchDNS GSS-Negotiate IDN IPv6 Largefile NTLM NTLM_WB SSL libz unix-sockets
 
-	curl 7.29.0 (x86_64-redhat-linux-gnu) libcurl/7.29.0 NSS/3.36 zlib/1.2.7 libidn/1.28 libssh2/1.4.3
-	Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp scp sftp smtp smtps telnet tftp
-	Features: AsynchDNS GSS-Negotiate IDN IPv6 Largefile NTLM NTLM_WB SSL libz unix-sockets
-
-The *requirements.sh* evaluates if the default version, 7.29.0, is installed and in this case it will build from the sources
-a defined and stable version of curl to provide Kerberos authentication and a more recent version.
+The *requirements.sh* evaluates if the default version 7.29.0 is installed and in this case it will build from the sources
+a defined and stable version of curl to provide Kerberos authentication, output of the curl after the upgrade:
+::
+    $ curl -V
+    curl 7.65.3 (x86_64-unknown-linux-gnu) libcurl/7.65.3 OpenSSL/1.0.2k-fips zlib/1.2.7
+    Release-Date: 2019-07-19
+    Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
+    Features: AsynchDNS GSS-API HTTPS-proxy IPv6 Kerberos Largefile libz NTLM NTLM_WB SPNEGO SSL UnixSockets
 
 At the current stage as described at `curl homepage`_, the most recent stable version is the 7.65.3, released on 19th of July 2019,
-so *requirements.sh* will eventually install this version downloading the sources directly from `curl sources`_
+so *requirements.sh* will install this version downloading the sources directly from `curl sources`_
 
 
 

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -107,6 +107,7 @@ try the resolution of the name using the usual *ping* command:
 	64 bytes from pi-server.dianomic.com (192.168.1.51): icmp_seq=3 ttl=128 time=0.455 ms
 
 **NOTE:**
+
 - *the name of the KDC should be the first in the list of aliases*
 
 
@@ -155,15 +156,18 @@ Troubleshooting the Kerberos authentication
 	-rw-rw-r-- 1 foglamp foglamp 199 Aug 13 15:30 README.rst
 
 3) verify the reachability of the Kerberos server (usually the PI-Server)
+
+Network reachability
 ::
-    # Network reachability
+
     $ ping pi-server.dianomic.com
     PING pi-server.dianomic.com (192.168.1.51) 56(84) bytes of data.
     64 bytes from pi-server.dianomic.com (192.168.1.51): icmp_seq=1 ttl=128 time=5.07 ms
     64 bytes from pi-server.dianomic.com (192.168.1.51): icmp_seq=2 ttl=128 time=1.92 ms
 
+Kerberos reachability and keys retrival
 ::
-    # Kerberos reachability and keys retrival
+
     $ kinit -p HTTPS/pi-server@DIANOMIC.COM
     Password for HTTPS/pi-server@DIANOMIC.COM:
     $ klist

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -31,11 +31,8 @@ FogLAMP North plugin
 The North plugin has a set of configurable options that should be changed, using either the FogLAMP API or the FogLAMP GUI,
 to select the Kerberos authentication.
 
-The *URL* should be set to reference your end point server, an example:
-    https://pi-server:443/piwebapi/omf
-
-**NOTE:**
-- *pi-server should be substituted with the name/IP-Address of your PI-Server node*
+The *URL* should be set to reference your end point server, an example: *https://pi-server:443/piwebapi/omf*.
+*pi-server* should be substituted with the name/IP-Address of your PI-Server node
 
 The North plugin supports the configurable option *PIServerEndpoint* for allowing to select the target among:
 ::

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -31,10 +31,6 @@ FogLAMP North plugin
 The North plugin has a set of configurable options that should be changed, using either the FogLAMP API or the FogLAMP GUI,
 to select the Kerberos authentication.
 
-The *URL* should be set to reference your end point server, an example: *https://pi-server:443/piwebapi/omf*.
-
-*pi-server* should be substituted with the name/IP-Address of your PI-Server node
-
 The North plugin supports the configurable option *PIServerEndpoint* for allowing to select the target among:
 ::
 	Connector Relay
@@ -42,6 +38,16 @@ The North plugin supports the configurable option *PIServerEndpoint* for allowin
 	Auto Discovery
 
 *Auto Discovery* will let the North plugin to evaluate if the provided URL is related to an either *Connector Relay* or *PI Web API* endpoint.
+
+The *URL* should be set to reference your end point server, these are the address to be used against the OSIsoft components:
+::
+
+    - *PI Web API* - https://pi-server:443/piwebapi/omf
+    - *Connector Relay*  - https://pi-server:5460/ingress/messages
+
+**NOTE:**
+
+- *pi-server* should be substituted with the name/IP-Address of your PI-Server node
 
 the *PIWebAPIAuthenticationMethod* option permits to select the desired authentication among:
 ::

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -28,7 +28,10 @@ The Windows Active directory should be installed and properly configured for all
 
 FogLAMP North plugin
 ====================
-Configure the *URL* options to the proper value, for example:
+The North plugin has a set of configurable options that should be changed, using either the FogLAMP API or the FogLAMP GUI,
+to select the Kerberos authentication.
+
+The *URL* should be set to reference your end point server, an example:
     https://pi-server:443/piwebapi/omf
 
 **NOTE:**
@@ -165,16 +168,16 @@ Troubleshooting the Kerberos authentication
 
 Kerberos authentication on RedHat/CentOS
 ========================================
-RedHat and CentOS version 7.6 provide by default an old version of curl and the related libcurl,
+RedHat and CentOS version 7.6 provide by default an old version of curl and the related libcurl
 and it does not support Kerberos, output of the curl provided by CentOS:
 ::
-	$ curl -V
+    $ curl -V
     curl 7.29.0 (x86_64-redhat-linux-gnu) libcurl/7.29.0 NSS/3.36 zlib/1.2.7 libidn/1.28 libssh2/1.4.3
     Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp scp sftp smtp smtps telnet tftp
     Features: AsynchDNS GSS-Negotiate IDN IPv6 Largefile NTLM NTLM_WB SSL libz unix-sockets
 
-The *requirements.sh* evaluates if the default version 7.29.0 is installed and in this case it will build from the sources
-a defined and stable version of curl to provide Kerberos authentication, output of the curl after the upgrade:
+The *requirements.sh* evaluates if the default version 7.29.0 is installed and in this case it will download the sources, build and install
+the version 7.65.3 to provide Kerberos authentication, output of the curl after the upgrade:
 ::
     $ curl -V
     curl 7.65.3 (x86_64-unknown-linux-gnu) libcurl/7.65.3 OpenSSL/1.0.2k-fips zlib/1.2.7
@@ -182,10 +185,7 @@ a defined and stable version of curl to provide Kerberos authentication, output 
     Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
     Features: AsynchDNS GSS-API HTTPS-proxy IPv6 Kerberos Largefile libz NTLM NTLM_WB SPNEGO SSL UnixSockets
 
-At the current stage as described at `curl homepage`_, the most recent stable version is the 7.65.3, released on 19th of July 2019,
-so *requirements.sh* will install this version downloading the sources directly from `curl sources`_
-
-
+The sources are downloaded from the curl repository `curl sources`_, the curl homepage is available at `curl homepage`_.
 
 Kerberos authentication on Raspbian/Ubuntu
 ==========================================

--- a/docs/KERBEROS.rst
+++ b/docs/KERBEROS.rst
@@ -39,11 +39,11 @@ The North plugin supports the configurable option *PIServerEndpoint* for allowin
 
 *Auto Discovery* will let the North plugin to evaluate if the provided URL is related to an either *Connector Relay* or *PI Web API* endpoint.
 
-The *URL* should be set to reference your end point server, these are the address to be used against the OSIsoft components:
+The *URL* should be set to reference your end point server, these are the addresses to be used against the OSIsoft components:
 ::
 
-    - *PI Web API* - https://pi-server:443/piwebapi/omf
-    - *Connector Relay*  - https://pi-server:5460/ingress/messages
+    - PI Web API       - https://pi-server:443/piwebapi/omf
+    - Connector Relay  - https://pi-server:5460/ingress/messages
 
 **NOTE:**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,4 +18,4 @@ Welcome to FogLAMP's documentation!
     92_downloads
     RASPBIAN
     REDHAT
-
+    KERBEROS

--- a/tests/unit/C/plugins/common/CMakeLists.txt
+++ b/tests/unit/C/plugins/common/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 2.6)
 set(CMAKE_CXX_FLAGS "-std=c++11 -O3")
 set(UUIDLIB -luuid)
 set(COMMONLIB -ldl)
- 
+set(LIBCURL_LIB -lcurl)
+
 # Locate GTest
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
@@ -52,6 +53,7 @@ target_link_libraries(RunTests -lssl -lcrypto -lz)
 target_link_libraries(RunTests ${COMMON_LIB})
 target_link_libraries(RunTests ${SERVICE_COMMON_LIB})
 target_link_libraries(RunTests ${PLUGINS_COMMON_LIB})
+target_link_libraries(RunTests ${LIBCURL_LIB})
 
 # Add Python 3.x library
 target_link_libraries(RunTests ${PYTHON_LIBRARIES})


### PR DESCRIPTION
*Working stage*  

**IMPORTANT NOTE**
we use the curl repo : 
https://github.com/curl/curl/releases/download/curl-7_65_3



tested/to be tested : 
* 1st test on a fresh ubuntu 18
* centos fresh - to be tested
* raspbian fresh - to be tested

```
to install/cfg kerberos are need, done by requirements.sh  - ubuntu :
sudo apt-get install -y krb5-user
sudo apt-get install -y libcurl4-openssl-dev

answers : 
* DIANOMIC.COM
* win-4m7odkb0rh2.dianomic.com
* win-4m7odkb0rh2.dianomic.com

sudo vi  /etc/hosts
192.168.1.51    win-4m7odkb0rh2.dianomic.com win-4m7odkb0rh2

#copy the keybtab file in 
${FOGLAMP_DATA}/data/etc/kerberos/piwebapi_kerberos_https.keytab
```


Configuration : 
![image](https://user-images.githubusercontent.com/4919069/62851464-6be23e80-bce6-11e9-8e40-1b7b7fb0e0b8.png)

erro handling fixed : 
```
Aug 13 11:23:40 rdev2 North_Readings_to_PI[6842]: ERROR: Sending JSON data error: |HTTP code |500| - HTTP error |HTTP/1.1 500 Internal Server Error|| - HostPort |WIN-4M7ODKB0RH2:443| - path |/piwebapi/omf| - OMF message |[{"containerid": "
```

added check : 
```
Aug 13 13:50:51 rzero North_Readings_to_PI[15755]: ERROR: Kerberos authentication not possible, the keytab file :/home/foglamp/Development/FogLAMP/data/etc/kerberos/piwebapi_kerberos_https.keytab: is missing.
```