### PR TITLE
FOGL-3701: Fix for unsupported TLS v1.2 in Simple Web Server code on …

### DIFF
--- a/C/thirdparty/Simple-Web-Server/client_https.hpp
+++ b/C/thirdparty/Simple-Web-Server/client_https.hpp
@@ -26,7 +26,13 @@ namespace SimpleWeb {
      */
     Client(const std::string &server_port_path, bool verify_certificate = true, const std::string &certification_file = std::string(),
            const std::string &private_key_file = std::string(), const std::string &verify_file = std::string())
-        : ClientBase<HTTPS>::ClientBase(server_port_path, 443), context(asio::ssl::context::tlsv12) {
+        : ClientBase<HTTPS>::ClientBase(server_port_path, 443), 
+#ifdef RHEL_CENTOS_7
+	  context(asio::ssl::context::tlsv1) 
+#else
+	  context(asio::ssl::context::tlsv12) 
+#endif
+    {
       if(certification_file.size() > 0 && private_key_file.size() > 0) {
         context.use_certificate_chain_file(certification_file);
         context.use_private_key_file(private_key_file, asio::ssl::context::pem);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,16 @@ project (FogLAMP)
 
 set(CMAKE_CXX_FLAGS "-std=c++11 -O3")
 
+EXECUTE_PROCESS( COMMAND grep -o ^NAME=.* /etc/os-release COMMAND cut -f2 -d\" COMMAND sed s/\"//g OUTPUT_VARIABLE os_name )
+EXECUTE_PROCESS( COMMAND grep -o ^VERSION_ID=.* /etc/os-release COMMAND cut -f2 -d\" COMMAND sed s/\"//g OUTPUT_VARIABLE os_version )
+
+if ( ( ${os_name} MATCHES "Red Hat" OR ${os_name} MATCHES "CentOS") AND ( ${os_version} MATCHES "7" ) )
+	add_compile_options(-D RHEL_CENTOS_7)
+	message( "System is RHEL/CentOS 7" )
+else()
+	message( "System is not RHEL/CentOS 7" )
+endif()
+
 find_package(PkgConfig REQUIRED)
 
 add_subdirectory(C/common)


### PR DESCRIPTION
…CentOS/RHEL 7.x since it has very old boost asio library v1.53 from 2013. So in case of CentOS/RHEL 7.x, use TLS v1, otherwise use TLS v1.2

Signed-off-by: Amandeep Singh Arora <aman@dianomic.com>