### PR TITLE
Fogl 3673: AF Hierarchy in PI North Plugin

### DIFF
--- a/C/plugins/common/include/omf.h
+++ b/C/plugins/common/include/omf.h
@@ -203,8 +203,8 @@ class OMF
 
 		// Add the 1st level of AF hierarchy if the end point is PI Web API
 		bool sendAFHierarchy();
-   		bool sendAFHierarchyTypes(const std::string AFHierarchyLevel);
-   		bool sendAFHierarchyStatic(const std::string AFHierarchyLevel);
+		bool sendAFHierarchyTypes(const std::string AFHierarchyLevel);
+		bool sendAFHierarchyStatic(const std::string AFHierarchyLevel);
 		bool sendAFHierarchyLink(std::string parent, std::string child);
 		bool AFHierarchySendMessage(const std::string& msgType, std::string& jsonData);
 
@@ -212,21 +212,21 @@ class OMF
 		const std::string	m_path;
 		long			m_typeId;
 		const std::string	m_producerToken;
-    		std::string		m_PIServerEndpoint;
-			std::string		m_DefaultAFLocation;
-    		std::string		m_AFHierarchyLevel;
-			std::string		m_prefixAFAsset;
+		std::string		m_PIServerEndpoint;
+		std::string		m_DefaultAFLocation;
+		std::string		m_AFHierarchyLevel;
+		std::string		m_prefixAFAsset;
 
 		// Define the OMF format to use for each type
 		// the format will not be applied if the string is empty
-                std::map<const std::string, std::string> m_formatTypes {
+		std::map<const std::string, std::string> m_formatTypes {
 			{OMF_TYPE_STRING, ""},
 			{OMF_TYPE_INTEGER,"int64"},
 			{OMF_TYPE_FLOAT,  "float64"},
 			{OMF_TYPE_UNSUPPORTED,  "unsupported"}
 		};
 
-    		// Vector with OMF_TYPES
+		// Vector with OMF_TYPES
 		const std::vector<std::string> omfTypes = { OMF_TYPE_STRING,
 							    OMF_TYPE_FLOAT,  // Forces the creation of float also for integer numbers
 							    OMF_TYPE_FLOAT,

--- a/C/plugins/common/include/omf.h
+++ b/C/plugins/common/include/omf.h
@@ -203,8 +203,9 @@ class OMF
 
 		// Add the 1st level of AF hierarchy if the end point is PI Web API
 		bool sendAFHierarchy();
-   		bool sendAFHierarchyTypes();
-   		bool sendAFHierarchyStatic();
+   		bool sendAFHierarchyTypes(const std::string AFHierarchyLevel);
+   		bool sendAFHierarchyStatic(const std::string AFHierarchyLevel);
+		bool sendAFHierarchyLink(std::string parent, std::string child);
 		bool AFHierarchySendMessage(const std::string& msgType, std::string& jsonData);
 
 	private:
@@ -212,7 +213,8 @@ class OMF
 		long			m_typeId;
 		const std::string	m_producerToken;
     		std::string		m_PIServerEndpoint;
-    		std::string		m_AFHierarchy1Level;
+			std::string		m_DefaultAFLocation;
+    		std::string		m_AFHierarchyLevel;
 			std::string		m_prefixAFAsset;
 
 		// Define the OMF format to use for each type

--- a/C/plugins/common/include/omf.h
+++ b/C/plugins/common/include/omf.h
@@ -92,11 +92,13 @@ class OMF
 		// Set saved OMF formats
 		void setFormatType(const std::string &key, std::string &value);
 
-    		// Set which PIServer component should be used for the communication
-    		void setPIServerEndpoint(const std::string &PIServerEndpoint);
+		// Set which PIServer component should be used for the communication
+		void setPIServerEndpoint(const std::string &PIServerEndpoint);
 
-    		// Set the first level of hierarchy in Asset Framework in which the assets will be created, PI Web API only.
-    		void setAFHierarchy1Level(const std::string &AFHierarchy1Level);
+		// Set the first level of hierarchy in Asset Framework in which the assets will be created, PI Web API only.
+		void setDefaultAFLocation(const std::string &DefaultAFLocation);
+
+		void setPrefixAFAsset(const std::string &prefixAFAsset);
 
 		// Get saved OMF formats
 		std::string getFormatType(const std::string &key) const;
@@ -200,10 +202,10 @@ class OMF
 		void clearCreatedTypes(const std::string& key);
 
 		// Add the 1st level of AF hierarchy if the end point is PI Web API
-    		bool sendAFHierarchy();
-    		bool sendAFHierarchyTypes();
-    		bool sendAFHierarchyStatic();
-    		bool AFHierarchySendMessage(const std::string& msgType, std::string& jsonData);
+		bool sendAFHierarchy();
+   		bool sendAFHierarchyTypes();
+   		bool sendAFHierarchyStatic();
+		bool AFHierarchySendMessage(const std::string& msgType, std::string& jsonData);
 
 	private:
 		const std::string	m_path;
@@ -211,6 +213,7 @@ class OMF
 		const std::string	m_producerToken;
     		std::string		m_PIServerEndpoint;
     		std::string		m_AFHierarchy1Level;
+			std::string		m_prefixAFAsset;
 
 		// Define the OMF format to use for each type
 		// the format will not be applied if the string is empty
@@ -257,7 +260,7 @@ class OMFData
 		OMFData(const Reading& reading,
 			const long typeId,
 			const std::string& PIServerEndpoint = std::string(),
-			const std::string& AFHierarchy1Level = std::string());
+			const std::string& DefaultAFLocation = std::string());
 
 		const std::string& OMFdataVal() const;
 	private:

--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -599,9 +599,8 @@ bool OMF::sendAFHierarchyStatic(const std::string AFHierarchyLevel)
 	return success;
 }
 
