### PR TITLE
FOGL-3600: Improving SQLite ingest times - Implement the algorithm in FogLAMP

### DIFF
--- a/C/plugins/storage/sqlite/common/connection_manager.cpp
+++ b/C/plugins/storage/sqlite/common/connection_manager.cpp
@@ -24,6 +24,8 @@ ConnectionManager::ConnectionManager()
 		m_trace = true;
 	else
 		m_trace = false;
+
+	m_ReadingsGId=1;
 }
 
 /**

--- a/C/plugins/storage/sqlite/common/connection_manager.cpp
+++ b/C/plugins/storage/sqlite/common/connection_manager.cpp
@@ -25,7 +25,7 @@ ConnectionManager::ConnectionManager()
 	else
 		m_trace = false;
 
-	m_ReadingsGId=1;
+	m_ReadingsGId=ATOMIC_VAR_INIT(1);
 }
 
 /**

--- a/C/plugins/storage/sqlite/common/include/connection.h
+++ b/C/plugins/storage/sqlite/common/include/connection.h
@@ -81,7 +81,7 @@ class Connection {
 		int		delete_table_snapshot(const std::string& table, const std::string& id);
 		bool		get_table_snapshots(const std::string& table, std::string& resultSet);
 #endif
-		int		appendReadings(const char *readings);
+		int		appendReadings(const char *readings, int readingsGId);
 		int 	readingStream(ReadingStream **readings, bool commit);
 		bool		fetchReadings(unsigned long id, unsigned int blksize,
 						std::string& resultSet);

--- a/C/plugins/storage/sqlite/common/include/connection.h
+++ b/C/plugins/storage/sqlite/common/include/connection.h
@@ -16,7 +16,7 @@
 #include <sqlite3.h>
 #include <mutex>
 #include <reading_stream.h>
-
+#include <atomic>
 
 #define LEN_BUFFER_DATE 100
 #define F_TIMEH24_S             "%H:%M:%S"
@@ -81,7 +81,7 @@ class Connection {
 		int		delete_table_snapshot(const std::string& table, const std::string& id);
 		bool		get_table_snapshots(const std::string& table, std::string& resultSet);
 #endif
-		int		appendReadings(const char *readings, int readingsGId);
+		int		appendReadings(const char *readings, std::atomic<int>* readingsGId);
 		int 	readingStream(ReadingStream **readings, bool commit);
 		bool		fetchReadings(unsigned long id, unsigned int blksize,
 						std::string& resultSet);

--- a/C/plugins/storage/sqlite/common/include/connection_manager.h
+++ b/C/plugins/storage/sqlite/common/include/connection_manager.h
@@ -28,16 +28,22 @@ class ConnectionManager {
 		void                      release(Connection *);
 		void			  shutdown();
 		void			  setError(const char *, const char *, bool);
+		void			  setReadingsGId(int readingsGId) {m_ReadingsGId = readingsGId;};
+		int			      getReadingsGId()                {return m_ReadingsGId; };
+
 		PLUGIN_ERROR		  *getError()
 					  {
 						return &lastError;
 					  }
 
-	protected:
+protected:
 		ConnectionManager();
 
 	private:
 		static ConnectionManager     *instance;
+		int                        m_ReadingsGId=1;
+
+
 	protected:
 		std::list<Connection *>      idle;
 		std::list<Connection *>      inUse;
@@ -46,6 +52,7 @@ class ConnectionManager {
 		std::mutex                   errorLock;
 		PLUGIN_ERROR		     lastError;
 		bool			     m_trace;
+
 };
 
 #endif

--- a/C/plugins/storage/sqlite/common/include/connection_manager.h
+++ b/C/plugins/storage/sqlite/common/include/connection_manager.h
@@ -13,6 +13,7 @@
 #include <plugin_api.h>
 #include <list>
 #include <mutex>
+#include <atomic>
 
 class Connection;
 
@@ -28,21 +29,18 @@ class ConnectionManager {
 		void                      release(Connection *);
 		void			  shutdown();
 		void			  setError(const char *, const char *, bool);
-		void			  setReadingsGId(int readingsGId) {m_ReadingsGId = readingsGId;};
-		int			      getReadingsGId()                {return m_ReadingsGId; };
-
 		PLUGIN_ERROR		  *getError()
 					  {
 						return &lastError;
 					  }
+
+		std::atomic<int>           m_ReadingsGId;
 
 protected:
 		ConnectionManager();
 
 	private:
 		static ConnectionManager     *instance;
-		int                        m_ReadingsGId=1;
-
 
 	protected:
 		std::list<Connection *>      idle;

--- a/C/plugins/storage/sqlite/common/readings.cpp
+++ b/C/plugins/storage/sqlite/common/readings.cpp
@@ -609,6 +609,8 @@ Logger::getLogger()->debug("DBG xxx  ReadingsGId :%d: ", readingsGId);
 Logger::getLogger()->setMinLevel("warning");
 
 char readingsGIdStr [255];
+// FIXME_I:
+snprintf(readingsGIdStr, sizeof(readingsGIdStr), "%d", 2);
 
 // Default template parameter uses UTF8 and MemoryPoolAllocator.
 Document doc;
@@ -654,7 +656,9 @@ int sleep_time_ms = 0;
 		return -1;
 	}
 
-	const char *sql_cmd="INSERT INTO foglamp.readings_1 ( id, user_ts, reading ) VALUES  (?,?,?)";
+	//const char *sql_cmd="INSERT INTO foglamp.readings_1 ( id, user_ts, reading ) VALUES  (?,?,?)";
+	const char *sql_cmd="INSERT INTO foglamp.readings ( user_ts, asset_code, reading ) VALUES  (?,?,?)";
+
 
 	if (sqlite3_prepare_v2(dbHandle, sql_cmd, strlen(sql_cmd), &stmt, NULL) != SQLITE_OK)
 	{
@@ -716,10 +720,14 @@ int sleep_time_ms = 0;
 			reading = escape(buffer.GetString());
 
 			if(stmt != NULL) {
-				snprintf(readingsGIdStr, sizeof(readingsGIdStr), "%d", readingsGId);
+				//snprintf(readingsGIdStr, sizeof(readingsGIdStr), "%d", readingsGId);
 
-				sqlite3_bind_text(stmt, 1, readingsGIdStr  ,-1, SQLITE_STATIC);
-				sqlite3_bind_text(stmt, 2, user_ts         ,-1, SQLITE_STATIC);
+//				sqlite3_bind_text(stmt, 1, readingsGIdStr  ,-1, SQLITE_STATIC);
+//				sqlite3_bind_text(stmt, 2, user_ts         ,-1, SQLITE_STATIC);
+//				sqlite3_bind_text(stmt, 3, reading.c_str(), -1, SQLITE_STATIC);
+
+				sqlite3_bind_text(stmt, 1, user_ts         ,-1, SQLITE_STATIC);
+				sqlite3_bind_text(stmt, 2, asset_code      ,-1, SQLITE_STATIC);
 				sqlite3_bind_text(stmt, 3, reading.c_str(), -1, SQLITE_STATIC);
 
 				retries =0;

--- a/C/plugins/storage/sqlite/common/readings.cpp
+++ b/C/plugins/storage/sqlite/common/readings.cpp
@@ -600,6 +600,11 @@ int Connection::readingStream(ReadingStream **readings, bool commit)
  */
 int Connection::appendReadings(const char *readings)
 {
+// FIXME_I:
+Logger::getLogger()->setMinLevel("debug");
+Logger::getLogger()->debug("DBG xxx-1 count - appendReadings ");
+Logger::getLogger()->setMinLevel("warning");
+
 // Default template parameter uses UTF8 and MemoryPoolAllocator.
 Document doc;
 int      row = 0;
@@ -802,6 +807,11 @@ int sleep_time_ms = 0;
 		                           timeT3
 		);
 #endif
