### PR TITLE
FOGL-3387 Handling added on PUT configuration item as per optional attribute value

### DIFF
--- a/C/common/config_category.cpp
+++ b/C/common/config_category.cpp
@@ -570,6 +570,25 @@ string ConfigCategory::getDisplayName(const string& name) const
 }
 
 /**
+ * Return the length value of the configuration category item
+ *
+ * @param name	The name of the configuration item to return
+ * @return string	The configuration item name
+ * @throws exception if the item does not exist in the category
+ */
+string ConfigCategory::getLength(const string& name) const
+{
+	for (unsigned int i = 0; i < m_items.size(); i++)
+	{
+		if (name.compare(m_items[i]->m_name) == 0)
+		{
+			return m_items[i]->m_length;
+		}
+	}
+	throw new ConfigItemNotFound();
+}
+
+/**
  * Return the minimum value of the configuration category item
  *
  * @param name	The name of the configuration item to return
@@ -857,6 +876,14 @@ ConfigCategory::CategoryItem::CategoryItem(const string& name,
 		m_order = "";
 	}
 
+    if (item.HasMember("length"))
+	{
+		m_length = item["length"].GetString();
+	}
+	else
+	{
+		m_length = "";
+	}
 
 	if (item.HasMember("minimum"))
 	{
@@ -1203,6 +1230,7 @@ ConfigCategory::CategoryItem::CategoryItem(const CategoryItem& rhs)
        	m_readonly = rhs.m_readonly;
        	m_mandatory = rhs.m_mandatory;
        	m_deprecated = rhs.m_deprecated;
+       	m_length = rhs.m_length;
        	m_minimum = rhs.m_minimum;
        	m_maximum = rhs.m_maximum;
        	m_filename = rhs.m_filename;
@@ -1267,6 +1295,11 @@ ostringstream convert;
 			convert << ", \"order\" : \"" << m_order << "\"";
 		}
 
+        if (!m_length.empty())
+		{
+			convert << ", \"length\" : \"" << m_length << "\"";
+		}
+
 		if (!m_minimum.empty())
 		{
 			convert << ", \"minimum\" : \"" << m_minimum << "\"";
@@ -1327,6 +1360,11 @@ ostringstream convert;
 	if (!m_displayName.empty())
 	{
 		convert << ", \"displayName\" : \"" << m_displayName << "\"";
+	}
+
+    if (!m_length.empty())
+	{
+		convert << ", \"length\" : \"" << m_length << "\"";
 	}
 
 	if (!m_minimum.empty())

--- a/C/common/include/config_category.h
+++ b/C/common/include/config_category.h
@@ -94,6 +94,7 @@ class ConfigCategory {
 		bool				setDefault(const std::string& name, const std::string& value);
 		std::string			getDisplayName(const std::string& name) const;
 		std::vector<std::string>	getOptions(const std::string& name) const;
+		std::string			getLength(const std::string& name) const;
 		std::string			getMinimum(const std::string& name) const;
 		std::string			getMaximum(const std::string& name) const;
 		bool				isString(const std::string& name) const;
@@ -145,6 +146,7 @@ class ConfigCategory {
 				std::string 	m_readonly;
 				std::string 	m_mandatory;
 				std::string 	m_deprecated;
+				std::string	m_length;
 				std::string	m_minimum;
 				std::string	m_maximum;
 				std::string 	m_filename;

--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -516,7 +516,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 old_value = cat_info[item_name]['value']
                 new_val = self._clean(cat_info[item_name]['type'], new_val)
                 # Validations on the basis of optional attributes
-                self._val_validation_as_per_optional_attribute(cat_info[item_name], new_val)
+                self.validate_value_per_optional_attribute(cat_info[item_name], new_val)
 
                 old_value_for_check = old_value
                 new_val_for_check = new_val
@@ -751,7 +751,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 if eval(rule) is False:
                     raise ValueError('The value of {} is not valid, please supply a valid value'.format(item_name))
             # Validations on the basis of optional attributes
-            self._val_validation_as_per_optional_attribute(storage_value_entry, new_value_entry)
+            self.validate_value_per_optional_attribute(storage_value_entry, new_value_entry)
 
             await self._update_value_val(category_name, item_name, new_value_entry)
             # always get value from storage
@@ -1409,7 +1409,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                         cat_value[k]["file"] = latest_file
         return cat_value
 
-    def _val_validation_as_per_optional_attribute(self, storage_value_entry, new_value_entry):
+    def validate_value_per_optional_attribute(self, storage_value_entry, new_value_entry):
         # FIXME: Logically below exception throw as ValueError; TypeError used ONLY to get right HTTP status code returned from API endpoint.
         # As we used same defs for optional attribute value & config item value save
         def in_range(n, start, end):
@@ -1419,7 +1419,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
         if config_item_type == 'string':
             if 'length' in storage_value_entry:
                 if len(new_value_entry) > int(storage_value_entry['length']):
-                    raise TypeError('You cannot set the new value, beyond a certain length {}'.format(
+                    raise TypeError('You cannot set the new value, beyond the length {}'.format(
                         storage_value_entry['length']))
 
         if config_item_type == 'integer' or config_item_type == 'float':
@@ -1434,7 +1434,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                     _max_value = float(storage_value_entry['maximum'])
 
                 if not in_range(_new_value, _min_value, _max_value):
-                    raise TypeError('You cannot set the new value, value should be in range ({},{})'.format(
+                    raise TypeError('You cannot set the new value, beyond the range ({},{})'.format(
                         storage_value_entry['minimum'], storage_value_entry['maximum']))
             elif 'minimum' in storage_value_entry:
                 if config_item_type == 'integer':
@@ -1444,7 +1444,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                     _new_value = float(new_value_entry)
                     _min_value = float(storage_value_entry['minimum'])
                 if _new_value < _min_value:
-                    raise TypeError('You cannot set the new value, beyonds the minimum limit {}'.format(_min_value))
+                    raise TypeError('You cannot set the new value, below {}'.format(_min_value))
             elif 'maximum' in storage_value_entry:
                 if config_item_type == 'integer':
                     _new_value = int(new_value_entry)
@@ -1453,4 +1453,4 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                     _new_value = float(new_value_entry)
                     _max_value = float(storage_value_entry['maximum'])
                 if _new_value > _max_value:
-                    raise TypeError('You cannot set the new value, exceeds the maximum limit {}'.format(_max_value))
+                    raise TypeError('You cannot set the new value, above {}'.format(_max_value))

--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -750,6 +750,17 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 rule = storage_value_entry['rule'].replace("value", new_value_entry)
                 if eval(rule) is False:
                     raise ValueError('The value of {} is not valid, please supply a valid value'.format(item_name))
+            if 'minimum' in storage_value_entry and 'maximum' in storage_value_entry:
+                if int(new_value_entry) not in range(int(storage_value_entry['minimum']),
+                                                     int(storage_value_entry['maximum']) + 1):  # Python range doesn't include upper range value
+                    raise ValueError('You cannot set the new value, value should be in range ({},{})'.format(
+                        storage_value_entry['minimum'], storage_value_entry['maximum']))
+            elif 'minimum' in storage_value_entry:
+                if int(new_value_entry) < int(storage_value_entry['minimum']):
+                    raise ValueError('You cannot set the new value as it beyonds the minimum limit')
+            elif 'maximum' in storage_value_entry:
+                if int(new_value_entry) > int(storage_value_entry['maximum']):
+                    raise ValueError('You cannot set the new value as it exceeds the maximum limit')
             await self._update_value_val(category_name, item_name, new_value_entry)
             # always get value from storage
             cat_item = await self._read_item_val(category_name, item_name)

--- a/python/foglamp/common/configuration_manager.py
+++ b/python/foglamp/common/configuration_manager.py
@@ -516,7 +516,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 old_value = cat_info[item_name]['value']
                 new_val = self._clean(cat_info[item_name]['type'], new_val)
                 # Validations on the basis of optional attributes
-                self.validate_value_per_optional_attribute(cat_info[item_name], new_val)
+                self._validate_value_per_optional_attribute(item_name, cat_info[item_name], new_val)
 
                 old_value_for_check = old_value
                 new_val_for_check = new_val
@@ -751,7 +751,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                 if eval(rule) is False:
                     raise ValueError('The value of {} is not valid, please supply a valid value'.format(item_name))
             # Validations on the basis of optional attributes
-            self.validate_value_per_optional_attribute(storage_value_entry, new_value_entry)
+            self._validate_value_per_optional_attribute(item_name, storage_value_entry, new_value_entry)
 
             await self._update_value_val(category_name, item_name, new_value_entry)
             # always get value from storage
@@ -1409,7 +1409,7 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                         cat_value[k]["file"] = latest_file
         return cat_value
 
-    def validate_value_per_optional_attribute(self, storage_value_entry, new_value_entry):
+    def _validate_value_per_optional_attribute(self, item_name, storage_value_entry, new_value_entry):
         # FIXME: Logically below exception throw as ValueError; TypeError used ONLY to get right HTTP status code returned from API endpoint.
         # As we used same defs for optional attribute value & config item value save
         def in_range(n, start, end):
@@ -1419,8 +1419,8 @@ class ConfigurationManager(ConfigurationManagerSingleton):
         if config_item_type == 'string':
             if 'length' in storage_value_entry:
                 if len(new_value_entry) > int(storage_value_entry['length']):
-                    raise TypeError('You cannot set the new value, beyond the length {}'.format(
-                        storage_value_entry['length']))
+                    raise TypeError('For config item {} you cannot set the new value, beyond the length {}'.format(
+                        item_name, storage_value_entry['length']))
 
         if config_item_type == 'integer' or config_item_type == 'float':
             if 'minimum' in storage_value_entry and 'maximum' in storage_value_entry:
@@ -1434,8 +1434,8 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                     _max_value = float(storage_value_entry['maximum'])
 
                 if not in_range(_new_value, _min_value, _max_value):
-                    raise TypeError('You cannot set the new value, beyond the range ({},{})'.format(
-                        storage_value_entry['minimum'], storage_value_entry['maximum']))
+                    raise TypeError('For config item {} you cannot set the new value, beyond the range ({},{})'.format(
+                        item_name, storage_value_entry['minimum'], storage_value_entry['maximum']))
             elif 'minimum' in storage_value_entry:
                 if config_item_type == 'integer':
                     _new_value = int(new_value_entry)
@@ -1444,7 +1444,8 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                     _new_value = float(new_value_entry)
                     _min_value = float(storage_value_entry['minimum'])
                 if _new_value < _min_value:
-                    raise TypeError('You cannot set the new value, below {}'.format(_min_value))
+                    raise TypeError('For config item {} you cannot set the new value, below {}'.format(item_name,
+                                                                                                       _min_value))
             elif 'maximum' in storage_value_entry:
                 if config_item_type == 'integer':
                     _new_value = int(new_value_entry)
@@ -1453,4 +1454,5 @@ class ConfigurationManager(ConfigurationManagerSingleton):
                     _new_value = float(new_value_entry)
                     _max_value = float(storage_value_entry['maximum'])
                 if _new_value > _max_value:
-                    raise TypeError('You cannot set the new value, above {}'.format(_max_value))
+                    raise TypeError('For config item {} you cannot set the new value, above {}'.format(item_name,
+                                                                                                       _max_value))

--- a/python/foglamp/services/core/api/configuration.py
+++ b/python/foglamp/services/core/api/configuration.py
@@ -263,6 +263,9 @@ async def set_configuration_item(request):
                 is_core_mgt = request.is_core_mgt
             except AttributeError:
                 storage_value_entry = await cf_mgr.get_category_item(category_name, config_item)
+                if storage_value_entry is None:
+                    raise ValueError("No detail found for the category_name: {} and item_name: {}"
+                               .format(category_name, config_item))
                 if 'readonly' in storage_value_entry:
                     if storage_value_entry['readonly'] == 'true':
                         raise TypeError("Update not allowed for {} item_name as it has readonly attribute set".format(config_item))

--- a/tests/unit/python/foglamp/common/test_configuration_manager.py
+++ b/tests/unit/python/foglamp/common/test_configuration_manager.py
@@ -2785,30 +2785,30 @@ class TestConfigurationManager:
 
     @pytest.mark.parametrize("new_value_entry, storage_value_entry, exc_msg", [
         ("FogLAMP", {'default': 'FOG', 'length': '3', 'displayName': 'Length Test', 'value': 'fog', 'type': 'string',
-                     'description': 'Test value '}, 'beyond a certain length 3'),
+                     'description': 'Test value '}, 'beyond the length 3'),
         ("0", {'order': '4', 'default': '10', 'minimum': '10', 'maximum': '19', 'displayName': 'RangeMin Test',
-               'value': '15', 'type': 'integer', 'description': 'Test value'}, 'value should be in range (10,19)'),
+               'value': '15', 'type': 'integer', 'description': 'Test value'}, 'beyond the range (10,19)'),
         ("20", {'order': '4', 'default': '10', 'minimum': '10', 'maximum': '19', 'displayName': 'RangeMax Test',
-                'value': '19', 'type': 'integer', 'description': 'Test value'}, 'value should be in range (10,19)'),
+                'value': '19', 'type': 'integer', 'description': 'Test value'}, 'beyond the range (10,19)'),
         ("1", {'order': '5', 'default': '2', 'minimum': '2', 'displayName': 'MIN', 'value': '10', 'type': 'integer',
-               'description': 'Test value '}, 'beyonds the minimum limit 2'),
+               'description': 'Test value '}, 'below 2'),
         ("11", {'default': '10', 'maximum': '10', 'displayName': 'MAX', 'value': '10', 'type': 'integer',
-                'description': 'Test value'}, 'exceeds the maximum limit 10'),
+                'description': 'Test value'}, 'above 10'),
         ("19.0", {'default': '19.3', 'minimum': '19.1', 'maximum': '19.5', 'displayName': 'RangeMin Test',
-                  'value': '19.1', 'type': 'float', 'description': 'Test val'}, 'value should be in range (19.1,19.5)'),
+                  'value': '19.1', 'type': 'float', 'description': 'Test val'}, 'beyond the range (19.1,19.5)'),
         ("19.6", {'default': '19.4', 'minimum': '19.1', 'maximum': '19.5', 'displayName': 'RangeMax Test',
-                  'value': '19.5', 'type': 'float', 'description': 'Test val'}, 'value should be in range (19.1,19.5)'),
+                  'value': '19.5', 'type': 'float', 'description': 'Test val'}, 'beyond the range (19.1,19.5)'),
         ("20", {'order': '8', 'default': '10.1', 'maximum': '19.8', 'displayName': 'MAX Test', 'value': '10.1',
-                'type': 'float', 'description': 'Test value'}, 'exceeds the maximum limit 19.8'),
+                'type': 'float', 'description': 'Test value'}, 'above 19.8'),
         ("0.7", {'order': '9', 'default': '0.9', 'minimum': '0.8', 'displayName': 'MIN Test', 'value': '0.9',
-                 'type': 'float', 'description': 'Test value'}, 'beyonds the minimum limit 0.8')
+                 'type': 'float', 'description': 'Test value'}, 'below 0.8')
     ])
-    def test_bad__val_validation_as_per_optional_attribute(self, new_value_entry, storage_value_entry, exc_msg):
+    def test_bad__validate_value_per_optional_attribute(self, new_value_entry, storage_value_entry, exc_msg):
         message = "You cannot set the new value, {}".format(exc_msg)
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with pytest.raises(Exception) as excinfo:
-            c_mgr._val_validation_as_per_optional_attribute(storage_value_entry, new_value_entry)
+            c_mgr.validate_value_per_optional_attribute(storage_value_entry, new_value_entry)
         assert excinfo.type is TypeError
         assert message == str(excinfo.value)
 
@@ -2830,12 +2830,12 @@ class TestConfigurationManager:
         ("15", {'order': '4', 'default': '10', 'minimum': '10', 'maximum': '19', 'displayName': 'Range Test',
                 'value': '15', 'type': 'integer', 'description': 'Test value'})
     ])
-    def test_good__val_validation_as_per_optional_attribute(self, new_value_entry, storage_value_entry):
+    def test_good__validate_value_per_optional_attribute(self, new_value_entry, storage_value_entry):
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         raised = False
         try:
-            c_mgr._val_validation_as_per_optional_attribute(storage_value_entry, new_value_entry)
+            c_mgr.validate_value_per_optional_attribute(storage_value_entry, new_value_entry)
         except Exception:
             raised = True
         assert raised is False

--- a/tests/unit/python/foglamp/common/test_configuration_manager.py
+++ b/tests/unit/python/foglamp/common/test_configuration_manager.py
@@ -2782,3 +2782,60 @@ class TestConfigurationManager:
             readpatch.assert_called_once_with(category_name, item_name)
         assert 1 == log_exc.call_count
         log_exc.assert_called_once_with('Unable to set optional %s entry based on category_name %s and item_name %s and value_item_entry %s', optional_key_name, 'catname', 'itemname', new_value_entry)
+
+    @pytest.mark.parametrize("new_value_entry, storage_value_entry, exc_msg", [
+        ("FogLAMP", {'default': 'FOG', 'length': '3', 'displayName': 'Length Test', 'value': 'fog', 'type': 'string',
+                     'description': 'Test value '}, 'beyond a certain length 3'),
+        ("0", {'order': '4', 'default': '10', 'minimum': '10', 'maximum': '19', 'displayName': 'RangeMin Test',
+               'value': '15', 'type': 'integer', 'description': 'Test value'}, 'value should be in range (10,19)'),
+        ("20", {'order': '4', 'default': '10', 'minimum': '10', 'maximum': '19', 'displayName': 'RangeMax Test',
+                'value': '19', 'type': 'integer', 'description': 'Test value'}, 'value should be in range (10,19)'),
+        ("1", {'order': '5', 'default': '2', 'minimum': '2', 'displayName': 'MIN', 'value': '10', 'type': 'integer',
+               'description': 'Test value '}, 'beyonds the minimum limit 2'),
+        ("11", {'default': '10', 'maximum': '10', 'displayName': 'MAX', 'value': '10', 'type': 'integer',
+                'description': 'Test value'}, 'exceeds the maximum limit 10'),
+        ("19.0", {'default': '19.3', 'minimum': '19.1', 'maximum': '19.5', 'displayName': 'RangeMin Test',
+                  'value': '19.1', 'type': 'float', 'description': 'Test val'}, 'value should be in range (19.1,19.5)'),
+        ("19.6", {'default': '19.4', 'minimum': '19.1', 'maximum': '19.5', 'displayName': 'RangeMax Test',
+                  'value': '19.5', 'type': 'float', 'description': 'Test val'}, 'value should be in range (19.1,19.5)'),
+        ("20", {'order': '8', 'default': '10.1', 'maximum': '19.8', 'displayName': 'MAX Test', 'value': '10.1',
+                'type': 'float', 'description': 'Test value'}, 'exceeds the maximum limit 19.8'),
+        ("0.7", {'order': '9', 'default': '0.9', 'minimum': '0.8', 'displayName': 'MIN Test', 'value': '0.9',
+                 'type': 'float', 'description': 'Test value'}, 'beyonds the minimum limit 0.8')
+    ])
+    def test_bad__val_validation_as_per_optional_attribute(self, new_value_entry, storage_value_entry, exc_msg):
+        message = "You cannot set the new value, {}".format(exc_msg)
+        storage_client_mock = MagicMock(spec=StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        with pytest.raises(Exception) as excinfo:
+            c_mgr._val_validation_as_per_optional_attribute(storage_value_entry, new_value_entry)
+        assert excinfo.type is TypeError
+        assert message == str(excinfo.value)
+
+    @pytest.mark.parametrize("new_value_entry, storage_value_entry", [
+        ("FogLAMP", {'default': 'FOG', 'length': '7', 'displayName': 'Length Test', 'value': 'foglamp',
+                     'type': 'string', 'description': 'Test value '}),
+        ("2", {'order': '5', 'default': '10', 'minimum': '2', 'displayName': 'MIN', 'value': '10', 'type': 'integer',
+               'description': 'Test value '}),
+        ("19.1", {'default': '19.4', 'minimum': '19.1', 'maximum': '19.5', 'displayName': 'RangeMin Test',
+                  'value': '19.5', 'type': 'float', 'description': 'Test val'}),
+        ("19.5", {'default': '19.4', 'minimum': '19.1', 'maximum': '19.5', 'displayName': 'RangeMax Test',
+                  'value': '19.5', 'type': 'float', 'description': 'Test val'}),
+        ("19.2", {'default': '19.4', 'minimum': '19.1', 'maximum': '19.5', 'displayName': 'Range Test',
+                  'value': '19.5', 'type': 'float', 'description': 'Test val'}),
+        ("10", {'order': '4', 'default': '10', 'minimum': '10', 'maximum': '19', 'displayName': 'RangeMin Test',
+              'value': '15', 'type': 'integer', 'description': 'Test value'}),
+        ("19", {'order': '4', 'default': '10', 'minimum': '10', 'maximum': '19', 'displayName': 'RangeMax Test',
+                'value': '15', 'type': 'integer', 'description': 'Test value'}),
+        ("15", {'order': '4', 'default': '10', 'minimum': '10', 'maximum': '19', 'displayName': 'Range Test',
+                'value': '15', 'type': 'integer', 'description': 'Test value'})
+    ])
+    def test_good__val_validation_as_per_optional_attribute(self, new_value_entry, storage_value_entry):
+        storage_client_mock = MagicMock(spec=StorageClientAsync)
+        c_mgr = ConfigurationManager(storage_client_mock)
+        raised = False
+        try:
+            c_mgr._val_validation_as_per_optional_attribute(storage_value_entry, new_value_entry)
+        except Exception:
+            raised = True
+        assert raised is False

--- a/tests/unit/python/foglamp/common/test_configuration_manager.py
+++ b/tests/unit/python/foglamp/common/test_configuration_manager.py
@@ -2804,11 +2804,11 @@ class TestConfigurationManager:
                  'type': 'float', 'description': 'Test value'}, 'below 0.8')
     ])
     def test_bad__validate_value_per_optional_attribute(self, new_value_entry, storage_value_entry, exc_msg):
-        message = "You cannot set the new value, {}".format(exc_msg)
+        message = "For config item {} you cannot set the new value, {}".format(ITEM_NAME, exc_msg)
         storage_client_mock = MagicMock(spec=StorageClientAsync)
         c_mgr = ConfigurationManager(storage_client_mock)
         with pytest.raises(Exception) as excinfo:
-            c_mgr.validate_value_per_optional_attribute(storage_value_entry, new_value_entry)
+            c_mgr._validate_value_per_optional_attribute(ITEM_NAME, storage_value_entry, new_value_entry)
         assert excinfo.type is TypeError
         assert message == str(excinfo.value)
 
@@ -2835,7 +2835,7 @@ class TestConfigurationManager:
         c_mgr = ConfigurationManager(storage_client_mock)
         raised = False
         try:
-            c_mgr.validate_value_per_optional_attribute(storage_value_entry, new_value_entry)
+            c_mgr._validate_value_per_optional_attribute(ITEM_NAME, storage_value_entry, new_value_entry)
         except Exception:
             raised = True
         assert raised is False


### PR DESCRIPTION
- [x] length optional attribute is added in C-files as required; as it is NOT appearing without this change
- [x] Value handling with optional attribute added in set config item & bulk config item
i.e fixed for minimum, maximum, length, (mandatory, rule has already covered before)
- [x] unit tests added

Custom CI ub1804postgres report [here](http://jenkins.dianomic.com:8080/view/custom%20jobs/job/foglamp_postgres_ub1804/74/) against this branch. So Unit (4 audit unit tests are failing as expected on Postgres; already have a JIRA for the same)& system (api, e2e, smoke) tests are okay.