-
 /**
- *  AFHierarchy - // FIXME_I:
+ *  AFHierarchy - creates the link between 2 elements in the AF hierarchy
  *
  */
 bool OMF::sendAFHierarchyLink(std::string parent, std::string child)
@@ -625,7 +624,9 @@ bool OMF::sendAFHierarchyLink(std::string parent, std::string child)
 }
 
 /**
- * Add the 1st level of AF hierarchy if the end point is PI Web API
+ * Creates the hierarchies tree in the AF as defined in the configuration item DefaultAFLocation
+ * each level is separated by /
+ * the implementation is available for PI Web API only
  * The hierarchy is created/recreated if an OMF type message is sent
  *
  */
@@ -637,7 +638,7 @@ bool OMF::sendAFHierarchy()
 
 	if (m_PIServerEndpoint.compare("p") == 0)
 	{
-		// FIXME_I:
+		// Implementation onfly for PI Web API
 		std::stringstream defaultAFLocation(m_DefaultAFLocation);
 
 		if (m_DefaultAFLocation.find(AFHierarchySeparator) == string::npos)
@@ -1282,7 +1283,6 @@ const std::string OMF::createStaticData(const Reading& reading) const
 	}
 	else if (m_PIServerEndpoint.compare("p") == 0)
 	{
-		// FIXME_I:x1
 		sData.append(reading.getAssetName());
 		sData.append("\", \"AssetId\": \"");
 		sData.append(m_prefixAFAsset + "_" + reading.getAssetName());
@@ -1348,7 +1348,6 @@ const std::string OMF::createLinkData(const Reading& reading) const
 		StringReplace(tmpStr, "_placeholder_src_type_", m_AFHierarchyLevel + "_typeid");
 		StringReplace(tmpStr, "_placeholder_src_idx_",  m_AFHierarchyLevel );
 		StringReplace(tmpStr, "_placeholder_tgt_type_", targetTypeId);
-		// FIXME_I:x1
 		StringReplace(tmpStr, "_placeholder_tgt_idx_",  m_prefixAFAsset + "_" + assetName);
 
 		lData.append(tmpStr);
@@ -1371,7 +1370,6 @@ const std::string OMF::createLinkData(const Reading& reading) const
 	}
 	else if (m_PIServerEndpoint.compare("p") == 0)
 	{
-		// FIXME_I:x1
 		lData.append(m_prefixAFAsset + "_" + assetName);
 	}
 

--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -1037,8 +1037,18 @@ const std::string OMF::createTypeData(const Reading& reading) const
 		tData.append(it->first.c_str());
 		tData.append("\": {\"type\": \"string\"},");
 	}