+
+	// FIXME_I:
+	Logger::getLogger()->setMinLevel("debug");
+	Logger::getLogger()->debug("DBG xxx-2 count - appendReadings :%d: ", row);
+	Logger::getLogger()->setMinLevel("warning");
 
 	return row;
 }

--- a/C/plugins/storage/sqlite/plugin.cpp
+++ b/C/plugins/storage/sqlite/plugin.cpp
@@ -129,13 +129,9 @@ int plugin_reading_append(PLUGIN_HANDLE handle, char *readings)
 ConnectionManager *manager = (ConnectionManager *)handle;
 Connection        *connection = manager->allocate();
 
-	int ReadingsGId = manager->getReadingsGId();
-	int result = connection->appendReadings(readings, ReadingsGId);
+	int result = connection->appendReadings(readings, &(manager->m_ReadingsGId));
 
 	manager->release(connection);
-	if (result != -1) {
-		manager->setReadingsGId(ReadingsGId + result);
-	}
 	return result;;
 }
 

--- a/C/plugins/storage/sqlite/plugin.cpp
+++ b/C/plugins/storage/sqlite/plugin.cpp
@@ -129,8 +129,13 @@ int plugin_reading_append(PLUGIN_HANDLE handle, char *readings)
 ConnectionManager *manager = (ConnectionManager *)handle;
 Connection        *connection = manager->allocate();
 
