### PR TITLE
FOGL-3326 (Interactive skipped for kerberos dep while installing foglamp) ub1804 pkg installation

### DIFF
--- a/tests/system/python/packages/test_available_and_install_api.py
+++ b/tests/system/python/packages/test_available_and_install_api.py
@@ -114,7 +114,9 @@ class TestPackages:
         assert 200 == r.status
         r = r.read().decode()
         jdoc = json.loads(r)
-        assert {'message': '{} is successfully installed'.format(data['name'])} == jdoc
+        assert 'message' in jdoc
+        assert 'link' in jdoc
+        assert '{} is successfully installed'.format(data['name']) == jdoc['message']
 
         # verify service installed
         conn.request("GET", '/foglamp/service/installed')

--- a/tests/system/python/scripts/package/setup
+++ b/tests/system/python/scripts/package/setup
@@ -44,7 +44,7 @@ wget -q -O - http://archives.dianomic.com/KEY.gpg | sudo apt-key add -
 echo "deb http://archives.dianomic.com/${PACKAGE_BUILD_VERSION}/${ID}/${UNAME}/ /" | sudo tee -a /etc/apt/sources.list
 sudo apt update
 
-time sudo apt install -y foglamp
+time sudo DEBIAN_FRONTEND=noninteractive apt install -yq foglamp
 echo "==================== DONE INSTALLING FogLAMP =================="
 
 time sudo apt install -y foglamp-gui


### PR DESCRIPTION
**Fixed items:**
- [x] skipped interactive on foglamp installation (But this true for FRESH ONLY)
- [x] fixed servie installation assertions as 'link' key has been added in response IN FOGL-3172
- [x] foglamp_packages_installation_ub1804 CI JOB PASSED

Here are the [CI results](http://jenkins.dianomic.com:8080/view/custom%20jobs/job/foglamp_packages_installation_ub1804/28/)