### PR TITLE
FOGL-3455 support bundle psinfo fixes

### DIFF
--- a/python/foglamp/services/core/support.py
+++ b/python/foglamp/services/core/support.py
@@ -175,11 +175,16 @@ class SupportBuilder:
     def add_psinfo(self, pyz, file_spec):
         # A PS listing of al the python applications running on the machine
         temp_file = self._interim_file_path + "/" + "psinfo-{}".format(file_spec)
-        a = subprocess.Popen(
-            'ps -eaf | grep python3', shell=True, stdout=subprocess.PIPE).stdout.readlines()[:-2]  # remove ps command
+        a = subprocess.Popen('ps -eaf | grep "foglamp\."', shell=True,
+                             stdout=subprocess.PIPE).stdout.readlines()
         c = [b.decode() for b in a]  # Since "a" contains return value in bytes, convert it to string
+
+        c_tasks = subprocess.Popen('ps -eaf | grep "./tasks/sending_process"', shell=True, stdout=subprocess.PIPE).stdout.readlines()
+        c_tasks_decode = [t.decode() for t in c_tasks]
+        if c_tasks_decode:
+            c.extend(c_tasks_decode)
         data = {
-            "runningPythonProcesses": c
+            "runningProcesses": c
         }
         self.write_to_tar(pyz, temp_file, data)
 

--- a/python/foglamp/services/core/support.py
+++ b/python/foglamp/services/core/support.py
@@ -184,8 +184,10 @@ class SupportBuilder:
         c_tasks_decode = [t.decode() for t in c_tasks]
         if c_tasks_decode:
             c.extend(c_tasks_decode)
+        # Remove "/n" from the c list output
+        d = list(map(lambda x: x.strip(), c))
         data = {
-            "runningProcesses": c
+            "runningProcesses": d
         }
         self.write_to_tar(pyz, temp_file, data)
 

--- a/python/foglamp/services/core/support.py
+++ b/python/foglamp/services/core/support.py
@@ -185,9 +185,8 @@ class SupportBuilder:
         if c_tasks_decode:
             c.extend(c_tasks_decode)
         # Remove "/n" from the c list output
-        d = list(map(lambda x: x.strip(), c))
         data = {
-            "runningProcesses": d
+            "runningProcesses": list(map(str.strip, c))
         }
         self.write_to_tar(pyz, temp_file, data)
 

--- a/python/foglamp/services/core/support.py
+++ b/python/foglamp/services/core/support.py
@@ -175,11 +175,12 @@ class SupportBuilder:
     def add_psinfo(self, pyz, file_spec):
         # A PS listing of al the python applications running on the machine
         temp_file = self._interim_file_path + "/" + "psinfo-{}".format(file_spec)
-        a = subprocess.Popen('ps -eaf | grep "foglamp\."', shell=True,
+        a = subprocess.Popen('ps -aufx | egrep "(%MEM|foglamp\.)" | grep -v grep', shell=True,
                              stdout=subprocess.PIPE).stdout.readlines()
         c = [b.decode() for b in a]  # Since "a" contains return value in bytes, convert it to string
 
-        c_tasks = subprocess.Popen('ps -eaf | grep "./tasks/sending_process"', shell=True, stdout=subprocess.PIPE).stdout.readlines()
+        c_tasks = subprocess.Popen('ps -aufx | grep "./tasks" | grep -v grep', shell=True,
+                                   stdout=subprocess.PIPE).stdout.readlines()
         c_tasks_decode = [t.decode() for t in c_tasks]
         if c_tasks_decode:
             c.extend(c_tasks_decode)

--- a/scripts/foglamp
+++ b/scripts/foglamp
@@ -483,7 +483,6 @@ foglamp_status() {
                 ps -ef | grep "foglamp.services.storage" | grep -v 'grep' | grep -v awk | awk '{print "foglamp.services.storage " $9 " " $10}' || true
                 ps -ef | grep "foglamp.services.south" |grep python3| grep -v 'grep' | awk '{print "foglamp.services.south " $11 " " $12 " " $13}' || true
                 ps -ef | grep "foglamp.services.south" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{print "foglamp.services.south " $9 " " $10 " " $11}' || true
-                ps -ef | grep "foglamp.services.north" | grep -v 'grep' | grep -v awk | awk '{print "foglamp.services.north " $9 " " $10}' || true
                 ps -ef | grep "foglamp.services.notification" |grep -v python3| grep -v 'grep' | grep -v awk | awk '{print "foglamp.services.notification " $9 " " $10 " " $11}' || true
 
                 # Show Tasks


### PR DESCRIPTION
**O/P**
```
{
    "runningProcesses": [
        "USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND",
        "foglamp  25502  7.5  0.6 2286524 48528 pts/20  Sl   13:17   0:03          \\_ python3 -m foglamp.services.core",
        "foglamp  25756 20.8  1.1 1417924 87844 pts/20  Sl   13:18   0:01          |   |   \\_ python3 -m foglamp.tasks.north.sending_process --port=42461 --address=127.0.0.1 --name=PI",
        "foglamp  25758  8.7  0.4 1583072 31348 pts/20  Sl   13:18   0:00          |   |   \\_ python3 -m foglamp.tasks.north.sending_process --port=42461 --address=127.0.0.1 --name=HT",
        "foglamp  25510  2.4  0.2 416036 22856 ?        Ssl  13:17   0:01          \\_ /home/foglamp/Development/FogLAMP/services/foglamp.services.storage --address=0.0.0.0 --port=42461",
        "foglamp  25578  0.4  0.2 518352 19712 ?        Ssl  13:18   0:00          \\_ ./foglamp.services.south --port=42461 --address=127.0.0.1 --name=RW",
        "foglamp  25582  0.0  0.0 259256  6580 ?        Ssl  13:18   0:00          \\_ ./foglamp.services.notification --port=42461 --address=127.0.0.1 --name=FogLAMP Notifications",
        "foglamp  25586  0.0  0.0 475972  6064 ?        Ssl  13:18   0:00          \\_ ./foglamp.services.south --port=42461 --address=127.0.0.1 --name=bench2",
        "foglamp  25589  0.0  0.0 480236  6148 ?        Ssl  13:18   0:00          \\_ ./foglamp.services.south --port=42461 --address=127.0.0.1 --name=Bench",
        "foglamp  25753  1.7  0.1 560372 14720 pts/20   Sl   13:18   0:00          |   |   \\_ ./tasks/sending_process --port=42461 --address=127.0.0.1 --name=NorthReadingsToPI"
    ]
}
```