-	int result = connection->appendReadings(readings);
+	int ReadingsGId = manager->getReadingsGId();
+	int result = connection->appendReadings(readings, ReadingsGId);
+
 	manager->release(connection);
+	if (result != -1) {
+		manager->setReadingsGId(ReadingsGId + result);
+	}
 	return result;;
 }
 

--- a/C/plugins/storage/sqlitememory/connection.cpp
+++ b/C/plugins/storage/sqlitememory/connection.cpp
@@ -109,8 +109,10 @@ Connection::Connection()
 
 /**
  * Append a set of readings to the readings table
+ *
+ * Note: ReadingsGId is not used in the in memory engine
  */
-int Connection::appendReadings(const char *readings)
+int Connection::appendReadings(const char *readings, int ReadingsGId)
 {
 // Default template parameter uses UTF8 and MemoryPoolAllocator.
 Document 	doc;

--- a/C/plugins/storage/sqlitememory/connection.cpp
+++ b/C/plugins/storage/sqlitememory/connection.cpp
@@ -112,7 +112,7 @@ Connection::Connection()
  *
  * Note: ReadingsGId is not used in the in memory engine
  */
-int Connection::appendReadings(const char *readings, int ReadingsGId)
+int Connection::appendReadings(const char *readings,  std::atomic<int>* readingsGId)
 {
 // Default template parameter uses UTF8 and MemoryPoolAllocator.
 Document 	doc;

--- a/C/plugins/storage/sqlitememory/include/connection.h
+++ b/C/plugins/storage/sqlitememory/include/connection.h
@@ -21,7 +21,7 @@ class Connection {
 		~Connection();
 		bool		retrieveReadings(const std::string& condition,
 					std::string& resultSet);
-		int		appendReadings(const char *readings);
+		int		    appendReadings(const char *readings, int readingsGId);
 		bool		fetchReadings(unsigned long id, unsigned int blksize,
 						std::string& resultSet);
 		unsigned int	purgeReadings(unsigned long age, unsigned int flags,

--- a/C/plugins/storage/sqlitememory/include/connection.h
+++ b/C/plugins/storage/sqlitememory/include/connection.h
@@ -21,7 +21,7 @@ class Connection {
 		~Connection();
 		bool		retrieveReadings(const std::string& condition,
 					std::string& resultSet);
-		int		    appendReadings(const char *readings, int readingsGId);
+		int		    appendReadings(const char *readings, std::atomic<int>* readingsGId);
 		bool		fetchReadings(unsigned long id, unsigned int blksize,
 						std::string& resultSet);
 		unsigned int	purgeReadings(unsigned long age, unsigned int flags,

--- a/C/plugins/storage/sqlitememory/plugin.cpp
+++ b/C/plugins/storage/sqlitememory/plugin.cpp
@@ -70,7 +70,7 @@ int plugin_reading_append(PLUGIN_HANDLE handle, char *readings)
 ConnectionManager *manager = (ConnectionManager *)handle;
 Connection        *connection = manager->allocate();
 
-	int result = connection->appendReadings(readings);
+	int result = connection->appendReadings(readings, -1);
 	manager->release(connection);
 	return result;;
 }

--- a/C/plugins/storage/sqlitememory/plugin.cpp
+++ b/C/plugins/storage/sqlitememory/plugin.cpp
@@ -70,7 +70,7 @@ int plugin_reading_append(PLUGIN_HANDLE handle, char *readings)
 ConnectionManager *manager = (ConnectionManager *)handle;
 Connection        *connection = manager->allocate();
 
-	int result = connection->appendReadings(readings, -1);
+	int result = connection->appendReadings(readings, NULL);
 	manager->release(connection);
 	return result;;
 }

--- a/scripts/plugins/storage/sqlite/init.sql
+++ b/scripts/plugins/storage/sqlite/init.sql
@@ -222,12 +222,12 @@ CREATE TABLE foglamp.readings (
     user_ts    DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW')),      -- UTC time
     ts         DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))       -- UTC time
 );
-
-CREATE INDEX fki_readings_fk1
-    ON readings (asset_code, user_ts desc);
-
-CREATE INDEX readings_ix2
-    ON readings (asset_code);
+--
+-- CREATE INDEX fki_readings_fk1
+--     ON readings (asset_code, user_ts desc);
+--
+-- CREATE INDEX readings_ix2
+--     ON readings (asset_code);
 
 CREATE INDEX readings_ix3
     ON readings (user_ts);

--- a/scripts/plugins/storage/sqlite/init.sql
+++ b/scripts/plugins/storage/sqlite/init.sql
@@ -209,6 +209,7 @@ CREATE INDEX fki_asset_messages_fk1
 CREATE INDEX fki_asset_messages_fk2
     ON asset_messages (status_id);
 
+-- // FIXME_I: to be removed
 -- Readings table
 -- This tables contains the readings for assets.
 -- An asset can be a south with multiple sensor, a single sensor,
@@ -230,6 +231,36 @@ CREATE INDEX readings_ix2
 
 CREATE INDEX readings_ix3
     ON readings (user_ts);
+
+--###   #########################################################################################:
+--// FIXME_I:
+
+-- Used to track the multiple reading tables,
+-- mapping a particular asset_code to a table that holds readings for that asset_code
+CREATE TABLE foglamp.asset_reading_catalogue (
+    id         INTEGER                     PRIMARY KEY AUTOINCREMENT,
+    asset_code character varying(50)       NOT NULL
+);
+
+-- Readings tables - readings_1
+-- These tables contain the readings for asset.
+-- An asset can be a south with multiple sensor, a single sensor,
+-- a software or anything that generates data that is sent to FogLAMP
+CREATE TABLE foglamp.readings_1 (
+    id         INTEGER,
+    reading    JSON                        NOT NULL DEFAULT '{}',            -- The json object received
+    user_ts    DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW')),      -- UTC time
+    ts         DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))       -- UTC time
+);
+
+
+CREATE INDEX readings_1_ix1
+    ON readings_1 (id);
+
+CREATE INDEX readings_1_ix2
+    ON readings_1 (user_ts);
+
+--###   #########################################################################################:
 
 -- Streams table
 -- List of the streams to the Cloud.

