### PR TITLE
FOGL-3324 mandatory optional item mechanism added in configuration manager along with unit tests

### DIFF
--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -266,7 +266,10 @@ async def set_configuration_item(request):
                 if 'readonly' in storage_value_entry:
                     if storage_value_entry['readonly'] == 'true':
                         raise TypeError("Update not allowed for {} item_name as it has readonly attribute set".format(config_item))
-
+                if 'mandatory' in storage_value_entry:
+                    if storage_value_entry['mandatory'] == 'true' and not len(value):
+                        found_optional = True
+                        raise ValueError("A value must be given for {}".format(config_item))
             await cf_mgr.set_category_item_value_entry(category_name, config_item, value)
         else:
             await cf_mgr.set_optional_value_entry(category_name, config_item, list(found_optional.keys())[0], list(found_optional.values())[0])
@@ -313,6 +316,9 @@ async def update_configuration_item_bulk(request):
                         if storage_value_entry['readonly'] == 'true':
                             raise TypeError(
                                 "Bulk update not allowed for {} item_name as it has readonly attribute set".format(item_name))
+                    if 'mandatory' in storage_value_entry:
+                        if storage_value_entry['mandatory'] == 'true' and not len(new_val):
+                            raise ValueError("A value must be given for {}".format(item_name))
         await cf_mgr.update_configuration_item_bulk(category_name, data)
     except (NameError, KeyError) as ex:
         raise web.HTTPNotFound(reason=ex)

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -286,20 +286,22 @@ class TestConfiguration:
                 assert item_name == args[1]
             patch_set_entry.assert_called_once_with(category_name, item_name, payload['value'])
 
-    async def test_set_config_item_not_allowed(self, client, category_name='rest_api', item_name='http_port'):
+    @pytest.mark.parametrize("payload, optional_item, message", [
+        ({"value": '8082'}, "readonly", "Update not allowed for {} item_name as it has readonly attribute set"),
+        ({"value": ''}, "mandatory", "A value must be given for {}")
+    ])
+    async def test_set_config_item_not_allowed(self, client, payload, message, optional_item, category_name='rest_api', item_name='http_port'):
         async def async_mock(return_value):
             return return_value
-
-        payload = {"value": '8082'}
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         storage_value_entry = {'value': '8082', 'type': 'integer', 'default': '8081',
-                               'description': 'The port to accept HTTP connections on', 'readonly': 'true'}
+                               'description': 'The port to accept HTTP connections on', optional_item: 'true'}
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=async_mock(storage_value_entry)) as patch_get_cat:
                 resp = await client.put('/foglamp/category/{}/{}'.format(category_name, item_name), data=json.dumps(payload))
                 assert 400 == resp.status
-                assert 'Update not allowed for {} item_name as it has readonly attribute set'.format(item_name) == resp.reason
+                assert message.format(item_name) == resp.reason
             patch_get_cat.assert_called_once_with(category_name, item_name)
 
     @pytest.mark.parametrize("value", [
@@ -433,6 +435,9 @@ class TestConfiguration:
         ({"key": "test", "description": "des"}, "\"'value' param required to create a category\""),
         ({"key": "test", "value": "val"}, "\"'description' param required to create a category\""),
         ({"description": "desc", "value": "val"}, "\"'key' param required to create a category\""),
+        ({"key":"test", "description":"test", "value": {"test1": {"type": "string", "description": "d", "default": "",
+                                                                  "mandatory": "true"}}},
+         "For test category, A default value must be given for test1")
     ])
     async def test_create_category_bad_request(self, client, payload, message):
         storage_client_mock = MagicMock(StorageClientAsync)
@@ -767,21 +772,25 @@ class TestConfiguration:
                 assert "'{} config item not found'".format(config_item_name) == resp.reason
             patch_get_cat_item.assert_called_once_with(category_name, config_item_name)
 
