### PR TITLE
500 exception handling tests fixes; fixed exception with HTTPInternalServerError instead of HTTPException

### DIFF
--- a/python/foglamp/services/core/api/audit.py
+++ b/python/foglamp/services/core/api/audit.py
@@ -229,7 +229,7 @@ async def get_audit_entries(request):
             res.append(r)
 
     except Exception as ex:
-        raise web.HTTPException(reason=str(ex))
+        raise web.HTTPInternalServerError(reason=str(ex))
 
     return web.json_response({'audit': res, 'totalCount': total_count})
 

--- a/python/foglamp/services/core/api/backup_restore.py
+++ b/python/foglamp/services/core/api/backup_restore.py
@@ -103,7 +103,7 @@ async def get_backups(request):
             res.append(r)
 
     except Exception as ex:
-        raise web.HTTPException(reason=str(ex))
+        raise web.HTTPInternalServerError(reason=str(ex))
 
     return web.json_response({"backups": res})
 
@@ -117,7 +117,7 @@ async def create_backup(request):
         backup = Backup(connect.get_storage_async())
         status = await backup.create_backup()
     except Exception as ex:
-        raise web.HTTPException(reason=str(ex))
+        raise web.HTTPInternalServerError(reason=str(ex))
 
     return web.json_response({"status": status})
 
@@ -143,7 +143,7 @@ async def get_backup_details(request):
     except exceptions.DoesNotExist:
         raise web.HTTPNotFound(reason='Backup id {} does not exist'.format(backup_id))
     except Exception as ex:
-        raise web.HTTPException(reason=(str(ex)))
+        raise web.HTTPInternalServerError(reason=(str(ex)))
 
     return web.json_response(resp)
 
@@ -180,7 +180,7 @@ async def get_backup_download(request):
     except exceptions.DoesNotExist:
         raise web.HTTPNotFound(reason='Backup id {} does not exist'.format(backup_id))
     except Exception as ex:
-        raise web.HTTPException(reason=(str(ex)))
+        raise web.HTTPInternalServerError(reason=(str(ex)))
 
     return web.FileResponse(path=gz_path)
 
@@ -201,7 +201,7 @@ async def delete_backup(request):
     except exceptions.DoesNotExist:
         raise web.HTTPNotFound(reason='Backup id {} does not exist'.format(backup_id))
     except Exception as ex:
-        raise web.HTTPException(reason=str(ex))
+        raise web.HTTPInternalServerError(reason=str(ex))
 
 
 async def restore_backup(request):
@@ -222,7 +222,7 @@ async def restore_backup(request):
     except exceptions.DoesNotExist:
         raise web.HTTPNotFound(reason='Backup with {} does not exist'.format(backup_id))
     except Exception as ex:
-        raise web.HTTPException(reason=str(ex))
+        raise web.HTTPInternalServerError(reason=str(ex))
 
 
 async def get_backup_status(request):

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -158,7 +158,7 @@ async def create_category(request):
     except LookupError as ex:
         raise web.HTTPNotFound(reason=str(ex))
     except Exception as ex:
-        raise web.HTTPException(reason=str(ex))
+        raise web.HTTPInternalServerError(reason=str(ex))
     return web.json_response(result)
 
 
@@ -395,7 +395,7 @@ async def add_configuration_item(request):
     except NameError as ex:
         raise web.HTTPNotFound(reason=str(ex))
     except Exception as ex:
-        raise web.HTTPException(reason=str(ex))
+        raise web.HTTPInternalServerError(reason=str(ex))
 
     return web.json_response({"message": "{} config item has been saved for {} category".format(new_config_item, category_name)})
 

--- a/python/foglamp/services/core/api/support.py
+++ b/python/foglamp/services/core/api/support.py
@@ -158,7 +158,7 @@ async def get_syslog_entries(request):
         a = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.readlines()
         c = [b.decode() for b in a]  # Since "a" contains return value in bytes, convert it to string
     except (OSError, Exception) as ex:
