### PR TITLE
FOGL-3271 coral based plugins removed from system package API tests

### DIFF
--- a/tests/system/python/packages/data/package_list.json
+++ b/tests/system/python/packages/data/package_list.json
@@ -7,14 +7,14 @@
 		"rule": ["average", "simple-expression"]
 	}],
 	"p1": [{
-		"south": ["coral-object-detection", "dnp3", "envirophat", "flirax8", "game", "mqtt-sparkplug", "opcua", "people", "playback", "phidget", "randomwalk"],
+		"south": ["dnp3", "envirophat", "flirax8", "game", "mqtt-sparkplug", "opcua", "playback", "phidget", "randomwalk"],
 		"north": ["kafka", "opcua"],
 		"filter": ["change", "delta", "fft", "flirvalidity", "metadata", "rms"],
 		"notify": ["email"],
 		"rule": ["outofbound"]
 	}],
 	"p2": [{
-		"south": ["benchmark", "cc2650", "coap", "coral-classify", "coral-people-image", "csv", "dht11V2", "expression", "http-south", "modbustcp", "openweathermap", "random", "systeminfo", "wind-turbine"],
+		"south": ["benchmark", "cc2650", "coap", "csv", "dht11V2", "expression", "http-south", "modbustcp", "openweathermap", "random", "systeminfo", "wind-turbine"],
 		"north": ["http-north", "thingspeak"],
 		"filter": ["asset", "rate", "rms-trigger", "scale", "threshold"],
 		"notify": ["slack", "telegram"],

--- a/tests/system/python/packages/data/package_list.json
+++ b/tests/system/python/packages/data/package_list.json
@@ -21,7 +21,7 @@
 		"rule": []
 	}],
 	"p3": [{
-		"south": ["am2315", "csv-async", "dht11", "ina219", "pt100", "roxtec", "raspi-classify", "sensehat", "sensorphone"],
+		"south": ["am2315", "csv-async", "dht11", "ina219", "pt100", "roxtec", "sensehat", "sensorphone"],
 		"north": [],
 		"filter": ["python27", "scale-set"],
 		"notify": ["alexa", "blynk", "hangouts", "ifttt"],


### PR DESCRIPTION
This has been found via FOGL-3273 work. SO I have kept the branch name with original FOGL-3271