### PR TITLE
FOGL-3246 - description KV pair is added to configuration cache manager & other fixes

### DIFF
--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -367,9 +367,9 @@ class ConfigurationManager(ConfigurationManagerSingleton):
         # SELECT configuration.key, configuration.description, configuration.value, configuration.display_name, configuration.ts FROM configuration
         payload = PayloadBuilder().SELECT("key", "description", "value", "display_name", "ts") \
             .ALIAS("return", ("ts", 'timestamp')) \
-            .FORMAT("return", ("ts", "YYYY-MM-DD HH24:MI:SS.MS")).WHERE(["key", "=", cat_name]).payload()
+            .FORMAT("return", ("ts", "YYYY-MM-DD HH24:MI:SS.MS")).WHERE(["key", "=", cat_name]).LIMIT(1).payload()
         result = await self._storage.query_tbl_with_payload('configuration', payload)
-        return result['rows'] if result['rows'] else None
+        return result['rows'][0] if result['rows'] else None
 
     async def _read_all_groups(self, root, children):
         async def nested_children(child):
@@ -633,9 +633,9 @@ class ConfigurationManager(ConfigurationManagerSingleton):
             category = await self._read_category(category_name)  # await self._read_category_val(category_name)
             category_value = None
             if category is not None:
-                category_value = self._handle_script_type(category_name, category[0]["value"])
-                self._cacheManager.update(category_name, category[0]["description"], category_value,
-                                          category[0]["display_name"])
+                category_value = self._handle_script_type(category_name, category["value"])
+                self._cacheManager.update(category_name, category["description"], category_value,
+                                          category["display_name"])
             return category_value
         except:
             _logger.exception(
@@ -663,9 +663,9 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 if cat_item is not None:
                     category = await self._read_category(category_name)  # await self._read_category_val(category_name)
                     if category is not None:
-                        category_value = self._handle_script_type(category_name, category[0]["value"])
-                        self._cacheManager.update(category_name, category[0]["description"], category_value,
-                                                  category[0]["display_name"])
+                        category_value = self._handle_script_type(category_name, category["value"])
+                        self._cacheManager.update(category_name, category["description"], category_value,
+                                                  category["display_name"])
                         cat_item = category_value[item_name]
                 return cat_item
         except:

--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -369,7 +369,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
             .ALIAS("return", ("ts", 'timestamp')) \
             .FORMAT("return", ("ts", "YYYY-MM-DD HH24:MI:SS.MS")).WHERE(["key", "=", cat_name]).payload()
         result = await self._storage.query_tbl_with_payload('configuration', payload)
-        return result['rows']
+        return result['rows'] if result['rows'] else None
 
     async def _read_all_groups(self, root, children):
         async def nested_children(child):
@@ -631,8 +631,8 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 return category_value
 
             category = await self._read_category(category_name)  # await self._read_category_val(category_name)
-            category_value = []
-            if category:
+            category_value = None
+            if category is not None:
                 category_value = self._handle_script_type(category_name, category[0]["value"])
                 self._cacheManager.update(category_name, category[0]["description"], category_value,
                                           category[0]["display_name"])
@@ -662,7 +662,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 cat_item = await self._read_item_val(category_name, item_name)
                 if cat_item is not None:
                     category = await self._read_category(category_name)  # await self._read_category_val(category_name)
-                    if category:
+                    if category is not None:
                         category_value = self._handle_script_type(category_name, category[0]["value"])
                         self._cacheManager.update(category_name, category[0]["description"], category_value,
                                                   category[0]["display_name"])

--- a/tests/unit/python/foglamp/common/test_configuration_cache.py
+++ b/tests/unit/python/foglamp/common/test_configuration_cache.py
@@ -30,7 +30,8 @@ class TestConfigurationCache:
 
     def test_contains_with_cache(self):
         cached_manager = ConfigurationCache()
-        cached_manager.cache = {"test_cat": {'value': {'config_item': {'default': 'woo', 'description': 'foo', 'type': 'string'}}}}
+        cached_manager.cache = {"test_cat": {'value': {'config_item': {'default': 'woo', 'description': 'foo',
+                                                                       'type': 'string'}}}}
         assert cached_manager.__contains__("test_cat") is True
 
     def test_update(self):

--- a/tests/unit/python/foglamp/common/test_configuration_cache.py
+++ b/tests/unit/python/foglamp/common/test_configuration_cache.py
@@ -36,26 +36,36 @@ class TestConfigurationCache:
     def test_update(self):
         cached_manager = ConfigurationCache()
         cat_name = "test_cat"
+        cat_desc = "test_desc"
         cat_val = {'config_item': {'default': 'woo', 'description': 'foo', 'type': 'string'}}
+        cat_display_name = "AJ"
         cached_manager.cache = {cat_name: {'value': {}}}
-        cached_manager.update(cat_name, cat_val)
+        cached_manager.update(cat_name, cat_desc, cat_val)
         assert 'date_accessed' in cached_manager.cache[cat_name]
+        assert cat_desc == cached_manager.cache[cat_name]['description']
         assert cat_val == cached_manager.cache[cat_name]['value']
+        assert cat_name == cached_manager.cache[cat_name]['displayName']
+
+        cached_manager.update(cat_name, cat_desc, cat_val, cat_display_name)
+        assert 'date_accessed' in cached_manager.cache[cat_name]
+        assert cat_desc == cached_manager.cache[cat_name]['description']
+        assert cat_val == cached_manager.cache[cat_name]['value']
+        assert cat_display_name == cached_manager.cache[cat_name]['displayName']
 
     def test_remove_oldest(self):
         cached_manager = ConfigurationCache()
-        cached_manager.update("cat1", {'value': {}})
-        cached_manager.update("cat2", {'value': {}})
-        cached_manager.update("cat3", {'value': {}})
-        cached_manager.update("cat4", {'value': {}})
-        cached_manager.update("cat5", {'value': {}})
-        cached_manager.update("cat6", {'value': {}})
-        cached_manager.update("cat7", {'value': {}})
-        cached_manager.update("cat8", {'value': {}})
-        cached_manager.update("cat9", {'value': {}})
-        cached_manager.update("cat10", {'value': {}})
+        cached_manager.update("cat1", "desc1", {'value': {}})
+        cached_manager.update("cat2", "desc2", {'value': {}})
+        cached_manager.update("cat3", "desc3", {'value': {}})
+        cached_manager.update("cat4", "desc4", {'value': {}})
+        cached_manager.update("cat5", "desc5", {'value': {}})
+        cached_manager.update("cat6", "desc6", {'value': {}})
+        cached_manager.update("cat7", "desc7", {'value': {}})
+        cached_manager.update("cat8", "desc8", {'value': {}})
+        cached_manager.update("cat9", "desc9", {'value': {}})
+        cached_manager.update("cat10", "desc10", {'value': {}})
         assert 10 == cached_manager.size
-        cached_manager.update("cat11", {'value': {}})
+        cached_manager.update("cat11", "desc11", {'value': {}})
         assert 'cat1' not in cached_manager.cache
         assert 'cat2' in cached_manager.cache
         assert 'cat3' in cached_manager.cache
@@ -71,10 +81,10 @@ class TestConfigurationCache:
 
     def test_remove(self):
         cached_manager = ConfigurationCache()
-        cached_manager.update("cat1", {'value': {}})
-        cached_manager.update("cat2", {'value': {}})
-        cached_manager.update("cat3", {'value': {}})
-        cached_manager.update("cat4", {'value': {}})
+        cached_manager.update("cat1", "desc1", {'value': {}})
+        cached_manager.update("cat2", "desc2", {'value': {}})
+        cached_manager.update("cat3", "desc3", {'value': {}})
+        cached_manager.update("cat4", "desc4", {'value': {}})
         assert 4 == cached_manager.size
         cached_manager.remove("cat2")
         assert 3 == cached_manager.size

--- a/tests/unit/python/foglamp/common/test_configuration_manager.py
+++ b/tests/unit/python/foglamp/common/test_configuration_manager.py
@@ -21,6 +21,7 @@ __version__ = "${VERSION}"
 CAT_NAME = 'test'
 ITEM_NAME = "test_item_name"
 
+
 @pytest.allure.feature("unit")
 @pytest.allure.story("common", "configuration_manager")
 class TestConfigurationManager:
@@ -1561,34 +1562,34 @@ class TestConfigurationManager:
         attrs = {"query_tbl_with_payload.return_value": async_mock()}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
-        ret_val = await c_mgr._read_category("cat_name")
+        ret_val = await c_mgr._read_category(CAT_NAME)
         assert ret_val is None
         args, kwargs = storage_client_mock.query_tbl_with_payload.call_args
         assert 'configuration' == args[0]
         p = json.loads(args[1])
         assert {"return": ["key", "description", "value", "display_name",
                            {"column": "ts", "alias": "timestamp", "format": "YYYY-MM-DD HH24:MI:SS.MS"}],
-                "where": {"column": "key", "condition": "=", "value": "cat_name"}} == p
+                "where": {"column": "key", "condition": "=", "value": CAT_NAME}} == p
 