-    async def test_update_bulk_config_not_allowed(self, client, category_name='rest_api'):
+    @pytest.mark.parametrize("payload, optional_item, message", [
+        ({"http_port": '8082'}, "readonly", "Bulk update not allowed for {} item_name as it has readonly attribute set"),
+        ({"http_port": ''}, "mandatory", "A value must be given for {}")
+    ])
+    async def test_update_bulk_config_not_allowed(self, client, payload, optional_item, message,
+                                                  category_name='rest_api'):
         async def async_mock(return_value):
             return return_value
 
-        config_item_name = "http_port"
-        payload = {config_item_name: "8082"}
+        config_item_name = list(payload)[0]
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         storage_value_entry = {'description': 'Port to accept HTTP connections on', 'displayName': 'HTTP Port',
-                               'value': '8081', 'default': '8081', 'order': '2', 'type': 'integer', 'readonly': 'true'}
+                               'value': '8081', 'default': '8081', 'order': '2', 'type': 'integer', optional_item: 'true'}
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'get_category_item', return_value=async_mock(storage_value_entry)) as patch_get_cat_item:
                 resp = await client.put('/foglamp/category/{}'.format(category_name), data=json.dumps(payload))
                 assert 400 == resp.status
-                assert 'Bulk update not allowed for {} item_name as it has readonly attribute set'.format(config_item_name) == resp.reason
+                assert message.format(config_item_name) == resp.reason
             patch_get_cat_item.assert_called_once_with(category_name, config_item_name)
 
     @pytest.mark.parametrize("category_name", [


### PR DESCRIPTION
**Examples**

Bad create category 
```
$ curl -sX POST http://localhost:8081/foglamp/category -d '{"description": "test", "key": "test", "value": {"T2": {"description": "desc2", "type": "integer", "default": "2", "mandatory": "false"}, "T1": {"description": "desc1", "type": "string", "default": "", "mandatory": "true"}, "T3": {"description": "desc3", "type": "string", "default": "testing", "mandatory": "true"}}}'

400: For test category, A default value must be given for T1
```
Good create category
```
$ curl -sX POST http://localhost:8081/foglamp/category -d '{"description": "test", "key": "test", "value": {"T2": {"description": "desc2", "type": "integer", "default": "2", "mandatory": "false"}, "T1": {"description": "desc1", "type": "string", "default": "T1", "mandatory": "true"}, "T3": {"description": "desc3", "type": "string", "default": "testing", "mandatory": "true"}}}' | jq
{
  "value": {
    "T3": {
      "default": "testing",
      "type": "string",
      "mandatory": "true",
      "description": "desc3",
      "value": "testing"
    },
    "T1": {
      "default": "T1",
      "type": "string",
      "mandatory": "true",
      "description": "desc1",
      "value": "T1"
    },
    "T2": {
      "default": "2",
      "type": "integer",
      "mandatory": "false",
      "description": "desc2",
      "value": "2"
    }
  },
  "description": "test",
  "displayName": "test",
  "key": "test"
}

```
Bad Update

```
$ curl -sX PUT http://localhost:8081/foglamp/category/test/T3 -d '{"value": ""}'

400: A value must be given for T3
```

Good update

```
$ curl -sX PUT http://localhost:8081/foglamp/category/test/T2 -d '{"value": "25"}'

{"default": "2", "type": "integer", "mandatory": "false", "description": "desc2", "value": "25"}
```
Bad Bulk update
```
$ curl -sX PUT http://localhost:8081/foglamp/category/test -d '{"T3": "", "T2": "abc"}'

400: A value must be given for T3
```

Good bulk update

```
$ curl -sX PUT http://localhost:8081/foglamp/category/test -d '{"T3": "A", "T2": "13", "T1": "C"}'

{"T3": {"default": "testing", "type": "string", "mandatory": "true", "description": "desc3", "value": "A"}, "T1": {"default": "T1", "type": "string", "mandatory": "true", "description": "desc1", "value": "C"}, "T2": {"default": "2", "type": "integer", "mandatory": "false", "description": "desc2", "value": "13"}}
```

**NOTE**
No Regression in system configuration API tests health. Here is the local output
```
=== 13 passed, 1 skipped in 26.37 seconds ===
```