-        raise web.HTTPException(reason=str(ex))
+        raise web.HTTPInternalServerError(reason=str(ex))
 
     return web.json_response({'logs': c, 'count': total_lines})
 

--- a/tests/unit/python/foglamp/common/test_configuration_manager.py
+++ b/tests/unit/python/foglamp/common/test_configuration_manager.py
@@ -842,7 +842,7 @@ class TestConfigurationManager:
         ((2, 'catvalue', 'catdesc'), "category_name must be a string"),
         (('catname', 'catvalue', 3), "category_description must be a string")
     ])
-    @ pytest.mark.asyncio
+    @pytest.mark.asyncio
     async def test_bad_create_category(self, reset_singleton, mocker, payload, message):
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)

--- a/tests/unit/python/foglamp/services/core/api/test_audit.py
+++ b/tests/unit/python/foglamp/services/core/api/test_audit.py
@@ -157,10 +157,11 @@ class TestAudit:
                 assert response_message == resp.reason
 
     async def test_get_audit_http_exception(self, client):
-        with patch.object(connect, 'get_storage_async', return_value=Exception):
+        msg = 'Internal Server Error'
+        with patch.object(connect, 'get_storage_async', side_effect=Exception(msg)):
             resp = await client.get('/foglamp/audit')
             assert 500 == resp.status
-            assert 'Internal Server Error' == resp.reason
+            assert msg == resp.reason
 
     async def test_create_audit_entry(self, client, loop):
         request_data = {"source": "LMTR", "severity": "warning", "details": {"message": "Engine oil pressure low"}}

--- a/tests/unit/python/foglamp/services/core/api/test_backup_restore.py
+++ b/tests/unit/python/foglamp/services/core/api/test_backup_restore.py
@@ -100,10 +100,11 @@ class TestBackup:
         assert response_message == resp.reason
 
     async def test_get_backups_exceptions(self, client):
-        with patch.object(connect, 'get_storage_async', return_value=Exception):
+        msg = "Internal Server Error"
+        with patch.object(connect, 'get_storage_async', side_effect=Exception(msg)):
             resp = await client.get('/foglamp/backup')
             assert 500 == resp.status
-            assert "Internal Server Error" == resp.reason
+            assert msg == resp.reason
 
     async def test_create_backup(self, client):
         async def mock_create():
@@ -117,11 +118,11 @@ class TestBackup:
                 assert '{"status": "running_or_failed"}' == await resp.text()
 
     async def test_create_backup_exception(self, client):
-        with patch.object(connect, 'get_storage_async', return_value=Exception):
-            with patch.object(Backup, 'create_backup', return_value=Exception):
-                resp = await client.post('/foglamp/backup')
-                assert 500 == resp.status
-                assert "Internal Server Error" == resp.reason
+        msg = "Internal Server Error"
+        with patch.object(connect, 'get_storage_async', side_effect=Exception(msg)):
+            resp = await client.post('/foglamp/backup')
+            assert 500 == resp.status
+            assert msg == resp.reason
 
     async def test_get_backup_details(self, client):
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -138,7 +139,7 @@ class TestBackup:
 
     @pytest.mark.parametrize("input_exception, response_code, response_message", [
         (exceptions.DoesNotExist, 404, "Backup id 8 does not exist"),
-        (Exception, 500, "Internal Server Error")
+        (Exception("Internal Server Error"), 500, "Internal Server Error")
     ])
     async def test_get_backup_details_exceptions(self, client, input_exception, response_code, response_message):
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -165,7 +166,7 @@ class TestBackup:
 
     @pytest.mark.parametrize("input_exception, response_code, response_message", [
         (exceptions.DoesNotExist, 404, "Backup id 8 does not exist"),
-        (Exception, 500, "Internal Server Error")
+        (Exception("Internal Server Error"), 500, "Internal Server Error")
     ])
     async def test_delete_backup_exceptions(self, client, input_exception, response_code, response_message):
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -195,7 +196,7 @@ class TestBackup:
     @pytest.mark.parametrize("input_exception, response_code, response_message", [
         (ValueError, 400, "Invalid backup id"),
         (exceptions.DoesNotExist, 404, "Backup id 8 does not exist"),
-        (Exception, 500, "Internal Server Error")
+        (Exception("Internal Server Error"), 500, "Internal Server Error")
     ])
     async def test_get_backup_download_exceptions(self, client, input_exception, response_code, response_message):
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -247,7 +248,7 @@ class TestRestore:
 
     @pytest.mark.parametrize("backup_id, input_exception, code, message", [
         (8, exceptions.DoesNotExist, 404, "Backup with 8 does not exist"),
-        (2, Exception, 500, "Internal Server Error"),
+        (2, Exception("Internal Server Error"), 500, "Internal Server Error"),
         ('blah', ValueError, 400, 'Invalid backup id')
     ])
     async def test_restore_backup_exceptions(self, client, backup_id, input_exception, code, message):

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -515,10 +515,11 @@ class TestConfiguration:
     async def test_create_category_http_exception(self, client, name="test_cat", desc="Test desc"):
         info = {'info': {'type': 'boolean', 'value': 'False', 'description': 'Test', 'default': 'False'}}
         payload = {"key": name, "description": desc, "value": info}