-	tData.append("\"Name\": { \"type\": \"string\", \"isindex\": true } }, "
-			"\"classification\": \"static\", \"id\": \"");
+
+	if (m_PIServerEndpoint.compare("c") == 0)
+	{
+		tData.append("\"Name\": { \"type\": \"string\", \"isindex\": true } }, "
+					 "\"classification\": \"static\", \"id\": \"");
+	}
+	else if (m_PIServerEndpoint.compare("p") == 0)
+	{
+		tData.append("\"Name\": { \"type\": \"string\", \"isname\": true }, ");
+		tData.append("\"AssetId\": { \"type\": \"string\", \"isindex\": true } ");
+		tData.append(" }, \"classification\": \"static\", \"id\": \"");
+	}
 
 	// Add type_id + '_' + asset_name + '_typename_sensor'
 	OMF::setAssetTypeTag(reading.getAssetName(),
@@ -1189,7 +1199,17 @@ const std::string OMF::createStaticData(const Reading& reading) const
 	sData.append(" \"Name\": \"");
 
 	// Add asset_name
-	sData.append(reading.getAssetName());
+	if (m_PIServerEndpoint.compare("c") == 0)
+	{
+		sData.append(reading.getAssetName());
+	}
+	else if (m_PIServerEndpoint.compare("p") == 0)
+	{
+		sData.append(reading.getAssetName());
+		sData.append("\", \"AssetId\": \"");
+		sData.append(m_AFHierarchy1Level + "_" + reading.getAssetName());
+	}
+
 	sData.append("\"}]}]");
 
 	// Return JSON string
@@ -1250,7 +1270,7 @@ const std::string OMF::createLinkData(const Reading& reading) const
 		StringReplace(tmpStr, "_placeholder_src_type_", m_AFHierarchy1Level + "_typeid");
 		StringReplace(tmpStr, "_placeholder_src_idx_",  m_AFHierarchy1Level );
 		StringReplace(tmpStr, "_placeholder_tgt_type_", targetTypeId);
-		StringReplace(tmpStr, "_placeholder_tgt_idx_",  assetName);
+		StringReplace(tmpStr, "_placeholder_tgt_idx_",  m_AFHierarchy1Level + "_" + assetName);
 
 		lData.append(tmpStr);
 		lData.append(",");
@@ -1265,8 +1285,15 @@ const std::string OMF::createLinkData(const Reading& reading) const
 
 	lData.append("\", \"index\": \"");
 
-	// Add asset_name
-	lData.append(assetName);
+	if (m_PIServerEndpoint.compare("c") == 0)
+	{
+		// Add asset_name
+		lData.append(assetName);
+	}
+	else if (m_PIServerEndpoint.compare("p") == 0)
+	{
+		lData.append(m_AFHierarchy1Level + "_" + assetName);
+	}
 
 	measurementId = to_string(OMF::getAssetTypeId(assetName)) + "measurement_" + assetName;
 
@@ -1784,7 +1811,18 @@ bool OMF::setCreatedTypes(const Reading& row)
 	}
 
 	string types;
-	string key = row.getAssetName();
+	string key;
+
+	if (m_PIServerEndpoint.compare("c") == 0)
+	{
+		key = row.getAssetName();
+	}
+	else if (m_PIServerEndpoint.compare("p") == 0)
+	{
+		key = m_AFHierarchy1Level + "_" + row.getAssetName();
+	}
+
+
 	long typeId = OMF::getAssetTypeId(key);
 	const vector<Datapoint*> data = row.getReadingData();
 	types.append("{");

