### PR TITLE
FOGL-2718 - Error in syslog after south service deletion and re-creation 

### DIFF
--- a/python/foglamp/services/core/api/service.py
+++ b/python/foglamp/services/core/api/service.py
@@ -122,6 +122,8 @@ async def delete_service(request):
         sch_id = uuid.UUID(svc_schedule['id'])
         if svc_schedule['enabled'].lower() == 't':
             await server.Server.scheduler.disable_schedule(sch_id)
+            # return control to event loop
+            await asyncio.sleep(1)
 
         # Delete all configuration for the service name
         await config_mgr.delete_category_and_children_recursively(svc)


### PR DESCRIPTION
Custom Job ran `<BASE_URI>/nightly%20jobs/job/foglamp_nightly_build_ub18/347/`

**Result:** No regression as such found for our unit & system tests with this change