-        with patch.object(connect, 'get_storage_async', side_effect=Exception):
+        msg = 'Something went wrong'
+        with patch.object(connect, 'get_storage_async', side_effect=Exception(msg)):
             resp = await client.post('/foglamp/category', data=json.dumps(payload))
             assert 500 == resp.status
-            assert 'Internal Server Error' == resp.reason
+            assert msg == resp.reason
 
     @pytest.mark.parametrize("payload, message", [
         # FIXME: keys order mismatch assertion
@@ -624,10 +625,11 @@ class TestConfiguration:
 
     async def test_unknown_exception_for_add_config_item(self, client):
         data = {"default": "d", "description": "Test description", "type": "boolean"}
-        with patch.object(connect, 'get_storage_async', side_effect=Exception):
+        msg = 'Internal Server Error'
+        with patch.object(connect, 'get_storage_async', side_effect=Exception(msg)):
             resp = await client.post('/foglamp/category/{}/{}'.format("blah", "blah"), data=json.dumps(data))
             assert 500 == resp.status
-            assert 'Internal Server Error' == resp.reason
+            assert msg == resp.reason
 
     async def test_get_child_category(self, client):
         @asyncio.coroutine

--- a/tests/unit/python/foglamp/services/core/api/test_support.py
+++ b/tests/unit/python/foglamp/services/core/api/test_support.py
@@ -236,7 +236,8 @@ class TestBundleSupport:
             assert message == resp.reason
 
     async def test_get_syslog_entries_cmd_exception(self, client):
-        with patch.object(subprocess, "Popen", side_effect=Exception):
+        msg = 'Internal Server Error'
+        with patch.object(subprocess, "Popen", side_effect=Exception(msg)):
             resp = await client.get('/foglamp/syslog')
             assert 500 == resp.status
-            assert 'Internal Server Error' == resp.reason
+            assert msg == resp.reason


### PR DESCRIPTION
**Verified on below env:**

- [x] ub1804 with Python `3.6.8` and openssl version `1.1.1`
- [x] Rpi3 with `stretch` & Python `3.5.3` and openssl version `1.1.0k`
- [x] Rpi4 with `buster` & Python `3.7.3` and openssl version `1.1.1.c`

**O/P for Ub1804**
```
==== 1636 passed, 42 skipped, 3 warnings in 195.16 seconds ====
```
**O/P for Rpi3 with stretch**
```
=== 1636 passed, 42 skipped, 3 warnings in 650.43 seconds ====
```

**O/P for Rpi4 with buster**

```
tests/unit/python/foglamp/services/core/api/test_common_ping.py ....EEEE..

== 1632 passed, 42 skipped, 12 warnings, 4 error in 178.85 seconds ==
```