--- a/C/plugins/common/omf.cpp
+++ b/C/plugins/common/omf.cpp
@@ -75,7 +75,7 @@ const char *AF_HIERARCHY_1LEVEL_LINK = QUOTE(
 /**
  * OMFData constructor
  */
-OMFData::OMFData(const Reading& reading, const long typeId, const string& PIServerEndpoint,const string&  AFHierarchy1Level)
+OMFData::OMFData(const Reading& reading, const long typeId, const string& PIServerEndpoint,const string&  DefaultAFLocation)
 {
 	string outData;
 	string measurementId;
@@ -85,7 +85,7 @@ OMFData::OMFData(const Reading& reading, const long typeId, const string& PIServ
 	// Add the 1st level of AFHierarchy as a prefix to the name in case of PI Web API
 	if (PIServerEndpoint.compare("p") == 0)
 	{
-		measurementId = AFHierarchy1Level + "_" + measurementId;
+		measurementId = DefaultAFLocation + "_" + measurementId;
 	}
 
 	// Convert reading data into the OMF JSON string
@@ -1205,9 +1205,10 @@ const std::string OMF::createStaticData(const Reading& reading) const
 	}
 	else if (m_PIServerEndpoint.compare("p") == 0)
 	{
+		// FIXME_I:x1
 		sData.append(reading.getAssetName());
 		sData.append("\", \"AssetId\": \"");
-		sData.append(m_AFHierarchy1Level + "_" + reading.getAssetName());
+		sData.append(m_prefixAFAsset + "_" + reading.getAssetName());
 	}
 
 	sData.append("\"}]}]");
@@ -1270,7 +1271,8 @@ const std::string OMF::createLinkData(const Reading& reading) const
 		StringReplace(tmpStr, "_placeholder_src_type_", m_AFHierarchy1Level + "_typeid");
 		StringReplace(tmpStr, "_placeholder_src_idx_",  m_AFHierarchy1Level );
 		StringReplace(tmpStr, "_placeholder_tgt_type_", targetTypeId);
-		StringReplace(tmpStr, "_placeholder_tgt_idx_",  m_AFHierarchy1Level + "_" + assetName);
+		// FIXME_I:x1
+		StringReplace(tmpStr, "_placeholder_tgt_idx_",  m_prefixAFAsset + "_" + assetName);
 
 		lData.append(tmpStr);
 		lData.append(",");
@@ -1292,7 +1294,8 @@ const std::string OMF::createLinkData(const Reading& reading) const
 	}
 	else if (m_PIServerEndpoint.compare("p") == 0)
 	{
-		lData.append(m_AFHierarchy1Level + "_" + assetName);
+		// FIXME_I:x1
+		lData.append(m_prefixAFAsset + "_" + assetName);
 	}
 
 	measurementId = to_string(OMF::getAssetTypeId(assetName)) + "measurement_" + assetName;
@@ -1425,10 +1428,19 @@ void OMF::setPIServerEndpoint(const string &PIServerEndpoint)
 /**
  * Set the first level of hierarchy in Asset Framework in which the assets will be created, PI Web API only.
  */
-void OMF::setAFHierarchy1Level(const string &AFHierarchy1Level)
+void OMF::setDefaultAFLocation(const string &DefaultAFLocation)
 {
-	m_AFHierarchy1Level = AFHierarchy1Level;
+	m_AFHierarchy1Level = DefaultAFLocation;
 }
+
+/**
+ * Set the first level of hierarchy in Asset Framework in which the assets will be created, PI Web API only.
+ */
+void OMF::setPrefixAFAsset(const string &prefixAFAsset)
+{
+	m_prefixAFAsset = prefixAFAsset;
+}
+
 
 
 /**

--- a/C/plugins/north/PI_Server_V2/plugin.cpp
+++ b/C/plugins/north/PI_Server_V2/plugin.cpp
@@ -145,11 +145,11 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"displayName": "PI-Server Endpoint"
 		},
 		"DefaultAFLocation": {
-			"description": "Defines the hierarchy tree in Asset Framework in which the assets will be created, PI Web API only.",
+			"description": "Defines the hierarchies tree in Asset Framework in which the assets will be created, PI Web API only.",
 			"type": "string",
 			"default": "foglamp/data_piwebapi",
 			"order": "18",
-			"displayName": "Asset Framework hierarchy tree",
+			"displayName": "Asset Framework hierarchies tree",
 			"validity" : "PIServerEndpoint != \"Connector Relay\""
 		},
 		"notBlockingErrors": {

--- a/C/plugins/north/PI_Server_V2/plugin.cpp
+++ b/C/plugins/north/PI_Server_V2/plugin.cpp
@@ -28,6 +28,7 @@
 
 #include "crypto.hpp"
 
+
 #define VERBOSE_LOG	0
 
 using namespace std;
@@ -340,7 +341,9 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 
 	// FIXME_I: implement full alg
 	// FIXME_I: x1
-	connInfo->prefixAFAsset = "007f0100";
+	long hostId = gethostid();
+	std::size_t hierarchyHash = std::hash<std::string>{}(DefaultAFLocation);
+	connInfo->prefixAFAsset = std::to_string(hostId) + "_" + std::to_string(hierarchyHash);
 
 	// PI Web API end-point - evaluates the authentication method requested
 	if (PIWebAPIAuthMethod.compare("anonymous") == 0)

--- a/C/plugins/north/PI_Server_V2/plugin.cpp
+++ b/C/plugins/north/PI_Server_V2/plugin.cpp
@@ -145,7 +145,7 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"displayName": "PI-Server Endpoint"
 		},
 		"DefaultAFLocation": {
-			"description": "Defines the hierarchies tree in Asset Framework in which the assets will be created, PI Web API only.",
+			"description": "Defines the hierarchies tree in Asset Framework in which the assets will be created, each level is separated by /, PI Web API only.",
 			"type": "string",
 			"default": "foglamp/data_piwebapi",
 			"order": "18",
@@ -339,8 +339,7 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 	connInfo->formatInteger = formatInteger;
 	connInfo->DefaultAFLocation = DefaultAFLocation;
 
-	// FIXME_I: implement full alg
-	// FIXME_I: x1
+	// Generates the prefix to have unique asset_id across different levels of hierarchies
 	long hostId = gethostid();
 	std::size_t hierarchyHash = std::hash<std::string>{}(DefaultAFLocation);
 	connInfo->prefixAFAsset = std::to_string(hostId) + "_" + std::to_string(hierarchyHash);
@@ -553,12 +552,8 @@ uint32_t plugin_send(const PLUGIN_HANDLE handle,
 
 	// Set PIServerEndpoint configuration
 	connInfo->omf->setPIServerEndpoint(connInfo->PIServerEndpoint);
-
 	connInfo->omf->setDefaultAFLocation(connInfo->DefaultAFLocation);
-
-	// FIXME_I:x1
 	connInfo->omf->setPrefixAFAsset(connInfo->prefixAFAsset);
-
 
 	// Set OMF FormatTypes  
 	connInfo->omf->setFormatType(OMF_TYPE_FLOAT,

--- a/C/plugins/north/PI_Server_V2/plugin.cpp
+++ b/C/plugins/north/PI_Server_V2/plugin.cpp
@@ -143,12 +143,12 @@ const char *PLUGIN_DEFAULT_CONFIG_INFO = QUOTE(
 			"order": "17",
 			"displayName": "PI-Server Endpoint"
 		},
-		"AFHierarchy1Level": {
-			"description": "Defines the first level of hierarchy in Asset Framework in which the assets will be created, PI Web API only.",
+		"DefaultAFLocation": {
+			"description": "Defines the hierarchy tree in Asset Framework in which the assets will be created, PI Web API only.",
 			"type": "string",
-			"default": "foglamp_data_piwebapi",
+			"default": "foglamp/data_piwebapi",
 			"order": "18",
-			"displayName": "Asset Framework 1st Level Hierarchy",
+			"displayName": "Asset Framework hierarchy tree",
 			"validity" : "PIServerEndpoint != \"Connector Relay\""
 		},
 		"notBlockingErrors": {
@@ -220,11 +220,12 @@ typedef struct
 	string		producerToken;	        // PI Server connector token
 	string		formatNumber;	        // OMF protocol Number format
 	string		formatInteger;	        // OMF protocol Integer format
-    	string		PIServerEndpoint;       // Defines which PIServer component should be used for the communication:
-    	                                        // a=auto discovery - p=PI Web API, c=Connector Relay
-	string		AFHierarchy1Level;      // 1st hierarchy in Asset Framework, PI Web API only.
-    	string		PIWebAPIAuthMethod;     // Authentication method to be used with the PI Web API.
-    	string		PIWebAPICredentials;    // Credentials is the base64 encoding of id and password joined by a single colon (:)
+	string		PIServerEndpoint;       // Defines which PIServer component should be used for the communication:
+	// a=auto discovery - p=PI Web API, c=Connector Relay
+	string		DefaultAFLocation;      // 1st hierarchy in Asset Framework, PI Web API only.
+	string		prefixAFAsset;       	// Prefix to generate unique asste id
+	string		PIWebAPIAuthMethod;     // Authentication method to be used with the PI Web API.
+	string		PIWebAPICredentials;    // Credentials is the base64 encoding of id and password joined by a single colon (:)
 	string 		KerberosKeytab;         // Kerberos authentication keytab file
 	                                        //   stores the environment variable value about the keytab file path
 	                                        //   to allow the environment to persist for all the execution of the plugin
@@ -300,7 +301,7 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 	string formatNumber = configData->getValue("formatNumber");
 	string formatInteger = configData->getValue("formatInteger");
 	string PIServerEndpoint = configData->getValue("PIServerEndpoint");
-	string AFHierarchy1Level = configData->getValue("AFHierarchy1Level");
+	string DefaultAFLocation = configData->getValue("DefaultAFLocation");
 
 	string PIWebAPIAuthMethod     = configData->getValue("PIWebAPIAuthenticationMethod");
 	string PIWebAPIUserId         = configData->getValue("PIWebAPIUserId");
@@ -335,7 +336,11 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 	connInfo->producerToken = producerToken;
 	connInfo->formatNumber = formatNumber;
 	connInfo->formatInteger = formatInteger;
-	connInfo->AFHierarchy1Level = AFHierarchy1Level;
+	connInfo->DefaultAFLocation = DefaultAFLocation;
+
+	// FIXME_I: implement full alg
+	// FIXME_I: x1
+	connInfo->prefixAFAsset = "007f0100";
 
 	// PI Web API end-point - evaluates the authentication method requested
 	if (PIWebAPIAuthMethod.compare("anonymous") == 0)
@@ -546,7 +551,11 @@ uint32_t plugin_send(const PLUGIN_HANDLE handle,
 	// Set PIServerEndpoint configuration
 	connInfo->omf->setPIServerEndpoint(connInfo->PIServerEndpoint);
 
-	connInfo->omf->setAFHierarchy1Level(connInfo->AFHierarchy1Level);
+	connInfo->omf->setDefaultAFLocation(connInfo->DefaultAFLocation);
+
+	// FIXME_I:x1
+	connInfo->omf->setPrefixAFAsset(connInfo->prefixAFAsset);
+
 
 	// Set OMF FormatTypes  
 	connInfo->omf->setFormatType(OMF_TYPE_FLOAT,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,3 +25,5 @@ add_subdirectory(C/plugins/utils)
 add_subdirectory(C/plugins/north/PI_Server_V2)
 add_subdirectory(C/plugins/north/ocs_V2)
 
+#// FIXME:
+set(CMAKE_BUILD_TYPE Debug)


### PR DESCRIPTION
**Manual test**
Data inserted from 1 node in 2 hierarchies
and from a Raspberry r4 in another:

![image](https://user-images.githubusercontent.com/4919069/73462258-cb5b0600-437b-11ea-8289-33ae07b3fd11.png)

**Pi WEB API - System test** 
the system test related to the PI Web API should be adapted as

the property has changed name and the default location in AF will different.

	"DefaultAFLocation": {
		"description": "Defines the hierarchies tree in Asset Framework in which the assets will be created, each level is separated by /, PI Web API only.",
		"type": "string",
		"default": "foglamp/data_piwebapi",
		"order": "18",
		"displayName": "Asset Framework hierarchies tree",
		"validity" : "PIServerEndpoint != \"Connector Relay\""
	},
 
**Regression test - CR** 
no regression

![image](https://user-images.githubusercontent.com/4919069/73467554-c26e3280-4383-11ea-92f0-9ceffb186865.png)

**Customer hierarchy**
![image](https://user-images.githubusercontent.com/4919069/73472175-e3865180-438a-11ea-91d6-b21fee8f6ce5.png)

using spaces also
![image](https://user-images.githubusercontent.com/4919069/73472757-d61d9700-438b-11ea-8efe-c6b3ecd975f7.png)
