### PR TITLE
FOGL-3074: Set default loglevel to warning so that loaded plugins …

### DIFF
--- a/C/plugins/utils/get_plugin_info.cpp
+++ b/C/plugins/utils/get_plugin_info.cpp
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <dlfcn.h>
+#include <syslog.h>
 #include "plugin_api.h"
 
 typedef PLUGIN_INFORMATION *(*func_t)();
@@ -41,6 +42,9 @@ int main(int argc, char *argv[])
     exit(2);
   }
 
+  openlog(argv[0], LOG_PID|LOG_CONS, LOG_USER);
+  setlogmask(LOG_UPTO(LOG_WARNING));
+
   if ((hndl = dlopen(argv[1], RTLD_GLOBAL|RTLD_LAZY)) != NULL)
   {
     func_t infoEntry = (func_t)dlsym(hndl, argv[2]);
@@ -49,6 +53,7 @@ int main(int argc, char *argv[])
       // Unable to find plugin_info entry point
       fprintf(stderr, "Plugin library %s does not support %s function : %s\n", argv[1], argv[2], dlerror());
       dlclose(hndl);
+      closelog();
       exit(3);
     }
     PLUGIN_INFORMATION *info = (PLUGIN_INFORMATION *)(*infoEntry)();
@@ -58,7 +63,8 @@ int main(int argc, char *argv[])
   {
     fprintf(stderr, "dlopen failed: %s\n", dlerror());
   }
-
+  closelog();
+  
   return 0;
 }
 


### PR DESCRIPTION
…don't add info/debug level logs into syslog.