### PR TITLE
system test fixes as per FOGL-3086 changes

### DIFF
--- a/tests/system/python/api/test_audit.py
+++ b/tests/system/python/api/test_audit.py
@@ -25,7 +25,8 @@ class TestAudit:
         expected_code_list = ['PURGE', 'LOGGN', 'STRMN', 'SYPRG', 'START', 'FSTOP',
                               'CONCH', 'CONAD', 'SCHCH', 'SCHAD', 'SRVRG', 'SRVUN',
                               'SRVFL', 'NHCOM', 'NHDWN', 'NHAVL', 'UPEXC', 'BKEXC',
-                              'NTFDL', 'NTFAD', 'NTFSN', 'NTFCL', 'NTFST', 'NTFSD']
+                              'NTFDL', 'NTFAD', 'NTFSN', 'NTFCL', 'NTFST', 'NTFSD',
+                              'PKGIN', 'PKGUP']
         conn = http.client.HTTPConnection(foglamp_url)
         conn.request("GET", '/foglamp/audit/logcode')
         r = conn.getresponse()
@@ -33,7 +34,7 @@ class TestAudit:
         r = r.read().decode()
         jdoc = json.loads(r)
         assert len(jdoc), "No data found"
-        assert 24 == len(jdoc['logCode'])
+        assert 26 == len(jdoc['logCode'])
         codes = [key['code'] for key in jdoc['logCode']]
         assert Counter(expected_code_list) == Counter(codes)
 


### PR DESCRIPTION
```
$ pytest -s -vv tests/system/python/api/test_audit.py 
============================================================= test session starts =============================================================
platform linux -- Python 3.5.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1 -- /usr/local/bin/python3.5
cachedir: tests/system/python/.pytest_cache
rootdir: /home/foglamp/Development/FogLAMP/tests/system/python, inifile: pytest.ini
plugins: mock-1.10.3, cov-2.5.1, asyncio-0.10.0, allure-adaptor-1.7.10, aiohttp-0.3.0
collected 21 items                                                                                                                            

tests/system/python/TestAudit test_get_log_codes <- api/test_audit.py FogLAMP killed.
This script will remove all data stored in the SQLite3 datafile '/home/foglamp/Development/FogLAMP/data/foglamp.db'
Enter YES if you want to continue: Starting FogLAMP v1.7.0.......
FogLAMP started.
PASSED
tests/system/python/TestAudit test_get_severity <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_default_get_audit <- api/test_audit.py PASSED
tests/system/python/TestAudit test_create_audit_entry <- api/test_audit.py PASSED
tests/system/python/TestAudit test_create_audit_entry <- api/test_audit.py PASSED
tests/system/python/TestAudit test_create_audit_entry <- api/test_audit.py PASSED
tests/system/python/TestAudit test_create_audit_entry <- api/test_audit.py PASSED

========= 21 passed in 24.04 seconds ==============
```