### PR TITLE
FOGL-3498 package log name & filename fixes when update plugin package

### DIFF
--- a/python/foglamp/services/core/api/plugins/update.py
+++ b/python/foglamp/services/core/api/plugins/update.py
@@ -106,9 +106,9 @@ def update_repo_sources_and_plugin(_type: str, name: str) -> tuple:
     # For endpoint curl -X GET http://localhost:8081/foglamp/plugins/available we used
     # sudo apt list command internal so package name always returns in lowercase,
     # irrespective of package name defined in the configured repo.
-    name = name.lower()
+    name = "foglamp-{}-{}".format(_type, name.lower())
     _platform = platform.platform()
-    stdout_file_path = common.create_log_file(name)
+    stdout_file_path = common.create_log_file(action="update", plugin_name=name)
     pkg_mgt = 'apt'
     cmd = "sudo {} -y update > {} 2>&1".format(pkg_mgt, stdout_file_path)
     if 'centos' in _platform or 'redhat' in _platform:
@@ -117,7 +117,7 @@ def update_repo_sources_and_plugin(_type: str, name: str) -> tuple:
     ret_code = os.system(cmd)
     # sudo apt/yum -y install only happens when update is without any error
     if ret_code == 0:
-        cmd = "sudo {} -y install foglamp-{}-{} >> {} 2>&1".format(pkg_mgt, _type, name, stdout_file_path)
+        cmd = "sudo {} -y install {} >> {} 2>&1".format(pkg_mgt, name, stdout_file_path)
         ret_code = os.system(cmd)
 
     # relative log file link


### PR DESCRIPTION

```
$ curl -sX PUT http://localhost:8081/foglamp/plugins/south/sinusoid/update | jq
{
  "message": "sinusoid plugin update in process. Wait for few minutes to complete."
}

Nov 28 14:16:03 raspberrypi FogLAMP[22913] INFO: update: foglamp.services.core.api.plugins.update: sinusoid plugin update starts...
Nov 28 14:16:16 raspberrypi FogLAMP[22913] INFO: update: foglamp.services.core.api.plugins.update: sinusoid plugin update completed. Logs available at log/191128-14-16-03-foglamp-south-sinusoid-update.log



$ curl -sX GET http://localhost:8081/foglamp/package/log | jq
{
  "logs": [
    {
      "timestamp": "2019-11-28 14:16:03",
      "name": "foglamp-south-sinusoid-update",
      "filename": "191128-14-16-03-foglamp-south-sinusoid-update.log"
    }
  ]
}
```