-    async def test__read_category_1_row(self, reset_singleton, cat_name="test"):
+    async def test__read_category_1_row(self, reset_singleton):
         async def async_mock():
             return {"rows": storage_result, "count": 1}
 
-        storage_result = [{'display_name': 'test', 'key': 'test', 'description': 'Test Des',
+        storage_result = [{'display_name': CAT_NAME, 'key': CAT_NAME, 'description': 'Test Des',
                            'value': {'config_item': {'default': 'blah', 'value': 'blah', 'description': 'Des',
                                                      'type': 'string'}}}]
 
         attrs = {"query_tbl_with_payload.return_value": async_mock()}
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
-        ret_val = await c_mgr._read_category(cat_name)
+        ret_val = await c_mgr._read_category(CAT_NAME)
         assert storage_result == ret_val
         args, kwargs = storage_client_mock.query_tbl_with_payload.call_args
         assert 'configuration' == args[0]
         p = json.loads(args[1])
         assert {"return": ["key", "description", "value", "display_name",
                            {"column": "ts", "alias": "timestamp", "format": "YYYY-MM-DD HH24:MI:SS.MS"}],
-                "where": {"column": "key", "condition": "=", "value": cat_name}} == p
+                "where": {"column": "key", "condition": "=", "value": CAT_NAME}} == p
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("value, expected_result", [
@@ -2057,9 +2058,9 @@ class TestConfigurationManager:
                 ret_val = await c_mgr.delete_child_category(cat_name, child_name)
                 assert [child_name] == ret_val
             patch_read_all_child.assert_called_once_with(cat_name)
-        args, kwargs = storage_client_mock.delete_from_tbl.call_args
-        assert 'category_children' == args[0]
-        assert payload == json.loads(args[1])
+        del_args, del_kwargs = storage_client_mock.delete_from_tbl.call_args
+        assert 'category_children' == del_args[0]
+        assert payload == json.loads(del_args[1])
 
     async def test_delete_child_category_key_error(self, reset_singleton):
         @asyncio.coroutine
@@ -2642,8 +2643,9 @@ class TestConfigurationManager:
         async def async_mock(return_value):
             return return_value
 
-        cat_info = {'providers': {'default': '{"providers": ["username", "ldap"] }', 'description': 'descr', 'type': 'JSON', 'value':'{"providers": ["username", "ldap"] }' }}
-        config_item_list = {"providers": {"providers": ["username", "ldap"] }}
+        cat_info = {'providers': {'default': '{"providers": ["username", "ldap"] }', 'description': 'descr',
+                                  'type': 'JSON', 'value': '{"providers": ["username", "ldap"] }'}}
+        config_item_list = {"providers": {"providers": ["username", "ldap"]}}
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock(cat_info)) as patch_get_all_items:
@@ -2661,8 +2663,9 @@ class TestConfigurationManager:
         async def async_mock(return_value):
             return return_value
 
-        cat_info = {'providers': {'default': '{"providers": ["username", "ldap"] }', 'description': 'descr', 'type': 'JSON', 'value':'{"providers": ["username", "ldap"] }' }}
-        config_item_list = {"providers": {"providers": ["username", "ldap_new"] }}
+        cat_info = {'providers': {'default': '{"providers": ["username", "ldap"] }', 'description': 'descr',
+                                  'type': 'JSON', 'value': '{"providers": ["username", "ldap"] }'}}
+        config_item_list = {"providers": {"providers": ["username", "ldap_new"]}}
 
         update_result = {"response": "updated", "rows_affected": 1}
         read_val = {'allowPing': {'default': 'true', 'description': 'Allow access to ping', 'value': 'true', 'type': 'boolean'},
@@ -2755,18 +2758,21 @@ class TestConfigurationManager:
         async def async_mock(return_value):
             return return_value
 
-        min = '2'
-        max = '20'
+        minimum = '2'
+        maximum = '20'
         if _type is not None:
             if isinstance(1.1, _type):
-                min = '12.5'
-                max = '40.3'
+                minimum = '12.5'
+                maximum = '40.3'
 
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         category_name = 'catname'
         item_name = 'itemname'
-        storage_value_entry = {'length': '255', 'displayName': category_name, 'rule': 'value * 3 == 6', 'deprecated': 'false', 'readonly': 'true', 'type': 'string', 'order': '4', 'description': 'Test Optional', 'minimum': min, 'value': '13', 'maximum': max, 'default': '13', 'validity': 'field X is set', 'mandatory': 'false'}
+        storage_value_entry = {'length': '255', 'displayName': category_name, 'rule': 'value * 3 == 6',
+                               'deprecated': 'false', 'readonly': 'true', 'type': 'string', 'order': '4',
+                               'description': 'Test Optional', 'minimum': minimum, 'value': '13', 'maximum': maximum,
+                               'default': '13', 'validity': 'field X is set', 'mandatory': 'false'}
         with patch.object(_logger, "exception") as log_exc:
             with patch.object(ConfigurationManager, '_read_item_val', return_value=async_mock(storage_value_entry)) as readpatch:
                 with pytest.raises(Exception) as excinfo:

--- a/tests/unit/python/foglamp/common/test_configuration_manager.py
+++ b/tests/unit/python/foglamp/common/test_configuration_manager.py
@@ -1342,7 +1342,7 @@ class TestConfigurationManager:
 
         category_name = 'catname'
         cat_value = {"config_item": {"type": "string", "default": "blah", "description": "Des", "value": "blah"}}
-        cat_info = [{'display_name': category_name, 'key': category_name, 'description': 'Test Des', "value": cat_value}]
+        cat_info = {'display_name': category_name, 'key': category_name, 'description': 'Test Des', "value": cat_value}
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with patch.object(ConfigurationManager, '_read_category', return_value=async_mock(cat_info)) as readpatch:
@@ -1569,7 +1569,7 @@ class TestConfigurationManager:
         p = json.loads(args[1])
         assert {"return": ["key", "description", "value", "display_name",
                            {"column": "ts", "alias": "timestamp", "format": "YYYY-MM-DD HH24:MI:SS.MS"}],
-                "where": {"column": "key", "condition": "=", "value": CAT_NAME}} == p
+                "where": {"column": "key", "condition": "=", "value": CAT_NAME}, "limit": 1} == p
 
     async def test__read_category_1_row(self, reset_singleton):
         async def async_mock():
@@ -1583,13 +1583,13 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
         ret_val = await c_mgr._read_category(CAT_NAME)
-        assert storage_result == ret_val
+        assert storage_result[0] == ret_val
         args, kwargs = storage_client_mock.query_tbl_with_payload.call_args
         assert 'configuration' == args[0]
         p = json.loads(args[1])
         assert {"return": ["key", "description", "value", "display_name",
                            {"column": "ts", "alias": "timestamp", "format": "YYYY-MM-DD HH24:MI:SS.MS"}],
-                "where": {"column": "key", "condition": "=", "value": CAT_NAME}} == p
+                "where": {"column": "key", "condition": "=", "value": CAT_NAME},  "limit": 1} == p
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("value, expected_result", [

--- a/tests/unit/python/foglamp/common/test_configuration_manager.py
+++ b/tests/unit/python/foglamp/common/test_configuration_manager.py
@@ -1562,7 +1562,7 @@ class TestConfigurationManager:
         storage_client_mock = MagicMock(spec=StorageClientAsync, **attrs)
         c_mgr = ConfigurationManager(storage_client_mock)
         ret_val = await c_mgr._read_category("cat_name")
-        assert [] == ret_val
+        assert ret_val is None
         args, kwargs = storage_client_mock.query_tbl_with_payload.call_args
         assert 'configuration' == args[0]
         p = json.loads(args[1])

--- a/tests/unit/python/foglamp/services/core/api/test_configuration.py
+++ b/tests/unit/python/foglamp/services/core/api/test_configuration.py
@@ -465,7 +465,7 @@ class TestConfiguration:
         else:
             payload.update({'displayName': payload['key']})
 
-        c_mgr._cacheManager.update(payload['key'], new_info, payload['displayName'])
+        c_mgr._cacheManager.update(payload['key'], payload['description'], new_info, payload['displayName'])
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'create_category', return_value=async_mock(None)) as patch_create_cat:
                 with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock(new_info)) as patch_cat_all_item:
@@ -718,7 +718,7 @@ class TestConfiguration:
 
         storage_client_mock = MagicMock(StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
-        c_mgr._cacheManager.update(name, info, name)
+        c_mgr._cacheManager.update(name, desc, info, name)
         with patch.object(connect, 'get_storage_async', return_value=storage_client_mock):
             with patch.object(c_mgr, 'create_category', return_value=async_mock_create_cat()) as patch_create_cat:
                 with patch.object(c_mgr, 'get_category_all_items', return_value=async_mock()) as patch_cat_all_item:


### PR DESCRIPTION
Custom Job ran over [ub1804_with_poatgres](http://jenkins.dianomic.com:8080/view/custom%20jobs/job/foglamp_postgres_ub1804/70/) and don't see any regression with an existing unit & system tests. 4 tests are failing which is expected and due to FOGL-3125 with Postgres engine Only.