### PR TITLE
FOGL-3242 Prevent reconfiguration of the filter pipeline whilst data is

### DIFF
--- a/C/services/south/include/ingest.h
+++ b/C/services/south/include/ingest.h
@@ -75,6 +75,7 @@ private:
 	std::vector<Reading *>*		m_queue;
 	std::mutex			m_qMutex;
 	std::mutex			m_statsMutex;
+	std::mutex			m_pipelineMutex;
 	std::thread*			m_thread;
 	std::thread*			m_statsThread;
 	Logger*				m_logger;
@@ -83,7 +84,7 @@ private:
 	// Data ready to be filtered/sent
 	std::vector<Reading *>*		m_data;
 	unsigned int			m_discardedReadings; // discarded readings since last update to statistics table
-	FilterPipeline*			filterPipeline;
+	FilterPipeline*			m_filterPipeline;
 	
 	std::unordered_set<std::string>   		statsDbEntriesCache;  // confirmed stats table entries
 	std::map<std::string, int>		statsPendingEntries;  // pending stats table entries

--- a/C/services/south/ingest.cpp
+++ b/C/services/south/ingest.cpp
@@ -327,8 +327,8 @@ vector<Reading *>* newQ = new vector<Reading *>();
 	 *
 	 * We lock the filter pipeline here to prevent it being reconfigured whilst we
 	 * process the data. We do this because the qMutex is not good enough here as we
-	 * do not hold it, by deliberate policy. As we copy the queue holdign the qMutex
-	 * and then release it to enabl emore data to be queued while we process the previous
+	 * do not hold it, by deliberate policy. As we copy the queue holding the qMutex
+	 * and then release it to enable more data to be queued while we process the previous
 	 * queue via the filter pipeline and up to the storage layer.
 	 */
 	{

--- a/C/services/south/ingest.cpp
+++ b/C/services/south/ingest.cpp
@@ -451,7 +451,7 @@ bool Ingest::loadFilters(const string& categoryName)
 {
 	Logger::getLogger()->info("Ingest::loadFilters(): categoryName=%s", categoryName.c_str());
 	/*
-	 * We do everything to setup the pipeline using a local FitlerPipeline and then assign it
+	 * We do everything to setup the pipeline using a local FilterPipeline and then assign it
 	 * to the service m_filterPipeline once it is setup to guard against access to the pipeline
 	 * during setup.
 	 * This should not be an issue if the mutex is held, however this approach lessens the risk
@@ -476,7 +476,7 @@ bool Ingest::loadFilters(const string& categoryName)
 	}
 	else
 	{
-		Logger::getLogger()->error("Failed to setup the filter pipeline, the fitlers are not attached tp the service");
+		Logger::getLogger()->error("Failed to setup the filter pipeline, the filters are not attached to the service");
 		filterPipeline->cleanupFilters(categoryName);
 	}
 	return rval;
@@ -511,7 +511,7 @@ void Ingest::passToOnwardFilter(OUTPUT_HANDLE *outHandle,
  *	1. The filtering has all been done in place. In which case
  *	the m_data vector is in the ReadingSet passed in here.
  *
- *	2. The fitlering has created new ReadingSet in which case
+ *	2. The filttering has created new ReadingSet in which case
  *	the reading vector must be copied into m_data from the
  *	ReadingSet.
  *

--- a/C/services/south/ingest.cpp
+++ b/C/services/south/ingest.cpp
@@ -511,7 +511,7 @@ void Ingest::passToOnwardFilter(OUTPUT_HANDLE *outHandle,
  *	1. The filtering has all been done in place. In which case
  *	the m_data vector is in the ReadingSet passed in here.
  *
- *	2. The filttering has created new ReadingSet in which case
+ *	2. The filtering has created new ReadingSet in which case
  *	the reading vector must be copied into m_data from the
  *	ReadingSet.
  *


### PR DESCRIPTION
being processed via that pipeline. This change introduces a new moutex
on the pipeline itself as thw qMutex is not held during the processing
of the data ingested. This allows for better ingst performance by
allowing the next queue to be filled whilst the previous queue is
processed.