### PR TITLE
FOGL-3242 | FOGL-3245  Prevent reconfiguration of the filter pipeline whilst data is being processed and fixes of deadlock issue (1.7.0 RC) 

### DIFF
--- a/C/common/filter_pipeline.cpp
+++ b/C/common/filter_pipeline.cpp
@@ -198,6 +198,7 @@ bool FilterPipeline::loadFilters(const string& categoryName)
 			}
 		}
 
+		m_pipeline = filter;
 		/*
 		 * Put all the new catregories in the Filter category parent
 		 * Create an empty South category if one doesn't exist

--- a/C/common/include/filter_pipeline.h
+++ b/C/common/include/filter_pipeline.h
@@ -50,6 +50,7 @@ public:
 					     void *ingest);
 	// Check FilterPipeline is ready for data ingest
 	bool		isReady() { return m_ready; };
+	bool		hasChanged(const std::string pipeline) const { return m_pipeline != pipeline; }
 
 private:
 	PLUGIN_HANDLE	loadFilterPlugin(const std::string& filterName);
@@ -59,8 +60,11 @@ protected:
 	ManagementClient*	mgtClient;
 	StorageClient&		storage;
 	std::string		serviceName;
-	std::vector<FilterPlugin *>	m_filters;
-	std::map<std::string, FilterPlugin *>	m_filterCategories;
+	std::vector<FilterPlugin *>
+				m_filters;
+	std::map<std::string, FilterPlugin *>
+				m_filterCategories;
+	std::string		m_pipeline;
 };
 
 #endif

--- a/C/services/south/include/ingest.h
+++ b/C/services/south/include/ingest.h
@@ -75,6 +75,7 @@ private:
 	std::vector<Reading *>*		m_queue;
 	std::mutex			m_qMutex;
 	std::mutex			m_statsMutex;
+	std::mutex			m_pipelineMutex;
 	std::thread*			m_thread;
 	std::thread*			m_statsThread;
 	Logger*				m_logger;
@@ -83,7 +84,7 @@ private:
 	// Data ready to be filtered/sent
 	std::vector<Reading *>*		m_data;
 	unsigned int			m_discardedReadings; // discarded readings since last update to statistics table
-	FilterPipeline*			filterPipeline;
+	FilterPipeline*			m_filterPipeline;
 	
 	std::unordered_set<std::string>   		statsDbEntriesCache;  // confirmed stats table entries
 	std::map<std::string, int>		statsPendingEntries;  // pending stats table entries


### PR DESCRIPTION
- [x] FOGL-3242 Prevent reconfiguration of the filter pipeline whilst data is being processed via that pipeline. This change introduces a new moutex
on the pipeline itself as thw qMutex is not held during the processing
of the data ingested. This allows for better ingst performance by
allowing the next queue to be filled whilst the previous queue is
processed.
- [x] FOGL-3245 Fix deadlock issue in filter configuration change