### PR TITLE
browser unit tests fixes on other platforms as it was passed on ub16 ONLY

### DIFF
--- a/tests/unit/python/foglamp/services/core/api/test_browser_assets.py
+++ b/tests/unit/python/foglamp/services/core/api/test_browser_assets.py
@@ -397,11 +397,11 @@ class TestBrowserAssets:
          {'rows': [{'reading': {'temp': 13.45}}], 'count': 1}, "length must be a positive integer",
          "?length=-10", False),
         ('foglamp/asset/fogbench%2ftemp/bucket/10', 400,
-         {'rows': [{'reading': {'temp': 13.45}}], 'count': 1}, "Invalid value for start. Error: year is out of range",
+         {'rows': [{'reading': {'temp': 13.45}}], 'count': 1}, "Invalid value for start. Error: ",
          "?start=1491613677888", False),
         ('foglamp/asset/fogbench%2ftemp/bucket/10', 400,
          {'rows': [{'reading': {'temp': 13.45}}], 'count': 1},
-         "Invalid value for start. Error: [Errno 75] Value too large for defined data type",
+         "Invalid value for start. Error: ",
          "?start=567199223456346457", False),
         ('foglamp/asset/fogbench%2ftemp/temperature/bucket/60', 404, {'rows': [], 'count': 0},
          "'fogbench/temp asset code not found'", "", True),
@@ -410,7 +410,7 @@ class TestBrowserAssets:
          "?length=-10", True),
         ('foglamp/asset/fogbench%2ftemp/temperature/bucket/60', 400,
          {'rows': [{'reading': {'temperature': 13.45}}], 'count': 1},
-         "Invalid value for start. Error: timestamp out of range for platform time_t", "?start=149199235346457788234", True)
+         "Invalid value for start. Error: ", "?start=149199235346457788234", True)
     ])
     async def test_bad_asset_bucket_size_and_optional_params(self, client, url, code, storage_result, message,
                                                              request_params, with_readings):
@@ -425,7 +425,7 @@ class TestBrowserAssets:
             with patch.object(readings_storage_client_mock, 'query', side_effect=[mock_coro(storage_result), mock_coro(storage_result)]) as query_patch:
                 resp = await client.get(url)
                 assert code == resp.status
-                assert message == resp.reason
+                assert message in resp.reason
         assert 1 == query_patch.call_count
         args, kwargs = query_patch.call_args
         query_patch.assert_called_once_with(payload)


### PR DESCRIPTION
general exception message is different on platforms; so its better to assert message with in and with http_status 400 code

Signed-off-by: ashish-jabble <ashish@dianomic.com>