### PR TITLE
FOGL-3039 patch / FOGL-3089 HTTPInternalServerError instead of HTTPEx… (1.7.0 RC)

### DIFF
--- a/python/foglamp/services/core/api/asset_tracker.py
+++ b/python/foglamp/services/core/api/asset_tracker.py
@@ -57,6 +57,6 @@ async def get_asset_tracker_events(request):
     except KeyError:
         raise web.HTTPBadRequest(reason=result['message'])
     except Exception as ex:
-        raise web.HTTPException(reason=ex)
+        raise web.HTTPInternalServerError(reason=ex)
 
     return web.json_response({'track': response})

--- a/python/foglamp/services/core/api/common.py
+++ b/python/foglamp/services/core/api/common.py
@@ -149,7 +149,7 @@ async def shutdown(request):
     except TimeoutError as err:
         raise web.HTTPInternalServerError(reason=str(err))
     except Exception as ex:
-        raise web.HTTPException(reason=str(ex))
+        raise web.HTTPInternalServerError(reason=str(ex))
 
 
 def do_shutdown(request):
@@ -177,4 +177,4 @@ async def restart(request):
         raise web.HTTPInternalServerError(reason=e)
     except Exception as ex:
         _logger.exception("Error while stopping FogLAMP server: %s", ex)
-        raise web.HTTPException(reason=ex)
+        raise web.HTTPInternalServerError(reason=ex)

--- a/python/foglamp/services/core/api/plugins/install.py
+++ b/python/foglamp/services/core/api/plugins/install.py
@@ -135,7 +135,7 @@ async def add_plugin(request: web.Request) -> web.Response:
         msg = "Plugin installation request failed"
         raise web.HTTPBadRequest(body=json.dumps({"message": msg, "link": str(e)}), reason=msg)
     except Exception as ex:
-        raise web.HTTPException(reason=str(ex))
+        raise web.HTTPInternalServerError(reason=str(ex))
     else:
         return web.json_response(result_payload)
 

--- a/python/foglamp/services/core/server.py
+++ b/python/foglamp/services/core/server.py
@@ -1199,7 +1199,7 @@ class Server:
         except TimeoutError as err:
             raise web.HTTPInternalServerError(reason=str(err))
         except Exception as ex:
-            raise web.HTTPException(reason=str(ex))
+            raise web.HTTPInternalServerError(reason=str(ex))
 
     @classmethod
     async def restart(cls, request):
@@ -1224,7 +1224,7 @@ class Server:
         except TimeoutError as err:
             raise web.HTTPInternalServerError(reason=str(err))
         except Exception as ex:
-            raise web.HTTPException(reason=str(ex))
+            raise web.HTTPInternalServerError(reason=str(ex))
 
     @classmethod
     async def register_interest(cls, request):
@@ -1364,7 +1364,7 @@ class Server:
         except ValueError as ex:
             raise web.HTTPNotFound(reason=str(ex))
         except Exception as ex:
-            raise web.HTTPException(reason=ex)
+            raise web.HTTPInternalServerError(reason=ex)
 
         return web.json_response(result)
 
@@ -1447,6 +1447,6 @@ class Server:
         except ValueError as ex:
             raise web.HTTPNotFound(reason=str(ex))
         except Exception as ex:
-            raise web.HTTPException(reason=ex)
+            raise web.HTTPInternalServerError(reason=ex)
 
         return web.json_response(message)

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -338,7 +338,7 @@ class TestConfiguration:
             with patch.object(c_mgr, 'set_optional_value_entry', side_effect=ValueError) as patch_set_entry:
                 resp = await client.put('/foglamp/category/{}/{}'.format(category_name, item_name), data=json.dumps(payload))
                 assert 400 == resp.status
