### PR TITLE
FOGL-3194 system test - default asset prefix of enviro-pHAT changed; check stats etc. per that (1.7.0 RC)

### DIFF
--- a/tests/system/python/rpi/test_e2e_rpi_ephat.py
+++ b/tests/system/python/rpi/test_e2e_rpi_ephat.py
@@ -28,7 +28,7 @@ __version__ = "${VERSION}"
 SOUTH_PLUGIN = "envirophat"
 SVC_NAME = "Room-1"
 
-ASSET_PREFIX = "envirophat/"  # default for envirophat South plugin
+ASSET_PREFIX = "e_"  # default for envirophat South plugin
 
 ASSET_NAME_W = "weather"
 SENSOR_READ_KEY_W = {"temperature", "altitude", "pressure"}


### PR DESCRIPTION
cherry-picked #1683