### PR TITLE
FOGL-3081 update source repo list configuration before fetch or install available packages

### DIFF
--- a/python/foglamp/services/core/api/plugins/common.py
+++ b/python/foglamp/services/core/api/plugins/common.py
@@ -117,7 +117,7 @@ def load_and_fetch_c_hybrid_plugin_info(plugin_name: str, is_config: bool, plugi
 
 
 def fetch_available_packages(package_type: str = "") -> list:
-    plugins = []
+    log_output = []
     plugin_dir = '/plugins/'
     _PATH = _FOGLAMP_DATA + plugin_dir if _FOGLAMP_DATA else _FOGLAMP_ROOT + '/data{}'.format(plugin_dir)
     stdout_file_name = "output.txt"
@@ -144,12 +144,12 @@ def fetch_available_packages(package_type: str = "") -> list:
     with open("{}".format(stdout_file_path), 'r') as fh:
         for line in fh:
             line = line.rstrip("\n")
-            plugins.append(line)
+            log_output.append(line)
 
     # Remove stdout file
     os.remove(stdout_file_path)
 
     if ret_code != 0:
-        raise ValueError(plugins)
+        raise ValueError(log_output)
 
-    return plugins
+    return log_output

--- a/python/foglamp/services/core/api/plugins/common.py
+++ b/python/foglamp/services/core/api/plugins/common.py
@@ -8,7 +8,6 @@
 import logging
 import os
 import platform
-import subprocess
 import json
 import importlib.util
 from typing import Dict
@@ -134,12 +133,12 @@ def fetch_available_packages(package_type: str = "") -> list:
     ret_code = os.system(cmd)
     # sudo apt/yum -y install only happens when update is without any error
     if ret_code == 0:
-        if 'centos' in _platform or 'redhat' in _platform:
-            cmd = "sudo yum list available foglamp-{}\* | grep foglamp | cut -d . -f1 > {} 2>&1".\
-                format(pkg_type, stdout_file_path)
+        if pkg_mgt == 'yum':
+            cmd = "sudo yum list available foglamp-{}\* | grep foglamp | cut -d . -f1 > {} 2>&1".format(
+                pkg_type, stdout_file_path)
         else:
-            cmd = "sudo apt list | grep foglamp-{} | grep -v installed | cut -d / -f1  > {} 2>&1".\
-                format(pkg_type, stdout_file_path)
+            cmd = "sudo apt list | grep foglamp-{} | grep -v installed | cut -d / -f1  > {} 2>&1".format(
+                pkg_type, stdout_file_path)
         ret_code = os.system(cmd)
 
     with open("{}".format(stdout_file_path), 'r') as fh:
@@ -147,12 +146,10 @@ def fetch_available_packages(package_type: str = "") -> list:
             line = line.rstrip("\n")
             plugins.append(line)
 
-    if ret_code != 0:
-        # Remove stdout file in case of error
-        os.remove(stdout_file_path)
-        raise ValueError(plugins)
-
-    # Remove stdout file in case of success
+    # Remove stdout file
     os.remove(stdout_file_path)
+
+    if ret_code != 0:
+        raise ValueError(plugins)
 
     return plugins

--- a/python/foglamp/services/core/api/plugins/install.py
+++ b/python/foglamp/services/core/api/plugins/install.py
@@ -246,20 +246,29 @@ def copy_file_install_requirement(dir_files: list, plugin_type: str, file_name: 
 
 
 def install_package_from_repo(name: str, pkg_mgt: str, version: str) -> tuple:
-    stdout_file_path = "/data/plugins/output.txt"
-    cmd = "sudo {} -y install {}".format(pkg_mgt, name)
-    if version:
-        cmd = "sudo {} -y install {}={}".format(pkg_mgt, name, version)
-
-    ret_code = os.system(cmd + " > {} 2>&1".format(_FOGLAMP_ROOT + stdout_file_path))
     msg = ""
-    with open("{}".format(_FOGLAMP_ROOT + stdout_file_path), 'r') as fh:
+    plugin_dir = '/plugins/'
+    stdout_file_name = "output.txt"
+    stdout_file_path = "/{}/{}".format(_PATH, stdout_file_name)
+
+    if not os.path.exists(_PATH):
+        os.makedirs(_PATH)
+
+    cmd = "sudo {} update > {} 2>&1".format(pkg_mgt, stdout_file_path)
+    ret_code = os.system(cmd)
+    # sudo apt/yum -y install only happens when update is without any error
+    if ret_code == 0:
+        cmd = "sudo {} -y install {}".format(pkg_mgt, name)
+        if version:
+            cmd = "sudo {} -y install {}={}".format(pkg_mgt, name, version)
+
+        ret_code = os.system(cmd + " > {} 2>&1".format(stdout_file_path))
+    with open("{}".format(stdout_file_path), 'r') as fh:
         for line in fh:
             line = line.rstrip("\n")
             msg += line
 
     # Remove stdout file
-    cmd = "{}/extras/C/cmdutil rm {}".format(_FOGLAMP_ROOT, stdout_file_path)
-    subprocess.run([cmd], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    os.remove(stdout_file_path)
 
     return ret_code, msg


### PR DESCRIPTION
As discussed on friday scrum, we should add `sudo apt update` before fetching and on installing available packages.
1)  curl -X GET http://localhost:8081/foglamp/plugins/available
2) curl -sX POST http://localhost:8081/foglamp/plugins -d '{"format":"repository", "name": "foglamp-south-sinusoid"}'



**Use case:**
nightly [repo](http://archives.dianomic.com/nightly/ubuntu1804/x86_64/) gets updated over night

In case of any failure REST API throws a bad request 400 with an error message for below scenarios

1. Any network issues with configured source/repo list
2. On incorrect sources/repo list URL
3. Either  `sudo apt update` or `sudo apt list | grep foglamp`  failed which is used internally in code, now it will capture the standard output and standard error of the apt or or yum command


**NOTE:** As GUI dialog disappears with error messge after some time. So we have another story to store persistent log history and this will be taken care in FOGL-3032 and will probably saved under path `FOGLAMP_ROOT/data/plugins/`


Also as discussed with @praveen-garg filed a JIRA story FOGL-3086 for adding audit trail information on install/update package