### PR TITLE
FOGL-3000  deprecated plugin mechanism added for both C and python plugins including their unit tests

### DIFF
--- a/C/plugins/utils/get_plugin_info.cpp
+++ b/C/plugins/utils/get_plugin_info.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
       exit(3);
     }
     PLUGIN_INFORMATION *info = (PLUGIN_INFORMATION *)(*infoEntry)();
-    printf("{\"name\": \"%s\", \"version\": \"%s\", \"type\": \"%s\", \"interface\": \"%s\", \"deprecated\": \"%s\", \"config\": %s}\n", info->name, info->version, info->type, info->interface, info->deprecated ? "True" : "False", info->config);
+    printf("{\"name\": \"%s\", \"version\": \"%s\", \"type\": \"%s\", \"interface\": \"%s\", \"flag\": %d, \"config\": %s}\n", info->name, info->version, info->type, info->interface, info->options, info->config);
   }
   else
   {

--- a/C/plugins/utils/get_plugin_info.cpp
+++ b/C/plugins/utils/get_plugin_info.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
       exit(3);
     }
     PLUGIN_INFORMATION *info = (PLUGIN_INFORMATION *)(*infoEntry)();
-    printf("{\"name\": \"%s\", \"version\": \"%s\", \"type\": \"%s\", \"interface\": \"%s\", \"config\": %s}\n", info->name, info->version, info->type, info->interface, info->config);
+    printf("{\"name\": \"%s\", \"version\": \"%s\", \"type\": \"%s\", \"interface\": \"%s\", \"deprecated\": \"%s\", \"config\": %s}\n", info->name, info->version, info->type, info->interface, info->deprecated ? "True" : "False", info->config);
   }
   else
   {

--- a/C/services/common/include/plugin_api.h
+++ b/C/services/common/include/plugin_api.h
@@ -16,7 +16,8 @@ typedef struct {
         unsigned int	options;
         const char	*type;
         const char	*interface;
-	const char	*config;
+	    const char	*config;
+	    bool        deprecated;
 } PLUGIN_INFORMATION;
  
 typedef struct {

--- a/C/services/common/include/plugin_api.h
+++ b/C/services/common/include/plugin_api.h
@@ -16,8 +16,7 @@ typedef struct {
         unsigned int	options;
         const char	*type;
         const char	*interface;
-	    const char	*config;
-	    bool        deprecated;
+	const char	*config;
 } PLUGIN_INFORMATION;
  
 typedef struct {
@@ -36,7 +35,8 @@ typedef void * PLUGIN_HANDLE;
 #define SP_ASYNC	0x0004
 #define SP_PERSIST_DATA	0x0008
 #define SP_INGEST	0x0010
- 
+#define SP_DEPRECATED 0x0020
+
 /**
  * Plugin types
  */

--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -10,6 +10,8 @@ import os
 from foglamp.common import logger
 from foglamp.services.core.api import utils
 from foglamp.services.core.api.plugins import common
+from foglamp.plugins.common import utils as api_utils
+
 
 __author__ = "Amarendra K Sinha, Ashish Jabble"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -106,8 +108,8 @@ class PluginDiscovery(object):
                 if _type == 'binary':
                     jdoc = utils.get_plugin_info(name, dir=plugin_type)
                     if jdoc:
-                        if 'deprecated' in jdoc:
-                            if str_to_bool(jdoc['deprecated']):
+                        if 'flag' in jdoc:
+                            if api_utils.bit_at_given_position_set_or_unset(jdoc['flag'], api_utils.DEPRECATED_BIT_POSITION):
                                 raise DeprecationWarning
                         plugin_config = {'name': name,
                                          'type': plugin_type,
@@ -139,8 +141,8 @@ class PluginDiscovery(object):
             plugin_info = common.load_and_fetch_python_plugin_info(plugin_module_path,  plugin_module_path.split('/')[-1], plugin_type)
             # Fetch configuration from the configuration defined in the plugin
             if plugin_info['type'] == plugin_type:
-                if 'deprecated' in plugin_info:
-                    if plugin_info['deprecated']:
+                if 'flag' in plugin_info:
+                    if api_utils.bit_at_given_position_set_or_unset(plugin_info['flag'], api_utils.DEPRECATED_BIT_POSITION):
                         raise DeprecationWarning
                 plugin_config = {
                     'name': plugin_info['config']['plugin']['default'],
@@ -162,9 +164,3 @@ class PluginDiscovery(object):
 
         return plugin_config
 
-
-def str_to_bool(s):
-    if s == 'True':
-        return True
-    else:
-        return False

--- a/python/foglamp/common/plugin_discovery.py
+++ b/python/foglamp/common/plugin_discovery.py
@@ -106,6 +106,9 @@ class PluginDiscovery(object):
                 if _type == 'binary':
                     jdoc = utils.get_plugin_info(name, dir=plugin_type)
                     if jdoc:
+                        if 'deprecated' in jdoc:
+                            if str_to_bool(jdoc['deprecated']):
+                                raise DeprecationWarning
                         plugin_config = {'name': name,
                                          'type': plugin_type,
                                          'description': jdoc['config']['plugin']['description'],
@@ -119,6 +122,8 @@ class PluginDiscovery(object):
                     hybrid_plugin_config = common.load_and_fetch_c_hybrid_plugin_info(name, is_config)
                     if hybrid_plugin_config:
                         configs.append(hybrid_plugin_config)
+            except DeprecationWarning:
+                _logger.warning('"{}" plugin is deprecated'.format(name))
             except Exception as ex:
                 _logger.exception(ex)
 
@@ -134,6 +139,9 @@ class PluginDiscovery(object):
             plugin_info = common.load_and_fetch_python_plugin_info(plugin_module_path,  plugin_module_path.split('/')[-1], plugin_type)
             # Fetch configuration from the configuration defined in the plugin
             if plugin_info['type'] == plugin_type:
+                if 'deprecated' in plugin_info:
+                    if plugin_info['deprecated']:
+                        raise DeprecationWarning
                 plugin_config = {
                     'name': plugin_info['config']['plugin']['default'],
                     'type': plugin_info['type'],
@@ -145,9 +153,18 @@ class PluginDiscovery(object):
 
             if is_config:
                 plugin_config.update({'config': plugin_info['config']})
+        except DeprecationWarning:
+            _logger.warning('"{}" plugin is deprecated'.format(plugin_dir.split('/')[-1]))
         except FileNotFoundError as ex:
             _logger.error('Plugin "{}" import problem from path "{}". {}'.format(plugin_dir, plugin_module_path, str(ex)))
         except Exception as ex:
             _logger.exception('Plugin "{}" raised exception "{}" while fetching config'.format(plugin_dir, str(ex)))
 
         return plugin_config
+
+
+def str_to_bool(s):
+    if s == 'True':
+        return True
+    else:
+        return False

--- a/python/foglamp/plugins/common/utils.py
+++ b/python/foglamp/plugins/common/utils.py
@@ -13,6 +13,9 @@ __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
 __license__ = "Apache 2.0"
 __version__ = "${VERSION}"
 
+DEPRECATED_BIT_POSITION = 5
+DEPRECATED_BIT_MASK_VALUE = 32
+
 
 def get_diff(old, new):
     diff = list()
@@ -31,3 +34,20 @@ def local_timestamp():
     :example '2018-05-08 14:06:40.517313+05:30'
     """
     return str(datetime.datetime.now(datetime.timezone.utc).astimezone())
+
+
+def bit_at_given_position_set_or_unset(n, k):
+    """ Check whether the bit at given position is set or unset
+
+        :return: if it results to '1' then bit is set, else it results to '0' bit is unset
+        :example:
+              Input : n = 32, k = 5
+              Output : Set
+              (100000)
+              The 5th bit from the right is set.
+
+              Input : n = 32, k = 2
+              Output : Unset
+    """
+    new_num = n >> k
+    return new_num & 1

--- a/tests/unit/python/foglamp/common/test_plugin_discovery.py
+++ b/tests/unit/python/foglamp/common/test_plugin_discovery.py
@@ -13,6 +13,7 @@ import pytest
 from foglamp.common.plugin_discovery import PluginDiscovery, _logger
 from foglamp.services.core.api import utils
 from foglamp.services.core.api.plugins import common
+from foglamp.plugins.common import utils as api_utils
 
 
 __author__ = "Amarendra K Sinha, Ashish Jabble "
@@ -344,9 +345,9 @@ class TestPluginDiscovery:
     @pytest.mark.parametrize("info, warn_count", [
         ({'name': "modbus", 'version': "1.1", 'type': "south", 'interface': "1.0",
           'config': {'plugin': {'description': 'Modbus RTU plugin', 'type': 'string', 'default': 'modbus'}}}, 0),
-        ({'name': "modbus", 'version': "1.1", 'type': "south", 'interface': "1.0", 'deprecated': True,
+        ({'name': "modbus", 'version': "1.1", 'type': "south", 'interface': "1.0", 'flag': api_utils.DEPRECATED_BIT_MASK_VALUE,
           'config': {'plugin': {'description': 'Modbus RTU plugin', 'type': 'string', 'default': 'modbus'}}}, 1),
-        ({'name': "modbus", 'version': "1.1", 'type': "south", 'interface': "1.0", 'deprecated': False,
+        ({'name': "modbus", 'version': "1.1", 'type': "south", 'interface': "1.0", 'flag': 0,
           'config': {'plugin': {'description': 'Modbus RTU plugin', 'type': 'string', 'default': 'modbus'}}}, 0),
     ])
     def test_deprecated_python_plugins(self, info, warn_count, is_config=True):
@@ -400,7 +401,7 @@ class TestPluginDiscovery:
         (mock_c_plugins_config[4], "notificationRule")
     ])
     def test_deprecated_c_plugins_installed(self, info, dir_name):
-        info['deprecated'] = "True"
+        info['flag'] = api_utils.DEPRECATED_BIT_MASK_VALUE
         with patch.object(_logger, "warning") as patch_log_warn:
             with patch.object(utils, "find_c_plugin_libs", return_value=[(info['name'], "binary")]) as patch_plugin_lib:
                 with patch.object(utils, "get_plugin_info", return_value=info) as patch_plugin_info:

--- a/tests/unit/python/foglamp/common/test_plugin_discovery.py
+++ b/tests/unit/python/foglamp/common/test_plugin_discovery.py
@@ -341,6 +341,23 @@ class TestPluginDiscovery:
             actual = PluginDiscovery.get_plugin_config("modbus", "south", is_config)
             assert expected == actual
 
+    @pytest.mark.parametrize("info, warn_count", [
+        ({'name': "modbus", 'version': "1.1", 'type': "south", 'interface': "1.0",
+          'config': {'plugin': {'description': 'Modbus RTU plugin', 'type': 'string', 'default': 'modbus'}}}, 0),
+        ({'name': "modbus", 'version': "1.1", 'type': "south", 'interface': "1.0", 'deprecated': True,
+          'config': {'plugin': {'description': 'Modbus RTU plugin', 'type': 'string', 'default': 'modbus'}}}, 1),
+        ({'name': "modbus", 'version': "1.1", 'type': "south", 'interface': "1.0", 'deprecated': False,
+          'config': {'plugin': {'description': 'Modbus RTU plugin', 'type': 'string', 'default': 'modbus'}}}, 0),
+    ])
+    def test_deprecated_python_plugins(self, info, warn_count, is_config=True):
+        with patch.object(_logger, "warning") as patch_log_warn:
+            with patch.object(common, 'load_and_fetch_python_plugin_info', side_effect=[info]):
+                PluginDiscovery.get_plugin_config(info['name'], info['type'], is_config)
+        assert warn_count == patch_log_warn.call_count
+        if warn_count:
+            args, kwargs = patch_log_warn.call_args
+            assert '"{}" plugin is deprecated'.format(info['name']) == args[0]
+
     def test_bad_get_plugin_config(self):
         mock_plugin_info = {
                 'name': "HTTP",
@@ -374,6 +391,25 @@ class TestPluginDiscovery:
                 PluginDiscovery.fetch_c_plugins_installed(dir_name, True)
             patch_plugin_info.assert_called_once_with(info['name'], dir=dir_name)
         patch_plugin_lib.assert_called_once_with(dir_name)
+
+    @pytest.mark.parametrize("info, dir_name", [
+        (mock_c_plugins_config[0], "south"),
+        (mock_c_plugins_config[1], "north"),
+        (mock_c_plugins_config[2], "filter"),
+        (mock_c_plugins_config[3], "notificationDelivery"),
+        (mock_c_plugins_config[4], "notificationRule")
+    ])
+    def test_deprecated_c_plugins_installed(self, info, dir_name):
+        info['deprecated'] = "True"
+        with patch.object(_logger, "warning") as patch_log_warn:
+            with patch.object(utils, "find_c_plugin_libs", return_value=[(info['name'], "binary")]) as patch_plugin_lib:
+                with patch.object(utils, "get_plugin_info", return_value=info) as patch_plugin_info:
+                    PluginDiscovery.fetch_c_plugins_installed(dir_name, True)
+                patch_plugin_info.assert_called_once_with(info['name'], dir=dir_name)
+            patch_plugin_lib.assert_called_once_with(dir_name)
+        assert 1 == patch_log_warn.call_count
+        args, kwargs = patch_log_warn.call_args
+        assert '"{}" plugin is deprecated'.format(info['name']) == args[0]
 
     def test_fetch_c_hybrid_plugins_installed(self):
         info = {"version": "1.6.0", "name": "FlirAX8", "config": {"asset": {"description": "Default asset name", "default": "flir", "displayName": "Asset Name", "type": "string"}, "plugin": {"description": "A Modbus connected Flir AX8 infrared camera", "default": "FlirAX8", "readonly": "true", "type": "string"}}}

--- a/tests/unit/python/foglamp/plugins/common/test_plugins_common_utils.py
+++ b/tests/unit/python/foglamp/plugins/common/test_plugins_common_utils.py
@@ -23,3 +23,14 @@ class TestUtils:
     def test_get_diff(self, test_input_old, test_input_new, expected):
         actual = utils.get_diff(test_input_old, test_input_new)
         assert Counter(expected) == Counter(actual)
+
+    @pytest.mark.parametrize("number, bit_pos, expected", [
+        (32, 5, 1),
+        (32, 4, 0),
+        (2, 0, 0),
+        (2, 1, 1),
+        (96, 5, 1)
+    ])
+    def test_bit_at_given_position_set_or_unset(self, number, bit_pos, expected):
+        actual = utils.bit_at_given_position_set_or_unset(number, bit_pos)
+        assert expected == actual


### PR DESCRIPTION
**Fixed items:**
- [x] deprecated mechanism added for both C & python plugins
- [x] C -code changes (SP_DEPRECATED bit mask added & flag key now return in C-utility program to get plugin info) and for python plugins if flag key exists then only action will be taken.
**'flag' KEY has taken for consistency on Both sides**
- [x] new unit tests added for plugin discovery and utils function for bit position check

**More info**
- [x] Have tested with all plugin type supported (south, north, filter and notify delivery and rules)
- [x] Also tested with FOGLAMP_PLUGIN_PATH environment set
- [x] No regression in system API tests


**Testing Notes:**
1) Changes in sinusoid.py file
```
@@ -123,7 +123,8 @@ def plugin_info():
         'mode': 'poll',
         'type': 'south',
         'interface': '1.0',
-        'config': _DEFAULT_CONFIG
+        'config': _DEFAULT_CONFIG,
+        'flag': utils.DEPRECATED_BIT_MASK_VALUE
     }


OR

'flag': 32
```

2) Changes in plugin.cpp for foglamp-south-csv-async
```
 @@ -42,7 +42,7 @@ extern "C" {
 static PLUGIN_INFORMATION info = {
        PLUGIN_NAME,              // Name
        VERSION,                  // Version
-       SP_ASYNC,                 // Flags
+       SP_ASYNC | SP_DEPRECATED,                 // Flags
        PLUGIN_TYPE_SOUTH,        // Type
        "1.0.0",                  // Interface version
        CONFIG                    // Default configuration
```
3) Changes in plugin.cpp for foglamp-south-csv

```
@@ -40,7 +40,7 @@ extern "C" {
 static PLUGIN_INFORMATION info = {
        PLUGIN_NAME,              // Name
        VERSION,                  // Version
-       0,                        // Flags
+       SP_DEPRECATED,                // Flags
        PLUGIN_TYPE_SOUTH,        // Type
        "1.0.0",                  // Interface version
        CONFIG                    // Default configuration
```

So When I hit `curl -sX GET http://localhost:8081/foglamp/plugins/installed`, **deprecated plugins are NOT in response and logged warn in syslogs**

**Syslogs**

```
WARNING: plugin_discovery: foglamp.common.plugin_discovery: "sinusoid" plugin is deprecated
WARNING: plugin_discovery: foglamp.common.plugin_discovery: "Csv" plugin is deprecated
WARNING: plugin_discovery: foglamp.common.plugin_discovery: "CSV-Async" plugin is deprecated
```