-                assert resp.reason is None
+                assert resp.reason is ''
             patch_set_entry.assert_called_once_with(category_name, item_name, optional_key, payload[optional_key])
 
     @pytest.mark.parametrize("expected_result, hide_password", [
@@ -749,7 +749,7 @@ class TestConfiguration:
             with patch.object(c_mgr, 'get_category_item', side_effect=exception_name) as patch_get_cat_item:
                 resp = await client.put('/foglamp/category/{}'.format(category_name), data=json.dumps(payload))
                 assert code == resp.status
-                assert resp.reason is None
+                assert resp.reason is ''
             patch_get_cat_item.assert_called_once_with(category_name, config_item_name)
 
     async def test_update_bulk_config_item_not_found(self, client, category_name='rest_api'):

--- a/tests/unit/python/foglamp/services/core/api/test_filters.py
+++ b/tests/unit/python/foglamp/services/core/api/test_filters.py
@@ -170,7 +170,7 @@ class TestFilters:
             with patch.object(cf_mgr, 'get_category_all_items', side_effect=Exception) as get_cat_info_patch:
                 resp = await client.get('/foglamp/filter/{}'.format(filter_name))
                 assert 500 == resp.status
-                assert resp.reason is None
+                assert resp.reason is ''
             get_cat_info_patch.assert_called_once_with(filter_name)
 
     @pytest.mark.parametrize("data", [
@@ -291,7 +291,7 @@ class TestFilters:
                 with patch.object(_LOGGER, 'exception') as log_exc:
                     resp = await client.post('/foglamp/filter'.format("bench"), data=json.dumps({"name": name, "plugin": plugin_name}))
                     assert 500 == resp.status
-                    assert resp.reason is None
+                    assert resp.reason is ''
                 assert 1 == log_exc.call_count
                 log_exc.assert_called_once_with('Add filter, caught exception:  %s', '')
             get_cat_info_patch.assert_called_once_with(category_name=name)
@@ -652,7 +652,7 @@ class TestFilters:
             with patch.object(cf_mgr, 'get_category_all_items', side_effect=Exception) as get_cat_info_patch:
                 resp = await client.get('/foglamp/filter/{}/pipeline'.format(user))
                 assert 500 == resp.status
-                assert resp.reason is None
+                assert resp.reason is ''
             get_cat_info_patch.assert_called_once_with(category_name=user)
 
     @pytest.mark.skip(reason='Incomplete')

--- a/tests/unit/python/foglamp/services/core/api/test_scheduler_api.py
+++ b/tests/unit/python/foglamp/services/core/api/test_scheduler_api.py
@@ -163,7 +163,7 @@ class TestSchedules:
 
     @pytest.mark.parametrize("exception_name, response_code, response_message", [
         (ScheduleNotFoundError(_random_uuid), 404, 'Schedule not found: {}'.format(_random_uuid)),
-        (ValueError, 404, None),
+        (ValueError, 404, ''),
     ])
     async def test_get_schedule_exceptions(self, client, exception_name, response_code, response_message):
         with patch.object(server.Server.scheduler, 'get_schedule', side_effect=exception_name):
@@ -190,7 +190,7 @@ class TestSchedules:
 
     @pytest.mark.parametrize("exception_name, response_code, response_message", [
         (ScheduleNotFoundError(_random_uuid), 404, 'Schedule not found: {}'.format(_random_uuid)),
-        (ValueError, 404, None),
+        (ValueError, 404, ''),
     ])
     async def test_enable_schedule_exceptions(self, client, exception_name, response_code, response_message):
         with patch.object(server.Server.scheduler, 'enable_schedule', side_effect=exception_name):
@@ -217,7 +217,7 @@ class TestSchedules:
 
     @pytest.mark.parametrize("exception_name, response_code, response_message", [
         (ScheduleNotFoundError(_random_uuid), 404, 'Schedule not found: {}'.format(_random_uuid)),
-        (ValueError, 404, None),
+        (ValueError, 404, ''),
     ])
     async def test_disable_schedule_exceptions(self, client, exception_name, response_code, response_message):
         with patch.object(server.Server.scheduler, 'disable_schedule', side_effect=exception_name):
@@ -254,8 +254,8 @@ class TestSchedules:
 
     @pytest.mark.parametrize("exception_name, response_code, response_message", [
         (ScheduleNotFoundError(_random_uuid), 404, 'Schedule not found: {}'.format(_random_uuid)),
-        (NotReadyError(), 404, None),
-        (ValueError, 404, None),
+        (NotReadyError(), 404, ''),
+        (ValueError, 404, ''),
     ])
     async def test_start_schedule_exceptions(self, client, exception_name, response_code, response_message):
         with patch.object(server.Server.scheduler, 'get_schedule', side_effect=exception_name):
@@ -485,8 +485,8 @@ class TestSchedules:
 
     @pytest.mark.parametrize("exception_name, response_code, response_message", [
         (ScheduleNotFoundError(_random_uuid), 404, 'Schedule not found: {}'.format(_random_uuid)),
-        (NotReadyError(), 404, None),
-        (ValueError, 404, None),
+        (NotReadyError(), 404, ''),
+        (ValueError, 404, ''),
         (RuntimeWarning, 409, "Enabled Schedule {} cannot be deleted.".format(str(_random_uuid))),
     ])
     async def test_delete_schedule_exceptions(self, client, exception_name, response_code, response_message):
@@ -556,7 +556,7 @@ class TestTasks:
 
     @pytest.mark.parametrize("exception_name, response_code, response_message", [
         (TaskNotFoundError(_random_uuid), 404, 'Task not found: {}'.format(_random_uuid)),
-        (ValueError, 404, None),
+        (ValueError, 404, ''),
     ])
     async def test_get_task_exceptions(self, client, exception_name, response_code, response_message):
         with patch.object(server.Server.scheduler, 'get_task', side_effect=exception_name):
@@ -670,7 +670,7 @@ class TestTasks:
     @pytest.mark.parametrize("exception_name, response_code, response_message", [
         (TaskNotFoundError(_random_uuid), 404, 'Task not found: {}'.format(_random_uuid)),
         (TaskNotRunningError(_random_uuid), 404, 'Task is not running: {}'.format(_random_uuid)),
-        (ValueError, 404, None),
+        (ValueError, 404, ''),
     ])
     async def test_cancel_task_exceptions(self, client, exception_name, response_code, response_message):
         async def mock_coro():

--- a/tests/unit/python/foglamp/services/core/api/test_service.py
+++ b/tests/unit/python/foglamp/services/core/api/test_service.py
@@ -595,7 +595,7 @@ class TestService:
         mocker.patch.object(service, "get_schedule", side_effect=Exception)
         resp = await client.delete("/foglamp/service/{}".format(name))
         assert 500 == resp.status
-        assert resp.reason is None
+        assert resp.reason is ''
 
         async def mock_bad_result():
             return {"count": 0, "rows": []}

--- a/tests/unit/python/foglamp/services/core/api/test_task.py
+++ b/tests/unit/python/foglamp/services/core/api/test_task.py
@@ -487,7 +487,7 @@ class TestTask:
         mocker.patch.object(task, "get_schedule", side_effect=Exception)
         resp = await client.delete("/foglamp/scheduled/task/Test")
         assert 500 == resp.status
-        assert resp.reason is None
+        assert resp.reason is ''
 
         async def mock_bad_result():
             return {"count": 0, "rows": []}


### PR DESCRIPTION
…ception and  response reason not None handling ( cherry-picked #1690)


* middleware should capture all http exceptions hence reverted this statement; in case of 500 if response reason is not there it should be asserted with empty string instead of None

* in case of 500 if response reason is not there it should be asserted with empty string instead of None