### PR TITLE
FOGL-3088 multi select source code added in GET audit (in lieu of PR#1713)

### DIFF
--- a/python/foglamp/services/core/api/audit.py
+++ b/python/foglamp/services/core/api/audit.py
@@ -201,8 +201,7 @@ async def get_audit_entries(request):
             else:
                 payload = PayloadBuilder().SELECT("code", "level", "log", "ts") \
                     .ALIAS("return", ("ts", 'timestamp')).FORMAT("return", ("ts", "YYYY-MM-DD HH24:MI:SS.MS"))
-                for code in source_list:
-                    payload.OR_WHERE(['code', '=', code])
+                payload.WHERE(['code', 'in', source_list])
         if severity is not None:
             payload.AND_WHERE(['level', '=', severity])
 

--- a/tests/unit/python/foglamp/services/core/api/test_audit.py
+++ b/tests/unit/python/foglamp/services/core/api/test_audit.py
@@ -100,6 +100,7 @@ class TestAudit:
     @pytest.mark.parametrize("request_params, payload", [
         ('', {"return": ["code", "level", "log", {"column": "ts", "format": "YYYY-MM-DD HH24:MI:SS.MS", "alias": "timestamp"}], "where": {"column": "1", "condition": "=", "value": 1}, "sort": {"column": "ts", "direction": "desc"}, "limit": 20}),
         ('?source=PURGE', {'return': ['code', 'level', 'log', {'format': 'YYYY-MM-DD HH24:MI:SS.MS', 'column': 'ts', 'alias': 'timestamp'}], 'where': {'value': 1, 'and': {'value': 'PURGE', 'column': 'code', 'condition': '='}, 'column': '1', 'condition': '='}, 'sort': {'direction': 'desc', 'column': 'ts'}, 'limit': 20}),
+        ('?source=PURGE,START,CONAD', {'return': ['code', 'level', 'log', {'format': 'YYYY-MM-DD HH24:MI:SS.MS', 'column': 'ts', 'alias': 'timestamp'}], 'where': {'value': ['PURGE', 'START', 'CONAD'], 'column': 'code', 'condition': 'in'}, 'sort': {'direction': 'desc', 'column': 'ts'}, 'limit': 20}),
         ('?skip=1', {'where': {'value': 1, 'column': '1', 'condition': '='}, 'limit': 20, 'return': ['code', 'level', 'log', {'column': 'ts', 'format': 'YYYY-MM-DD HH24:MI:SS.MS', 'alias': 'timestamp'}], 'skip': 1, 'sort': {'direction': 'desc', 'column': 'ts'}}),
         ('?severity=failure', {'where': {'and': {'value': 1, 'column': 'level', 'condition': '='}, 'value': 1, 'column': '1', 'condition': '='}, 'limit': 20, 'return': ['code', 'level', 'log', {'column': 'ts', 'format': 'YYYY-MM-DD HH24:MI:SS.MS', 'alias': 'timestamp'}], 'sort': {'direction': 'desc', 'column': 'ts'}}),
         ('?severity=FAILURE&limit=1', {'limit': 1, 'sort': {'direction': 'desc', 'column': 'ts'}, 'return': ['code', 'level', 'log', {'column': 'ts', 'format': 'YYYY-MM-DD HH24:MI:SS.MS', 'alias': 'timestamp'}], 'where': {'value': 1, 'condition': '=', 'and': {'value': 1, 'condition': '=', 'column': 'level'}, 'column': '1'}}),
@@ -138,6 +139,7 @@ class TestAudit:
     @pytest.mark.parametrize("request_params, response_code, response_message", [
         ('?source=BLA', 400, "BLA is not a valid source"),
         ('?source=1234', 400, "1234 is not a valid source"),
+        ('?source=PURGE,NTF', 400, "NTF is not a valid source"),
         ('?limit=invalid', 400, "Limit must be a positive integer"),
         ('?limit=-1', 400, "Limit must be a positive integer"),
         ('?skip=invalid', 400, "Skip/Offset must be a positive integer"),


### PR DESCRIPTION
- [x] Unit tests
- [x] Code coverage tests 

Module | statements | missing | excluded | coverage
-- | -- | -- | -- | --
python/foglamp/services/core/api/audit.py | 133 | 0 | 0 | 100%

- [x] No Regression in Audit System API tests

Curl example with multi source
```
$ curl -sX GET http://localhost:8081/foglamp/audit?source=START,CONCH,FSTOP | jq
{
  "audit": [
    {
      "source": "CONCH",
      "timestamp": "2019-10-11 10:09:36.791",
      "details": {
        "message": "Scheduler configuration failed"
      },
      "severity": "FAILURE"
    },
    {
      "source": "START",
      "timestamp": "2019-10-11 10:09:36.729",
      "details": {
        "message": "foglamp started"
      },
      "severity": "INFORMATION"
    },
    {
      "source": "START",
      "timestamp": "2019-10-11 10:09:30.439",
      "details": {},
      "severity": "INFORMATION"
    }
  ],
  "totalCount": 3
}

```