--- a/scripts/plugins/storage/sqlite/init.sql
+++ b/scripts/plugins/storage/sqlite/init.sql
@@ -247,15 +247,15 @@ CREATE TABLE foglamp.asset_reading_catalogue (
 -- An asset can be a south with multiple sensor, a single sensor,
 -- a software or anything that generates data that is sent to FogLAMP
 CREATE TABLE foglamp.readings_1 (
-    id         INTEGER,
+    id         INTEGER PRIMARY KEY,
     reading    JSON                        NOT NULL DEFAULT '{}',            -- The json object received
     user_ts    DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW')),      -- UTC time
     ts         DATETIME DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', 'NOW'))       -- UTC time
 );
 
 
-CREATE INDEX readings_1_ix1
-    ON readings_1 (id);
+-- CREATE INDEX readings_1_ix1
+--     ON readings_1 (id);
 
 CREATE INDEX readings_1_ix2
     ON readings_1 (user_ts);


### PR DESCRIPTION
Signed-off-by: Stefano <stefano@dianomic.com>


**Global Reading ID** 
The handling should be fine,
I tested it having 4 sinusoids inserting at higher rate and having:

storage.json
```
"threads":{"value":"4","description":"The number of threads to run"}
```

```
id         INTEGER PRIMARY KEY
```

```
std::atomic<int>* readingsGId
```
reatrival and increment of the GID:
```
readingsGIdTmp = (*readingsGId)++;
snprintf(readingsGIdStr, sizeof(readingsGIdStr), "%d", readingsGIdTmp);
```
